### PR TITLE
Dev flags

### DIFF
--- a/uSync8.BackOffice/App_Plugins/uSync8/dashboard.html
+++ b/uSync8.BackOffice/App_Plugins/uSync8/dashboard.html
@@ -69,7 +69,7 @@
                     <div class="text-center">
                         <h4 class="usync-action-message">{{vm.status.Message}}</h4>
                         <small>{{vm.update.Message}}</small>
-                        <div class="progress" style="height: 3px;">
+                        <div class="progress usync-not-animated" style="height: 3px;">
                             <div class="bar" role="progressbar" style="width: {{vm.calcPercentage(vm.update)}}%;" aria-valuenow="{{vm.calcPercentage(vm.update)}}" aria-valuemin="0" aria-valuemax="100"></div>
                         </div>
                     </div>

--- a/uSync8.BackOffice/App_Plugins/uSync8/usync.css
+++ b/uSync8.BackOffice/App_Plugins/uSync8/usync.css
@@ -119,3 +119,7 @@
     .usync-root-folder input {
         width: 100%;
     }
+
+.usync-not-animated .bar {
+    transition: none;
+}

--- a/uSync8.BackOffice/Config/uSync8.config
+++ b/uSync8.BackOffice/Config/uSync8.config
@@ -7,6 +7,7 @@
     <ExportAtStartup>False</ExportAtStartup>
     <ExportOnSave>True</ExportOnSave>
     <UseGuidFilenames>False</UseGuidFilenames>
+    <BatchSave>False</BatchSave>
     <Handlers EnableMissing="true">
       <Handler Alias="dataTypeHandler" Enabled="true" />
       <Handler Alias="languageHandler" Enabled="true" />

--- a/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
+++ b/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
@@ -35,6 +35,7 @@ namespace uSync8.BackOffice.Configuration
             settings.ExportOnSave = node.Element("ExportOnSave").ValueOrDefault(true);
             settings.UseGuidNames = node.Element("UseGuidFilenames").ValueOrDefault(false);
             settings.BatchSave = node.Element("BatchSave").ValueOrDefault(false);
+            settings.ReportDebug = node.Element("ReportDebug").ValueOrDefault(false);
 
             var handlerConfig = node.Element("Handlers");
 
@@ -66,6 +67,7 @@ namespace uSync8.BackOffice.Configuration
             node.CreateOrSetElement("ExportOnSave", settings.ExportOnSave);
             node.CreateOrSetElement("UseGuidFilenames", settings.UseGuidNames);
             node.CreateOrSetElement("BatchSave", settings.BatchSave);
