### PR TITLE
Fix version description when no add-ons present

### DIFF
--- a/uSync8.BackOffice/App_Plugins/uSync8/backoffice/uSync8/uSyncDashboardController.js
+++ b/uSync8.BackOffice/App_Plugins/uSync8/backoffice/uSync8/uSyncDashboardController.js
@@ -39,9 +39,9 @@
 
         uSync8DashboardService.getAddOns()
             .then(function (result) {
-
+                vm.page.description = 'v' + result.data.Version;
                 if (result.data.AddOnString.length > 0) {
-                    vm.page.description = 'v' + result.data.Version + ' + ' + result.data.AddOnString;
+                    vm.page.description += ' + ' + result.data.AddOnString;
                 }
                 vm.addOns = result.data.AddOns;
 


### PR DESCRIPTION
When no add-ons are present, the version number fails to update with the controller-supplied value.
This PR fixes that.