### PR TITLE
remove IEntity dependency on Interfaces.

### DIFF
--- a/uSync8.Core/Dependency/ISyncDependencyChecker.cs
+++ b/uSync8.Core/Dependency/ISyncDependencyChecker.cs
@@ -13,7 +13,6 @@ namespace uSync8.Core.Dependency
     }
 
     public interface ISyncDependencyChecker<TObject> : ISyncDependencyItem
-        where TObject : IEntity
     {
         IEnumerable<uSyncDependency> GetDependencies(TObject item, DependencyFlags flags);
     }

--- a/uSync8.Core/Serialization/ISyncSerializer.cs
+++ b/uSync8.Core/Serialization/ISyncSerializer.cs
@@ -20,7 +20,6 @@ namespace uSync8.Core.Serialization
     /// </summary>
     /// <typeparam name="TObject"></typeparam>
     public interface ISyncSerializer<TObject> : ISyncSerializerBase
-        where TObject : IEntity
     {
         /// <summary>
         ///  Find an Item based on the XML node representation

--- a/uSync8.Core/Tracking/ISyncTracker.cs
+++ b/uSync8.Core/Tracking/ISyncTracker.cs
@@ -10,7 +10,6 @@ using uSync8.Core.Models;
 namespace uSync8.Core.Tracking
 {
     public interface ISyncTracker<TObject>
-        where TObject : IEntity
     {
         IEnumerable<uSyncChange> GetChanges(XElement node);
     }


### PR DESCRIPTION
Removes the where TObject : IEntity dependency on the interfaces (we don't need it on interfaces, and its a non-breaking change to remove it)