### PR TITLE
V8/cache rebuild

### DIFF
--- a/uSync8.BackOffice/App_Plugins/uSync8/settings/settings.html
+++ b/uSync8.BackOffice/App_Plugins/uSync8/settings/settings.html
@@ -44,6 +44,19 @@
                             <div class="umb-permission__description">Generate uSync files when items are saved</div>
                         </div>
                     </div>
+
+                    <div class="umb-permission">
+                        <umb-toggle class="umb-permission__toggle"
+                                    checked="vm.settings.RebuildCacheOnCompleation"
+                                    on-click="vm.settings.RebuildCacheOnCompleation = !vm.settings.RebuildCacheOnCompleation">
+                        </umb-toggle>
+                        <div class="umb-permission__content" ng-click="vm.settings.RebuildCacheOnCompleation = !vm.settings.RebuildCacheOnCompleation">
+                            <div>Rebuild Cache after import</div>
+                            <div class="umb-permission__description">Request that Umbraco rebuilds its cache after an import</div>
+                        </div>
+                    </div>
+
+
                 </umb-box-content>
             </umb-box>
 

--- a/uSync8.BackOffice/Cache/RebuildCacheComponent.cs
+++ b/uSync8.BackOffice/Cache/RebuildCacheComponent.cs
@@ -8,8 +8,10 @@ using uSync8.BackOffice.Configuration;
 
 namespace uSync8.BackOffice.Cache
 {
+    [ComposeBefore(typeof(uSyncBackOfficeComposer))]
     public class RebuildCacheComposer : ComponentComposer<RebuildCacheComponent> { }
 
+    
     public class RebuildCacheComponent : IComponent
     {
         private readonly IPublishedSnapshotService snapshotService;

--- a/uSync8.BackOffice/Cache/RebuildCacheComponent.cs
+++ b/uSync8.BackOffice/Cache/RebuildCacheComponent.cs
@@ -1,60 +1,66 @@
 ﻿using System.Linq;
+
 using Umbraco.Core.Composing;
-using Umbraco.Core.Logging;
 using Umbraco.Core.Services.Changes;
 using Umbraco.Web.Cache;
 using Umbraco.Web.PublishedCache;
+using uSync8.BackOffice.Configuration;
 
-using uSync8.BackOffice;
-
-namespace uSync8.EventTriggers
+namespace uSync8.BackOffice.Cache
 {
-    /// <summary>
-    ///  Composer to register the events. 
-    /// </summary>
-    public class EventTriggersComposer : ComponentComposer<EventTriggersComponent> { }
+    public class RebuildCacheComposer : ComponentComposer<RebuildCacheComponent> { }
 
-    /// <summary>
-    ///  Component, will trigger a cache rebuild when an import is completed. (and there are changes)
-    /// </summary>
-    public class EventTriggersComponent : IComponent
+    public class RebuildCacheComponent : IComponent
     {
         private readonly IPublishedSnapshotService snapshotService;
+        private uSyncSettings settings;
 
-        public EventTriggersComponent(IPublishedSnapshotService snapshotService)
+        public RebuildCacheComponent(IPublishedSnapshotService snapshotService)
         {
             this.snapshotService = snapshotService;
+
+            this.settings = Current.Configs.uSync();
+
+            uSyncConfig.Reloaded += Config_Reloaded;
+        }
+
+        private void Config_Reloaded(uSyncSettings settings)
+        {
+            this.settings = Current.Configs.uSync();
         }
 
         public void Initialize()
         {
-            uSyncService.ImportComplete += BulkEventComplete;
+            uSyncService.ImportComplete += ImportComplete;
+           
         }
 
-        private void BulkEventComplete(uSyncBulkEventArgs e)
+        private void ImportComplete(uSyncBulkEventArgs e)
         {
-            if (e.Actions.Any(x => x.Change > uSync8.Core.ChangeType.NoChange))
+            if (settings.RebuildCacheOnCompleation &&
+                e.Actions.Any(x => x.Change > uSync8.Core.ChangeType.NoChange))
             {
                 // change happened. - rebuild
                 snapshotService.Rebuild();
 
                 // then refresh the cache : 
-
                 // there is a function for this but it is internal, so we have extracted bits.
                 // mimics => DistributedCache.RefreshAllPublishedSnapshot
-
                 RefreshContentCache(Umbraco.Web.Composing.Current.DistributedCache);
                 RefreshMediaCache(Umbraco.Web.Composing.Current.DistributedCache);
                 RefreshAllDomainCache(Umbraco.Web.Composing.Current.DistributedCache);
             }
         }
 
-        private void RefreshContentCache(DistributedCache dc) {
+
+        private void RefreshContentCache(DistributedCache dc)
+        {
             var payloads = new[] { new ContentCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) };
-            Umbraco.Web.Composing.Current.DistributedCache.RefreshByPayload(ContentCacheRefresher.UniqueId, payloads);
+            dc.RefreshByPayload(ContentCacheRefresher.UniqueId, payloads);
         }
 
-        private void RefreshMediaCache(DistributedCache dc) {
+        private void RefreshMediaCache(DistributedCache dc)
+        {
             var payloads = new[] { new MediaCacheRefresher.JsonPayload(0, TreeChangeTypes.RefreshAll) };
             dc.RefreshByPayload(MediaCacheRefresher.UniqueId, payloads);
         }
@@ -68,7 +74,7 @@ namespace uSync8.EventTriggers
 
         public void Terminate()
         {
-            // end
+            // end. 
         }
     }
 }

--- a/uSync8.BackOffice/Config/uSync8.config
+++ b/uSync8.BackOffice/Config/uSync8.config
@@ -8,7 +8,9 @@
     <ExportOnSave>True</ExportOnSave>
     <UseGuidFilenames>False</UseGuidFilenames>
     <BatchSave>False</BatchSave>
-
+    
+    <!-- calls a rebuild cache when an import completes -->
+    <RebuildCacheOnCompleation>True</RebuildCacheOnCompleation>
     
     <!-- handler sets -->
     <HandlerSets default="default">

--- a/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
+++ b/uSync8.BackOffice/Configuration/BackOfficeConfig.cs
@@ -43,6 +43,7 @@ namespace uSync8.BackOffice.Configuration
             settings.BatchSave = node.Element("BatchSave").ValueOrDefault(false);
             settings.ReportDebug = node.Element("ReportDebug").ValueOrDefault(false);
             settings.AddOnPing = node.Element("AddOnPing").ValueOrDefault(true);
+            settings.RebuildCacheOnCompleation = node.Element("RebuildCacheOnCompleation").ValueOrDefault(true);
 
             // load the handlers 
             var handlerSets = node.Element("HandlerSets");
@@ -110,6 +111,7 @@ namespace uSync8.BackOffice.Configuration
             node.CreateOrSetElement("UseGuidFilenames", settings.UseGuidNames);
             node.CreateOrSetElement("BatchSave", settings.BatchSave);
             node.CreateOrSetElement("ReportDebug", settings.ReportDebug);
+            node.CreateOrSetElement("RebuildCacheOnCompleation", settings.RebuildCacheOnCompleation);
 
             if (settings.HandlerSets.Count > 0)
             {

--- a/uSync8.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync8.BackOffice/Configuration/uSyncSettings.cs
@@ -30,6 +30,8 @@ namespace uSync8.BackOffice.Configuration
 
         public bool AddOnPing { get; set; } = true;
 
+        public bool RebuildCacheOnCompleation { get; set; } = true;
+
         public HandlerSet DefaultHandlerSet()
             => this.HandlerSets.Where(x => x.Name.InvariantEquals(this.DefaultSet)).FirstOrDefault();
     }

--- a/uSync8.BackOffice/Services/uSyncService.cs
+++ b/uSync8.BackOffice/Services/uSyncService.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
-
+using Umbraco.Web.PublishedCache;
 using uSync8.BackOffice.Configuration;
 using uSync8.BackOffice.SyncHandlers;
 
@@ -27,6 +27,7 @@ namespace uSync8.BackOffice
         private readonly IProfilingLogger logger;
 
         public uSyncService(
+            IPublishedSnapshotService snapshotService,
             SyncHandlerFactory handlerFactory,
             IProfilingLogger logger)
         {
@@ -209,6 +210,7 @@ namespace uSync8.BackOffice
                     sw.Stop();
                     summary.UpdateHandler("Post Import", HandlerStatus.Complete,
                         $"Import Completed ({sw.ElapsedMilliseconds}ms)", 0);
+
                     callbacks?.Callback?.Invoke(summary);
 
                     // fire complete

--- a/uSync8.BackOffice/Services/uSyncService.cs
+++ b/uSync8.BackOffice/Services/uSyncService.cs
@@ -5,7 +5,6 @@ using System.Linq;
 
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
-using Umbraco.Web.PublishedCache;
 using uSync8.BackOffice.Configuration;
 using uSync8.BackOffice.SyncHandlers;
 
@@ -27,7 +26,6 @@ namespace uSync8.BackOffice
         private readonly IProfilingLogger logger;
 
         public uSyncService(
-            IPublishedSnapshotService snapshotService,
             SyncHandlerFactory handlerFactory,
             IProfilingLogger logger)
         {

--- a/uSync8.BackOffice/uSync8.BackOffice.csproj
+++ b/uSync8.BackOffice/uSync8.BackOffice.csproj
@@ -253,6 +253,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Cache\RebuildCacheComponent.cs" />
     <Compile Include="Configuration\BackOfficeConfig.cs" />
     <Compile Include="Configuration\ConfigExtensions.cs" />
     <Compile Include="Configuration\OverriddenValue.cs" />

--- a/uSync8.Site/App_Plugins/uSync8/settings/settings.html
+++ b/uSync8.Site/App_Plugins/uSync8/settings/settings.html
@@ -44,6 +44,19 @@
                             <div class="umb-permission__description">Generate uSync files when items are saved</div>
                         </div>
                     </div>
+
+                    <div class="umb-permission">
+                        <umb-toggle class="umb-permission__toggle"
+                                    checked="vm.settings.RebuildCacheOnCompleation"
+                                    on-click="vm.settings.RebuildCacheOnCompleation = !vm.settings.RebuildCacheOnCompleation">
+                        </umb-toggle>
+                        <div class="umb-permission__content" ng-click="vm.settings.RebuildCacheOnCompleation = !vm.settings.RebuildCacheOnCompleation">
+                            <div>Rebuild Cache after import</div>
+                            <div class="umb-permission__description">Request that Umbraco rebuilds its cache after an import</div>
+                        </div>
+                    </div>
+
+
                 </umb-box-content>
             </umb-box>
 

--- a/uSync8.Site/config/uSync8.config
+++ b/uSync8.Site/config/uSync8.config
@@ -4,7 +4,7 @@
     <!-- ><AddOnPing>False</AddOnPing> -->
     <Folder>~/uSync/v8/</Folder>
     <FlatFolders>True</FlatFolders>
-    <ImportAtStartup>False</ImportAtStartup>
+    <ImportAtStartup>True</ImportAtStartup>
     <ExportAtStartup>False</ExportAtStartup>
     <ExportOnSave>True</ExportOnSave>
     <UseGuidFilenames>False</UseGuidFilenames>

--- a/uSync8.Site/config/uSync8.config
+++ b/uSync8.Site/config/uSync8.config
@@ -10,7 +10,7 @@
     <UseGuidFilenames>False</UseGuidFilenames>
     <BatchSave>False</BatchSave>
     <ReportDebug>False</ReportDebug>
-    <HandlerSets default="default">
+    <HandlerSets default="default" Default="default">
       <Handlers Name="default">
         <Handler Alias="dataTypeHandler" Enabled="false" Actions="All" />
         <Handler Alias="languageHandler" Enabled="true" Actions="All" />
@@ -40,5 +40,6 @@
         <Handler Alias="mediaHandler" Enabled="true" Actions="All" />
       </Handlers>
     </HandlerSets>
+    <RebuildCacheOnCompleation>True</RebuildCacheOnCompleation>
   </BackOffice>
 </uSync>


### PR DESCRIPTION
Adds an event listener to uSync to call for a NuCache rebuild at the end of an import. this might help mitigate #18 and #40. 