### PR TITLE
Fix recomputing of SortOrder on import

### DIFF
--- a/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -453,7 +453,7 @@ namespace uSync8.Core.Serialization.Serializers
             if (string.IsNullOrWhiteSpace(folder)) return;
 
             var container = FindFolder(folderNode.GetKey(), folder);
-            if (container != null)
+            if (container != null && container.Id != item.ParentId)
             {
                 item.SetParent(container);
             }
@@ -470,7 +470,7 @@ namespace uSync8.Core.Serialization.Serializers
             if (key != Guid.Empty)
             {
                 var entity = entityService.Get(key);
-                if (entity != null)
+                if (entity != null && entity.Id != item.ParentId)
                 {
                     item.SetParent(entity);
                     return true;

--- a/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -78,7 +78,7 @@ namespace uSync8.Core.Serialization.Serializers
             if (string.IsNullOrWhiteSpace(folder)) return;
 
             var container = FindFolder(folderNode.GetKey(), folder);
-            if (container != null)
+            if (container != null && container.Id != item.ParentId)
             {
                 item.SetParent(container);
             }


### PR DESCRIPTION
This PR fixes the following issue:

When importing data types *into a folder*, the SetParent() method is called every time. The effect is that when requesting DataTypeService.Save(item), Umbraco 8 recomputes the SortOrder to a higher value because IsPropertyDirty("ParentId") returns true.
As a result, the updated datatype no longer matches the serialized .config - so it is listed in the Report (and imported again) time after time.

Proposed solution: check if the parentId values are different before calling SetParent().
Although I did not verify the same issue with the ContentType deserialization, I added the verification just in case.