### PR TITLE
Fix Typo

### DIFF
--- a/Dist/package.ContentEdition.xml
+++ b/Dist/package.ContentEdition.xml
@@ -20,7 +20,7 @@
     <readme>
       <![CDATA[
       <p>
-      Adds Content/Media/Dicrionary Items/and Domains to uSync Process
+      Adds Content/Media/Dictionary Items/and Domains to uSync Process
       </p>]]>
     </readme>
   </info>


### PR DESCRIPTION
Dictionary was spelled Dicrionary.