### PR TITLE
V8/content startup issues

### DIFF
--- a/uSync8.BackOffice/uSync8BackOffice.cs
+++ b/uSync8.BackOffice/uSync8BackOffice.cs
@@ -9,8 +9,6 @@ namespace uSync8.BackOffice
     public class uSync8BackOffice
     {
         public static bool eventsPaused { get; set; }
-
-        public static bool inStartup { get; set; }
     }
 
     internal class uSync

--- a/uSync8.BackOffice/uSync8BackOffice.cs
+++ b/uSync8.BackOffice/uSync8BackOffice.cs
@@ -9,6 +9,8 @@ namespace uSync8.BackOffice
     public class uSync8BackOffice
     {
         public static bool eventsPaused { get; set; }
+
+        public static bool inStartup { get; set; }
     }
 
     internal class uSync

--- a/uSync8.ContentEdition/Serializers/ContentSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/ContentSerializer.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
+
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Services;
-using uSync8.BackOffice;
+
 using uSync8.ContentEdition.Mapping;
 using uSync8.Core;
 using uSync8.Core.Extensions;

--- a/uSync8.ContentEdition/Serializers/ContentSerializerBase.cs
+++ b/uSync8.ContentEdition/Serializers/ContentSerializerBase.cs
@@ -1,18 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
+
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Entities;
 using Umbraco.Core.Services;
+
 using uSync8.ContentEdition.Mapping;
-using uSync8.Core;
 using uSync8.Core.Extensions;
-using uSync8.Core.Models;
 using uSync8.Core.Serialization;
 
 namespace uSync8.ContentEdition.Serializers


### PR DESCRIPTION
Workarounds for the fact that the notifications process throws errors after the content is saved during startup. 