+            node.CreateOrSetElement("ReportDebug", settings.ReportDebug);
 
             if (settings.Handlers != null && settings.Handlers.Any())
             {
@@ -134,7 +136,6 @@ namespace uSync8.BackOffice.Configuration
             settings.GuidNames = GetLocalValue(node.Attribute("GuidNames"), defaultSettings.UseGuidNames);
             settings.UseFlatStructure = GetLocalValue(node.Attribute("UseFlatStructure"), defaultSettings.UseFlatStructure);
             settings.BatchSave = GetLocalValue(node.Attribute("BatchSave"), defaultSettings.BatchSave);
-
             settings.Actions = node.Attribute("Actions").ValueOrDefault("All").ToDelimitedList().ToArray();
 
             var settingNode = node.Element("Settings");

--- a/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
+++ b/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
@@ -34,6 +34,7 @@ namespace uSync8.BackOffice.Configuration
             settings.ExportAtStartup = node.Element("ExportAtStartup").ValueOrDefault(false);
             settings.ExportOnSave = node.Element("ExportOnSave").ValueOrDefault(true);
             settings.UseGuidNames = node.Element("UseGuidFilenames").ValueOrDefault(false);
+            settings.BatchSave = node.Element("BatchSave").ValueOrDefault(false);
 
             var handlerConfig = node.Element("Handlers");
 
@@ -64,6 +65,7 @@ namespace uSync8.BackOffice.Configuration
             node.CreateOrSetElement("ExportAtStartup", settings.ExportAtStartup);
             node.CreateOrSetElement("ExportOnSave", settings.ExportOnSave);
             node.CreateOrSetElement("UseGuidFilenames", settings.UseGuidNames);
+            node.CreateOrSetElement("BatchSave", settings.BatchSave);
 
             if (settings.Handlers != null && settings.Handlers.Any())
             {
@@ -83,6 +85,9 @@ namespace uSync8.BackOffice.Configuration
 
                     if (!handler.UseFlatStructure.IsOverridden)
                         handler.UseFlatStructure.SetDefaultValue(settings.UseFlatStructure);
+
+                    if (!handler.BatchSave.IsOverridden)
+                        handler.BatchSave.SetDefaultValue(settings.BatchSave);
 
                     var handlerNode = handlerConfig.Elements("Handler").FirstOrDefault(x => x.Attribute("Alias").Value == handler.Alias);
                     if (handlerNode == null)
@@ -128,6 +133,7 @@ namespace uSync8.BackOffice.Configuration
             // we get them from the global setting.
             settings.GuidNames = GetLocalValue(node.Attribute("GuidNames"), defaultSettings.UseGuidNames);
             settings.UseFlatStructure = GetLocalValue(node.Attribute("UseFlatStructure"), defaultSettings.UseFlatStructure);
+            settings.BatchSave = GetLocalValue(node.Attribute("BatchSave"), defaultSettings.BatchSave);
 
             settings.Actions = node.Attribute("Actions").ValueOrDefault("All").ToDelimitedList().ToArray();
 
@@ -173,6 +179,9 @@ namespace uSync8.BackOffice.Configuration
 
             if (config.UseFlatStructure.IsOverridden)
                 node.SetAttributeValue("UseFlatStructure", config.UseFlatStructure);
+
+            if (config.BatchSave.IsOverridden)
+                node.SetAttributeValue("BatchSave", config.BatchSave);
 
             if (config.Actions.Length > 0 && !(config.Actions.Length == 1 && config.Actions[0].InvariantEquals("all")))
                 node.SetAttributeValue("Actions", string.Join(",", config.Actions));

--- a/uSync8.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync8.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -12,6 +12,8 @@ namespace uSync8.BackOffice.Configuration
         public OverriddenValue<bool> UseFlatStructure { get; set; } = new OverriddenValue<bool>();
         public OverriddenValue<bool> GuidNames { get; set; } = new OverriddenValue<bool>();
 
+        public OverriddenValue<bool> BatchSave { get; set; } = new OverriddenValue<bool>();
+
         public Dictionary<string, string> Settings { get; set; } = new Dictionary<string, string>();
 
         public HandlerSettings(string alias, bool enabled)

--- a/uSync8.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync8.BackOffice/Configuration/uSyncSettings.cs
@@ -15,6 +15,8 @@ namespace uSync8.BackOffice.Configuration
         public bool UseFlatStructure { get; set; } = true;
         public bool UseGuidNames { get; set; } = false;
 
+        public bool BatchSave { get; set; } = false; 
+
         public bool ImportAtStartup { get; set; } = false;
         public bool ExportAtStartup { get; set; } = false;
         public bool ExportOnSave { get; set; } = true;

--- a/uSync8.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync8.BackOffice/Configuration/uSyncSettings.cs
@@ -14,7 +14,6 @@ namespace uSync8.BackOffice.Configuration
 
         public bool UseFlatStructure { get; set; } = true;
         public bool UseGuidNames { get; set; } = false;
-
         public bool BatchSave { get; set; } = false; 
 
         public bool ImportAtStartup { get; set; } = false;
@@ -23,6 +22,8 @@ namespace uSync8.BackOffice.Configuration
 
         public bool EnableMissingHandlers { get; set; } = true;
         public List<HandlerSettings> Handlers { get; set; } = new List<HandlerSettings>();
+
+        public bool ReportDebug { get; set; } = false;
     }
 
 }

--- a/uSync8.BackOffice/Services/uSyncService.cs
+++ b/uSync8.BackOffice/Services/uSyncService.cs
@@ -47,6 +47,16 @@ namespace uSync8.BackOffice
 
             var summary = new SyncProgressSummary(configuredHandlers.Select(x => x.Handler), "Reporting", configuredHandlers.Count);
 
