### PR TITLE
Fix spelling mistake

### DIFF
--- a/uSync8.BackOffice/App_Plugins/uSync8/lang/en-US.xml
+++ b/uSync8.BackOffice/App_Plugins/uSync8/lang/en-US.xml
@@ -12,7 +12,7 @@
     <key alias="name">uSync 8</key>
     <key alias="intro">Database elements to and from disk</key>
 
-    <key alias="newer">There is a newer version of uSync avalible</key>
+    <key alias="newer">There is a newer version of uSync available</key>
     
     <key alias="import">Import</key>
     <key alias="importforce">Full Import</key>

--- a/uSync8.Site/App_Plugins/uSync8/lang/en-US.xml
+++ b/uSync8.Site/App_Plugins/uSync8/lang/en-US.xml
@@ -12,7 +12,7 @@
     <key alias="name">uSync 8</key>
     <key alias="intro">Database elements to and from disk</key>
 
-    <key alias="newer">There is a newer version of uSync avalible</key>
+    <key alias="newer">There is a newer version of uSync available</key>
     
     <key alias="import">Import</key>
     <key alias="importforce">Full Import</key>


### PR DESCRIPTION
I noticed a small spelling mistake in the new version of uSync message.
Updated lang file to fix spelling mistake.