### PR TITLE
#93 - Better error handling when an XML file is corrupt

### DIFF
--- a/uSync8.BackOffice/Services/SyncFileService.cs
+++ b/uSync8.BackOffice/Services/SyncFileService.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 
@@ -132,9 +134,17 @@ namespace uSync8.BackOffice.Services
         {
             EnsureFileExists(file);
 
-            using (var stream = OpenRead(file))
+            try
             {
-                return XElement.Load(stream);
+                using (var stream = OpenRead(file))
+                {
+                    return XElement.Load(stream);
+                }
+            }
+            catch(Exception ex)
+            {
+                logger.Warn<SyncFileService>("Error while reading in {file} {message}", file, ex.Message);
+                throw new Exception($"Error while reading in {file}", ex);
             }
         }
 

--- a/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync8.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -895,24 +895,32 @@ namespace uSync8.BackOffice.SyncHandlers
             {
                 if (!file.InvariantEquals(physicalFile))
                 {
-                    var node = syncFileService.LoadXElement(file);
-
-                    // if this xml file matches the item we have just saved. 
-
-                    if (!node.IsEmptyItem() || node.GetEmptyAction() != SyncActionType.Rename)
+                    try
                     {
-                        // the node isn't empty, or its not a rename (because all clashes become renames)
+                        var node = syncFileService.LoadXElement(file);
 
-                        if (DoItemsMatch(node, item))
+                        // if this xml file matches the item we have just saved. 
+
+                        if (!node.IsEmptyItem() || node.GetEmptyAction() != SyncActionType.Rename)
                         {
-                            logger.Debug(handlerType, "Duplicate {file} of {alias}, saving as rename", Path.GetFileName(file), this.GetItemAlias(item));
+                            // the node isn't empty, or its not a rename (because all clashes become renames)
 
-                            var attempt = serializer.SerializeEmpty(item, SyncActionType.Rename, node.GetAlias());
-                            if (attempt.Success)
+                            if (DoItemsMatch(node, item))
                             {
-                                syncFileService.SaveXElement(attempt.Item, file);
+                                logger.Debug(handlerType, "Duplicate {file} of {alias}, saving as rename", Path.GetFileName(file), this.GetItemAlias(item));
+
+                                var attempt = serializer.SerializeEmpty(item, SyncActionType.Rename, node.GetAlias());
+                                if (attempt.Success)
+                                {
+                                    syncFileService.SaveXElement(attempt.Item, file);
+                                }
                             }
                         }
+                    }
+                    catch(Exception ex)
+                    {
+                        logger.Warn(handlerType, "Error during cleanup of existing files {message}", ex.Message);
+                        // cleanup should fail silently ? - because it can impact on normal Umbraco operations?
                     }
                 }
             }


### PR DESCRIPTION
Some better logging when loading the XML fails (via the syncFileService) - so you can tell what file actually failed , and 

make the clean up process in the handler not actually throw the exception but fail in the logs.