+            if (settings.ReportDebug)
+            {
+                // debug - full export into a dated folder. 
+                summary.Message = "Debug: Creating Extract in Tracker folder";
+                callback?.Invoke(summary);
+            }
+
+            this.Export($"~/uSync/Tracker/{DateTime.Now.ToString("yyyyMMdd_HHmmss")}/", null, null);
+
+
             foreach (var configuredHandler in configuredHandlers)
             {
                 var handler = configuredHandler.Handler;

--- a/uSync8.BackOffice/Services/uSyncService.cs
+++ b/uSync8.BackOffice/Services/uSyncService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -74,6 +75,8 @@ namespace uSync8.BackOffice
         {
             lock (_importLock)
             {
+                var sw = Stopwatch.StartNew();
+
                 try
                 {
                     uSync8BackOffice.eventsPaused = true;
@@ -137,7 +140,8 @@ namespace uSync8.BackOffice
                         }
                     }
 
-                    summary.UpdateHandler("Post Import", HandlerStatus.Complete, "Import Completed");
+                    sw.Stop();
+                    summary.UpdateHandler("Post Import", HandlerStatus.Complete, $"Import Completed ({sw.ElapsedMilliseconds}ms)");
                     callback?.Invoke(summary);
 
                     return actions;

--- a/uSync8.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
+++ b/uSync8.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
@@ -62,7 +62,7 @@ namespace uSync8.BackOffice.SyncHandlers.Handlers
 
             foreach (var action in actions)
             {
-                var attempt = Import(action.FileName, config);
+                var attempt = Import(action.FileName, config, SerializerFlags.None);
                 if (attempt.Success)
                 {
                     ImportSecondPass(action.FileName, attempt.Item, config, null);

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -172,9 +172,9 @@ namespace uSync8.BackOffice.SyncHandlers
             }
 
             // bulk save ..
-            if (flags.HasFlag(SerializerFlags.DoNotSave))
+            if (flags.HasFlag(SerializerFlags.DoNotSave) && updates.Any())
             {
-                callback?.Invoke("Saving all changes", 1, 1);
+                callback?.Invoke($"Saving {updates.Count()} changes", 1, 1);
                 serializer.Save(updates.Select(x => x.Value));
             }
 

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -144,8 +144,10 @@ namespace uSync8.BackOffice.SyncHandlers
         protected virtual IEnumerable<uSyncAction> ImportFolder(string folder, HandlerSettings config, Dictionary<string, TObject> updates, bool force, SyncUpdateCallback callback)
         {
             List<uSyncAction> actions = new List<uSyncAction>();
-
             var files = syncFileService.GetFiles(folder, "*.config");
+
+            var flags = SerializerFlags.None;
+            if (force) flags |= SerializerFlags.Force;
 
             int count = 0;
             int total = files.Count();
@@ -155,7 +157,7 @@ namespace uSync8.BackOffice.SyncHandlers
 
                 callback?.Invoke($"Importing {Path.GetFileName(file)}", count, total);
 
-                var attempt = Import(file, config, force);
+                var attempt = Import(file, config, flags);
                 if (attempt.Success && attempt.Item != null)
                 {
                     updates.Add(file, attempt.Item);
@@ -166,6 +168,13 @@ namespace uSync8.BackOffice.SyncHandlers
                     action.Details = attempt.Details;
 
                 actions.Add(action);
+            }
+
+            // bulk save ..
+            if (flags.HasFlag(SerializerFlags.DoNotSave))
+            {
+                callback?.Invoke("Saving", 1, 1);
+                serializer.Save(updates.Select(x => x.Value));
             }
 
             var folders = syncFileService.GetDirectories(folder);
@@ -179,7 +188,7 @@ namespace uSync8.BackOffice.SyncHandlers
             return actions;
         }
 
-        virtual public SyncAttempt<TObject> Import(string filePath, HandlerSettings config, bool force = false)
+        virtual public SyncAttempt<TObject> Import(string filePath, HandlerSettings config, SerializerFlags flags)
         {
             try
             {
@@ -188,7 +197,7 @@ namespace uSync8.BackOffice.SyncHandlers
                 using (var stream = syncFileService.OpenRead(filePath))
                 {
                     var node = XElement.Load(stream);
-                    var attempt = serializer.Deserialize(node, force, false);
+                    var attempt = serializer.Deserialize(node, flags);
                     return attempt;
                 }
             }

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -148,6 +148,7 @@ namespace uSync8.BackOffice.SyncHandlers
 
             var flags = SerializerFlags.None;
             if (force) flags |= SerializerFlags.Force;
+            if (config.BatchSave) flags |= SerializerFlags.DoNotSave;
 
             int count = 0;
             int total = files.Count();
@@ -173,7 +174,7 @@ namespace uSync8.BackOffice.SyncHandlers
             // bulk save ..
             if (flags.HasFlag(SerializerFlags.DoNotSave))
             {
-                callback?.Invoke("Saving", 1, 1);
+                callback?.Invoke("Saving all changes", 1, 1);
                 serializer.Save(updates.Select(x => x.Value));
             }
 

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
@@ -93,6 +93,7 @@ namespace uSync8.BackOffice.SyncHandlers
             // loaded - now process.
             var flags = SerializerFlags.None;
             if (force) flags |= SerializerFlags.Force;
+            if (config.BatchSave) flags |= SerializerFlags.DoNotSave;
 
             var count = 0;
             foreach (var node in nodes.OrderBy(x => x.Level))
@@ -109,10 +110,10 @@ namespace uSync8.BackOffice.SyncHandlers
                 actions.Add(uSyncActionHelper<TObject>.SetAction(attempt, node.File, IsTwoPass));
             }
 
-            if (flags.HasFlag(SerializerFlags.DoNotSave))
+            if (flags.HasFlag(SerializerFlags.DoNotSave) && updates.Any())
             {
                 // bulk save - should be the fastest way to do this
-                callback?.Invoke("Saving", 1, 1);
+                callback?.Invoke($"Saving {updates.Count()} changes", 1, 1);
                 serializer.Save(updates.Select(x => x.Value));
             }
 

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
@@ -53,6 +53,7 @@ namespace uSync8.BackOffice.SyncHandlers
         /// <returns></returns>
         protected override IEnumerable<uSyncAction> ImportFolder(string folder, HandlerSettings config, Dictionary<string, TObject> updates, bool force, SyncUpdateCallback callback)
         {
+
             // if not using flat, then directory structure is doing
             // this for us. 
             if (config.UseFlatStructure == false)
@@ -90,6 +91,8 @@ namespace uSync8.BackOffice.SyncHandlers
             }
 
             // loaded - now process.
+            var flags = SerializerFlags.None;
+            if (force) flags |= SerializerFlags.Force;
 
             var count = 0;
             foreach (var node in nodes.OrderBy(x => x.Level))
@@ -97,13 +100,20 @@ namespace uSync8.BackOffice.SyncHandlers
                 count++;
                 callback?.Invoke($"{Path.GetFileName(node.File)}", count, nodes.Count);
 
-                var attempt = Import(node.File, config, force);
+                var attempt = Import(node.File, config, flags);
                 if (attempt.Success && attempt.Item != null)
                 {
                     updates.Add(node.File, attempt.Item);
                 }
 
                 actions.Add(uSyncActionHelper<TObject>.SetAction(attempt, node.File, IsTwoPass));
+            }
+
+            if (flags.HasFlag(SerializerFlags.DoNotSave))
+            {
+                // bulk save - should be the fastest way to do this
+                callback?.Invoke("Saving", 1, 1);
+                serializer.Save(updates.Select(x => x.Value));
             }
 
             var folders = syncFileService.GetDirectories(folder);

--- a/uSync8.ContentEdition/Serializers/ContentSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/ContentSerializer.cs
@@ -103,7 +103,7 @@ namespace uSync8.ContentEdition.Serializers
 
             DeserializeBase(item, node);
 
-            contentService.Save(item);
+            // contentService.Save(item);
 
             return SyncAttempt<IContent>.Succeed(
                 item.Name,
@@ -198,6 +198,11 @@ namespace uSync8.ContentEdition.Serializers
 
         #endregion
 
+        public override void Save(IEnumerable<IContent> items)
+            => contentService.Save(items);
+
+        protected override void SaveItem(IContent item)
+            => contentService.Save(item);
 
     }
 }

--- a/uSync8.ContentEdition/Serializers/ContentSerializerBase.cs
+++ b/uSync8.ContentEdition/Serializers/ContentSerializerBase.cs
@@ -22,7 +22,7 @@ namespace uSync8.ContentEdition.Serializers
 
         protected UmbracoObjectTypes umbracoObjectType;
 
-        public ContentSerializerBase(IEntityService entityService, ILogger logger, UmbracoObjectTypes umbracoObjectType) 
+        public ContentSerializerBase(IEntityService entityService, ILogger logger, UmbracoObjectTypes umbracoObjectType)
             : base(entityService, logger)
         {
             this.umbracoObjectType = umbracoObjectType;
@@ -58,7 +58,7 @@ namespace uSync8.ContentEdition.Serializers
             info.Add(new XElement("Path", GetItemPath(item)));
 
             var title = new XElement("NodeName", new XAttribute("Default", item.Name));
-            foreach(var culture in item.AvailableCultures)
+            foreach (var culture in item.AvailableCultures)
             {
                 title.Add(new XElement("Name", item.GetCultureName(culture),
                     new XAttribute("Culture", culture)));
@@ -74,27 +74,29 @@ namespace uSync8.ContentEdition.Serializers
         {
             var node = new XElement("Properties");
 
-            foreach(var property in item.Properties.OrderBy(x => x.Alias))
+            foreach (var property in item.Properties.OrderBy(x => x.Alias))
             {
                 var propertyNode = new XElement(property.Alias);
 
-                foreach(var value in property.Values)
+                // this can cause us false change readings
+                // but we need to preserve the values if they are blank
+                // because we have to be able to set them to blank on deserialization
+                foreach (var value in property.Values)
                 {
                     var valueNode = new XElement("Value");
-
-                    if (!string.IsNullOrWhiteSpace(value.Culture)) {
+                    if (!string.IsNullOrWhiteSpace(value.Culture))
+                    {
                         valueNode.Add(new XAttribute("Culture", value.Culture ?? string.Empty));
                     }
 
-                    if (!string.IsNullOrWhiteSpace(value.Segment)) {
-                       valueNode.Add(new XAttribute("Segment", value.Segment ?? string.Empty));
+                    if (!string.IsNullOrWhiteSpace(value.Segment))
+                    {
+                        valueNode.Add(new XAttribute("Segment", value.Segment ?? string.Empty));
                     }
 
                     valueNode.Value = value.EditedValue?.ToString() ?? string.Empty;
-
                     propertyNode.Add(valueNode);
                 }
-
                 node.Add(propertyNode);
             }
 
@@ -147,7 +149,7 @@ namespace uSync8.ContentEdition.Serializers
             if (name != string.Empty)
                 item.Name = name;
 
-            foreach(var cultureNode in nameNode.Elements("Name"))
+            foreach (var cultureNode in nameNode.Elements("Name"))
             {
                 var culture = cultureNode.Attribute("Culture").ValueOrDefault(string.Empty);
                 if (culture == string.Empty) continue;
@@ -168,7 +170,7 @@ namespace uSync8.ContentEdition.Serializers
             if (properties == null || !properties.HasElements)
                 return Attempt.Fail(item, new Exception("No Properties in the content node"));
 
-            foreach(var property in properties.Elements())
+            foreach (var property in properties.Elements())
             {
                 var alias = property.Name.LocalName;
                 if (item.HasProperty(alias))
@@ -204,7 +206,7 @@ namespace uSync8.ContentEdition.Serializers
         }
 
         public override bool IsValid(XElement node)
-             => node != null 
+             => node != null
                 && node.GetKey() != null
                 && node.GetAlias() != null
                 && node.Element("Info") != null;
@@ -229,7 +231,8 @@ namespace uSync8.ContentEdition.Serializers
             // create
             var parent = default(TObject);
 
-            if (parentKey != Guid.Empty) {
+            if (parentKey != Guid.Empty)
+            {
                 parent = FindItem(parentKey);
             }
 

--- a/uSync8.ContentEdition/Serializers/ContentTemplateSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/ContentTemplateSerializer.cs
@@ -53,7 +53,7 @@ namespace uSync8.ContentEdition.Serializers
 
             DeserializeBase(item, node);
 
-            contentService.SaveBlueprint(item);
+            // contentService.SaveBlueprint(item);
 
             return SyncAttempt<IContent>.Succeed(
                 item.Name,
@@ -108,5 +108,9 @@ namespace uSync8.ContentEdition.Serializers
             contentService.SaveBlueprint(item);
             return Attempt.Succeed<string>("blueprint saved");
         }
+
+        protected override void SaveItem(IContent item)
+            => contentService.SaveBlueprint(item);
     }
+
 }

--- a/uSync8.ContentEdition/Serializers/DictionaryItemSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/DictionaryItemSerializer.cs
@@ -87,7 +87,7 @@ namespace uSync8.ContentEdition.Serializers
 
             item.Translations = currentTranslations;
 
-            localizationService.Save(item);
+            // localizationService.Save(item);
         }
 
         protected override SyncAttempt<XElement> SerializeCore(IDictionaryItem item)
@@ -137,6 +137,9 @@ namespace uSync8.ContentEdition.Serializers
 
             return level;
         }
+
+        protected override void SaveItem(IDictionaryItem item)
+            => localizationService.Save(item);
 
     }
 }

--- a/uSync8.ContentEdition/Serializers/DomainSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/DomainSerializer.cs
@@ -76,7 +76,7 @@ namespace uSync8.ContentEdition.Serializers
             }
 
 
-            domainService.Save(item);
+            // domainService.Save(item);
 
             return SyncAttempt<IDomain>.Succeed(item.DomainName, item, ChangeType.Import);
 
@@ -179,5 +179,8 @@ namespace uSync8.ContentEdition.Serializers
             return default(IContent);
         }
 
