### PR TITLE
Allow the language serialize to work with node w/o key

### DIFF
--- a/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
@@ -223,7 +223,7 @@ namespace uSync.Core.Serialization.Serializers
 
         protected override XElement CleanseNode(XElement node)
         {
-            node.Attribute("Key").Value = "";
+            node.SetAttributeValue("Key", "");
             return node;
         }
 


### PR DESCRIPTION
This resolves issue #225 in that it uses the SetAttributeValue method, which adds handles the case where an attribute doesn't already exist.