### PR TITLE
Fix Structure items order by Alias - broken when Export On Save

### DIFF
--- a/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -115,16 +115,18 @@ namespace uSync8.Core.Serialization.Serializers
         protected XElement SerializeStructure(TObject item)
         {
             var node = new XElement("Structure");
-
-            foreach (var allowedType in item.AllowedContentTypes.OrderBy(x => x.Alias))
+            List<KeyValuePair<string, string>> items = new List<KeyValuePair<string, string>>();
+           
+            foreach (var allowedType in item.AllowedContentTypes)
             {
                 var allowedItem = FindItem(allowedType.Id.Value);
                 if (allowedItem != null)
                 {
-                    node.Add(new XElement(ItemType, new XAttribute("Key", allowedItem.Key.ToString()), allowedItem.Alias));
+                    items.Add(new KeyValuePair<string, string>(allowedItem.Key.ToString(), allowedItem.Alias));
                 }
             }
-
+            if (items.Count > 0)
+                node.Add(items.OrderBy(x => x.Value).Select(x => new XElement(ItemType, new XAttribute("Key", x.Key), x.Value)).ToArray());
             return node;
         }
 


### PR DESCRIPTION
When a full export is manually triggered, the `<Structure>` children are ordered by Alias as designed.
But when an Export on Save is triggered, the same code fails to sort the items.

The reason for that is that in this line:
```
foreach (var allowedType in item.AllowedContentTypes.OrderBy(x => x.Alias))
```
...the x.Alias property is null when called from Export On Save.