+
+        protected override void SaveItem(IDomain item)
+            => domainService.Save(item);
     }
 }

--- a/uSync8.ContentEdition/Serializers/MediaSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/MediaSerializer.cs
@@ -39,7 +39,7 @@ namespace uSync8.ContentEdition.Serializers
 
             DeserializeBase(item, node);
 
-            mediaService.Save(item);
+            // mediaService.Save(item);
 
             return SyncAttempt<IMedia>.Succeed(
                 item.Name, item, ChangeType.Import, "");
@@ -103,5 +103,12 @@ namespace uSync8.ContentEdition.Serializers
 
             return null;
         }
+
+        public override void Save(IEnumerable<IMedia> items)
+            => mediaService.Save(items);
+
+        protected override void SaveItem(IMedia item)
+            => mediaService.Save(item);
     }
+
 }

--- a/uSync8.Core/Serialization/ISyncSerializer.cs
+++ b/uSync8.Core/Serialization/ISyncSerializer.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
+
 using Umbraco.Core.Models.Entities;
+
 using uSync8.Core.Models;
 
 namespace uSync8.Core.Serialization
 {
-   
+
     public interface ISyncSerializerBase
     {
         Type objectType { get; }
@@ -25,7 +28,7 @@ namespace uSync8.Core.Serialization
 
         SyncAttempt<XElement> SerializeEmpty(TObject item, string alias);
 
-        SyncAttempt<TObject> Deserialize(XElement node, bool force, bool onePass);
+        SyncAttempt<TObject> Deserialize(XElement node, SerializerFlags flags);
         SyncAttempt<TObject> DeserializeSecondPass(TObject item, XElement node);
 
         /// <summary>
@@ -37,5 +40,7 @@ namespace uSync8.Core.Serialization
         bool IsTwoPass { get; }
 
         string ItemType { get; }
+
+        void Save(IEnumerable<TObject> items);
     }
 }

