### PR TITLE
Content Name/Key caching - to speed up recursive lookups.

### DIFF
--- a/uSync8.ContentEdition/Serializers/ContentSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/ContentSerializer.cs
@@ -122,7 +122,7 @@ namespace uSync8.ContentEdition.Serializers
 
         protected override SyncAttempt<IContent> DeserializeCore(XElement node)
         {
-
+         
             var item = FindOrCreate(node);
 
             DeserializeBase(item, node);
@@ -304,7 +304,12 @@ namespace uSync8.ContentEdition.Serializers
 
         #region Finders
         protected override IContent FindItem(int id)
-            => contentService.GetById(id);
+        {
+            var item = contentService.GetById(id);
+            if (!this.nameCache.ContainsKey(id))
+                this.nameCache[id] = new Tuple<Guid, string>(item.Key, item.Name);
+            return item;
+        }
 
         protected override IContent FindItem(Guid key)
         {

--- a/uSync8.ContentEdition/Serializers/MediaSerializer.cs
+++ b/uSync8.ContentEdition/Serializers/MediaSerializer.cs
@@ -180,7 +180,13 @@ namespace uSync8.ContentEdition.Serializers
         }
 
         protected override IMedia FindItem(int id)
-            => mediaService.GetById(id);
+        {
+            var item = mediaService.GetById(id);
+            if (!this.nameCache.ContainsKey(id))
+                this.nameCache[id] = new Tuple<Guid, string>(item.Key, item.Name);
+            return item;
+        }
+
 
         protected override IMedia FindItem(Guid key)
         {


### PR DESCRIPTION
Caching the content key/name speeds up the parent path lookups