### PR TITLE
Fixes backoffice static files not being copied

### DIFF
--- a/uSync.Backoffice.Assets/build/uSync.BackOffice.StaticAssets.targets
+++ b/uSync.Backoffice.Assets/build/uSync.BackOffice.StaticAssets.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <uSyncPackageContentFilesPath>$(MSBuildThisFileDirectory)..\Content\App_Plugins\usync\**\*.*</uSyncPackageContentFilesPath>
+        <uSyncPackageContentFilesPath>$(MSBuildThisFileDirectory)..\content\App_Plugins\usync\**\*.*</uSyncPackageContentFilesPath>
     </PropertyGroup>
 
     <Target Name="CopyuSyncPackageAssets" BeforeTargets="Build">


### PR DESCRIPTION
In case sensitive operating systems (e.g Linux) the static files weren't properly copied to the App_Plugins directory.

Should help with #267 as well, but I haven't validated if it fixes it completely, as I only saw the issue on a build server.