--- a/uSync8.Core/Serialization/SerializerFlags.cs
+++ b/uSync8.Core/Serialization/SerializerFlags.cs
@@ -1,0 +1,10 @@
+﻿namespace uSync8.Core.Serialization
+{
+    public enum SerializerFlags
+    {
+        None = 0,
+        Force = 1, // force the change (even if there isn't one)
+        OnePass = 2, // do this in one pass
+        DoNotSave = 4 // don't save 
+    }
+}

--- a/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -9,6 +9,7 @@ using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Services;
 using uSync8.Core.Extensions;
+using uSync8.Core.Models;
 
 namespace uSync8.Core.Serialization.Serializers
 {
@@ -638,6 +639,11 @@ namespace uSync8.Core.Serialization.Serializers
         override protected Attempt<OperationResult<OperationResultType, EntityContainer>> FindContainers(int parentId, string name)
             => baseService.CreateContainer(parentId, name);
 
+        protected override void SaveItem(TObject item)
+            => baseService.Save(item);
+
+        public override void Save(IEnumerable<TObject> items)
+            => baseService.Save(items);
 
         protected override void SaveContainer(EntityContainer container)
         {

--- a/uSync8.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -107,7 +107,7 @@ namespace uSync8.Core.Serialization.Serializers
             // templates 
             DeserializeTemplates(item, node);
 
-            contentTypeService.Save(item);
+            // contentTypeService.Save(item);
 
             return SyncAttempt<IContentType>.Succeed(
                 item.Name,
@@ -125,7 +125,8 @@ namespace uSync8.Core.Serialization.Serializers
         {
             DeserializeCompositions(item, node);
             DeserializeStructure(item, node);
-            contentTypeService.Save(item);
+            
+            // contentTypeService.Save(item);
 
             CleanFolder(item, node);
 

--- a/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -23,14 +23,12 @@ namespace uSync8.Core.Serialization.Serializers
     public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncSerializer<IDataType>
     {
         private readonly IDataTypeService dataTypeService;
-        private IContentSection contentSection;
 
         public DataTypeSerializer(IEntityService entityService, ILogger logger,
-            IDataTypeService dataTypeService, IContentSection contentSection)
+            IDataTypeService dataTypeService)
             : base(entityService, logger, UmbracoObjectTypes.DataTypeContainer)
         {
             this.dataTypeService = dataTypeService;
-            this.contentSection = contentSection;
         }
 
         protected override SyncAttempt<IDataType> DeserializeCore(XElement node)

--- a/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -66,7 +66,7 @@ namespace uSync8.Core.Serialization.Serializers
 
             SetFolderFromElement(item, info.Element("Folder"));
 
-            dataTypeService.Save(item);
+            // dataTypeService.Save(item);
 
             return SyncAttempt<IDataType>.Succeed(item.Name, item, ChangeType.Import);
 
@@ -179,6 +179,12 @@ namespace uSync8.Core.Serialization.Serializers
 
         protected override Attempt<OperationResult<OperationResultType, EntityContainer>> FindContainers(int parentId, string name)
             => dataTypeService.CreateContainer(parentId, name);
+
+        protected override void SaveItem(IDataType item)
+            => dataTypeService.Save(item);
+
+        public override void Save(IEnumerable<IDataType> items)
+            => dataTypeService.Save(items);
 
         protected override void SaveContainer(EntityContainer container)
             => dataTypeService.SaveContainer(container);

--- a/uSync8.Core/Serialization/Serializers/LanguageSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/LanguageSerializer.cs
@@ -52,8 +52,8 @@ namespace uSync8.Core.Serialization.Serializers
             if (fallback > 0)
                 item.FallbackLanguageId = fallback;
 
-            logger.Debug<ILanguage>("Saving Language");
-            localizationService.Save(item);
+            // logger.Debug<ILanguage>("Saving Language");
+            //localizationService.Save(item);
 
             return SyncAttempt<ILanguage>.Succeed(item.CultureName, item, ChangeType.Import);
         }
@@ -87,6 +87,9 @@ namespace uSync8.Core.Serialization.Serializers
             localizationService.GetLanguageByIsoCode(alias);
 
         protected override ILanguage FindItem(Guid key) => default(ILanguage);
+
+        protected override void SaveItem(ILanguage item)
+            => localizationService.Save(item);
 
         protected override XElement CleanseNode(XElement node)
         {

--- a/uSync8.Core/Serialization/Serializers/MacroSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/MacroSerializer.cs
@@ -97,7 +97,7 @@ namespace uSync8.Core.Serialization.Serializers
 
             RemoveOrphanProperties(item, properties);
 
-            macroService.Save(item);
+            // macroService.Save(item);
 
             var attempt = SyncAttempt<IMacro>.Succeed(item.Name, item, ChangeType.Import);
             if (changes.Any())
@@ -171,5 +171,7 @@ namespace uSync8.Core.Serialization.Serializers
         protected override IMacro FindItem(string alias)
             => macroService.GetByAlias(alias);
 
+        protected override void SaveItem(IMacro item)
+            => macroService.Save(item);
     }
 }

--- a/uSync8.Core/Serialization/Serializers/MediaTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/MediaTypeSerializer.cs
@@ -69,7 +69,7 @@ namespace uSync8.Core.Serialization.Serializers
 
             CleanTabs(item, node);
 
-            mediaTypeService.Save(item);
+            // mediaTypeService.Save(item);
 
             return SyncAttempt<IMediaType>.Succeed(
                 item.Name,
@@ -82,7 +82,8 @@ namespace uSync8.Core.Serialization.Serializers
         {
             DeserializeCompositions(item, node);
             DeserializeStructure(item, node);
-            mediaTypeService.Save(item);
+
+            // mediaTypeService.Save(item);
 
             return SyncAttempt<IMediaType>.Succeed(item.Name, item, ChangeType.Import);
         }

--- a/uSync8.Core/Serialization/Serializers/MemberTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/MemberTypeSerializer.cs
@@ -72,7 +72,7 @@ namespace uSync8.Core.Serialization.Serializers
 
             CleanTabs(item, node);
 
-            memberTypeService.Save(item);
+            // memberTypeService.Save(item);
 
             return SyncAttempt<IMemberType>.Succeed(
                 item.Name,

--- a/uSync8.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -82,7 +82,8 @@ namespace uSync8.Core.Serialization.Serializers
                     item.SetMasterTemplate(masterItem);
             }
 
-            fileService.SaveTemplate(item);
+            // Deserialize now takes care of the save.
+            // fileService.SaveTemplate(item);
 
             return SyncAttempt<ITemplate>.Succeed(item.Name, item, ChangeType.Import);
         }
@@ -123,7 +124,10 @@ namespace uSync8.Core.Serialization.Serializers
         protected override ITemplate FindItem(Guid key)
             => fileService.GetTemplate(key);
 
+        protected override void SaveItem(ITemplate item)
+            => fileService.SaveTemplate(item);
 
-
+        public override void Save(IEnumerable<ITemplate> items)
+            => fileService.SaveTemplate(items);
     }
 }

