### PR TITLE
Fix LabelOnTop not serialising

### DIFF
--- a/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync8.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -116,7 +116,7 @@ namespace uSync8.Core.Serialization.Serializers
                 // added in 8.10
                 if (UmbracoVersion.LocalVersion.Major > 8 || UmbracoVersion.LocalVersion.Minor >= 10)
                 {
-                    SerializeNewProperty<bool>(propNode, property, "labelOnTop");
+                    SerializeNewProperty<bool>(propNode, property, "LabelOnTop");
                 }
 
                 node.Add(propNode);


### PR DESCRIPTION
The LabelOnTop property for property types does not seem to serialise properly because it is named with a lowercase starting letter, but actually uses an upper case letter, so it is not found.

Suggesting changing the case of the first letter as this seems to fix the problem from my tests