### PR TITLE
DataTypeSerializer now finding DataEditor by alias, not name.

### DIFF
--- a/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -49,7 +49,7 @@ namespace uSync8.Core.Serialization.Serializers
             if (editorAlias != item.EditorAlias)
             {
                 // change the editor type.....
-                var newEditor = Current.DataEditors.FirstOrDefault(x => x.Name.InvariantEquals(editorAlias));
+                var newEditor = Current.DataEditors.FirstOrDefault(x => x.Alias.InvariantEquals(editorAlias));
                 if (newEditor != null)
                 {
                     item.Editor = newEditor;


### PR DESCRIPTION
When running an import, the property editor was not being changed for existing properties. This is because the DataEditor was not found (attempting to match the Alias in the XML file vs. the Name of the DataEditor).