--- a/uSync8.Core/Tracking/SyncBaseTracker.cs
+++ b/uSync8.Core/Tracking/SyncBaseTracker.cs
@@ -1,8 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Umbraco.Core;
+using Umbraco.Core.IO;
 using Umbraco.Core.Models.Entities;
 using uSync8.Core.Extensions;
 using uSync8.Core.Models;

--- a/uSync8.Core/uSync8.Core.csproj
+++ b/uSync8.Core/uSync8.Core.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Extensions\XElementExtensions.cs" />
     <Compile Include="Models\uSyncChange.cs" />
     <Compile Include="Serialization\ISyncSerializer.cs" />
+    <Compile Include="Serialization\SerializerFlags.cs" />
     <Compile Include="Serialization\Serializers\ContentTypeBaseSerializer.cs" />
     <Compile Include="Serialization\Serializers\ContentTypeSerializer.cs" />
     <Compile Include="Serialization\Serializers\DataTypeSerializer.cs" />

--- a/uSync8.Site/App_Plugins/uSync8/dashboard.html
+++ b/uSync8.Site/App_Plugins/uSync8/dashboard.html
@@ -69,7 +69,7 @@
                     <div class="text-center">
                         <h4 class="usync-action-message">{{vm.status.Message}}</h4>
                         <small>{{vm.update.Message}}</small>
