### PR TITLE
Dependency support for using File Upload and Image Cropper inline 

### DIFF
--- a/Dist/package.cmd
+++ b/Dist/package.cmd
@@ -1,7 +1,7 @@
 @echo off 
 
-REM SET config=release
-SET config=debug
+SET config=release
+REM SET config=debug
 
 @Echo Packaging for %config%
 nuget pack ..\uSync8.Core\uSync.Core.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=%config%"

--- a/Dist/package.cmd
+++ b/Dist/package.cmd
@@ -1,17 +1,19 @@
 @echo off 
 
-@Echo Packaging
-nuget pack ..\uSync8.Core\uSync.Core.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=release"
-nuget pack ..\uSync8.BackOffice\uSync.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=release"
-nuget pack ..\uSync8.BackOffice\uSync.BackOffice.Core.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=release"
-nuget pack ..\uSync8.Community.Contrib\uSync.Community.Contrib.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=release"
-nuget pack ..\uSync8.ContentEdition\uSync.ContentEdition.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=release"
-nuget pack ..\uSync8.ContentEdition\uSync.ContentEdition.Core.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=release"
+REM SET config=release
+SET config=debug
 
-nuget pack ..\uSync8.Community.DataTypeSerializers\uSync.Community.DataTypeSerializers.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=release"
+@Echo Packaging for %config%
+nuget pack ..\uSync8.Core\uSync.Core.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=%config%"
+nuget pack ..\uSync8.BackOffice\uSync.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=%config%"
+nuget pack ..\uSync8.BackOffice\uSync.BackOffice.Core.nuspec -build  -OutputDirectory %1 -version %1 -properties "depends=%1;Configuration=%config%"
+nuget pack ..\uSync8.Community.Contrib\uSync.Community.Contrib.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=%config%"
+nuget pack ..\uSync8.ContentEdition\uSync.ContentEdition.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=%config%"
+nuget pack ..\uSync8.ContentEdition\uSync.ContentEdition.Core.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=%config%"
 
+nuget pack ..\uSync8.Community.DataTypeSerializers\uSync.Community.DataTypeSerializers.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=%config%"
 
-nuget pack ..\uSync.Console\uSync.Console.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=release"
+nuget pack ..\uSync.Console\uSync.Console.nuspec  -OutputDirectory %1 -build -version %1 -properties "depends=%1;Configuration=%config%"
 
 call CreatePackages %1
 

--- a/uSync8.ContentEdition/Checkers/ContentBaseChecker.cs
+++ b/uSync8.ContentEdition/Checkers/ContentBaseChecker.cs
@@ -179,7 +179,7 @@ namespace uSync8.ContentEdition.Checkers
                         // media means we include media items (the files are checked)
                         if (flags.HasFlag(DependencyFlags.IncludeMedia))
                         {
-                            var media = linkedDependencies.Where(x => x.Udi.EntityType == UdiEntityType.Media).ToList();
+                            var media = linkedDependencies.Where(x => x.Udi.EntityType == UdiEntityType.Media || x.Udi.EntityType == UdiEntityType.MediaFile).ToList();
                             media.ForEach(x => { x.Flags |= DependencyFlags.IncludeAncestors; });
 
                             dependencies.AddRange(media);

--- a/uSync8.ContentEdition/Properties/AssemblyInfo.cs
+++ b/uSync8.ContentEdition/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.6.0.0")]
-[assembly: AssemblyFileVersion("8.6.0.0")]
+[assembly: AssemblyVersion("8.6.1.0")]
+[assembly: AssemblyFileVersion("8.6.1.0")]


### PR DESCRIPTION
Adds a new Dependency check for Umbraco FileUpload and Cropper, so we can get the inline dependencies when they are used directly on content/.