-                        <div class="progress" style="height: 3px;">
+                        <div class="progress usync-not-animated" style="height: 3px;">
                             <div class="bar" role="progressbar" style="width: {{vm.calcPercentage(vm.update)}}%;" aria-valuenow="{{vm.calcPercentage(vm.update)}}" aria-valuemin="0" aria-valuemax="100"></div>
                         </div>
                     </div>

--- a/uSync8.Site/App_Plugins/uSync8/usync.css
+++ b/uSync8.Site/App_Plugins/uSync8/usync.css
@@ -119,3 +119,7 @@
     .usync-root-folder input {
         width: 100%;
     }
+
+.usync-not-animated .bar {
+    transition: none;
+}

--- a/uSync8.Site/Web.config
+++ b/uSync8.Site/Web.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration> <!-- usync8 -->
+<configuration> <!-- usync8  -->
   <!--
     Define the web.config template, which is used when creating the initial web.config,
     and then transforms from web.Template.[Debug|Release].config are applied. Documentation

--- a/uSync8.Site/config/uSync8.config
+++ b/uSync8.Site/config/uSync8.config
@@ -7,6 +7,8 @@
     <ExportAtStartup>False</ExportAtStartup>
     <ExportOnSave>True</ExportOnSave>
     <UseGuidFilenames>False</UseGuidFilenames>
+    <BatchSave>False</BatchSave>
+    <ReportDebug>True</ReportDebug>
     <Handlers EnableMissing="false">
       <Handler Alias="dataTypeHandler" Enabled="true" />
       <Handler Alias="languageHandler" Enabled="true" />


### PR DESCRIPTION
Gives us the option to move the saving of the Umbraco item out of the serializer, which in turn will let us batch up some saves (like datatypes) - this should, in theory, give better performance, especially when Models builder is in live mode, as it currently rebuilds the models after every save .  