### PR TITLE
Fix #343 - use temp alias when clash in doc/media/member types

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncHandlerSetSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSetSettings.cs
@@ -1,8 +1,12 @@
-﻿using System;
+﻿using Newtonsoft.Json.Serialization;
+using Newtonsoft.Json;
+
+using System;
 using System.Collections.Generic;
 
 namespace uSync.BackOffice.Configuration
 {
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     public class uSyncHandlerSetSettings
     {
         /// <summary>

--- a/uSync.BackOffice/Services/uSyncService.cs
+++ b/uSync.BackOffice/Services/uSyncService.cs
@@ -7,6 +7,7 @@ using System.Xml.Linq;
 
 using Microsoft.Extensions.Logging;
 
+using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Semver;
 using Umbraco.Extensions;
@@ -38,13 +39,17 @@ namespace uSync.BackOffice
         private SyncFileService _syncFileService;
         private readonly uSyncEventService _mutexService;
 
+
+        private readonly IAppCache _appCache;
+
         public uSyncService(
             ILogger<uSyncService> logger,
             IEventAggregator eventAggregator,
             uSyncConfigService uSyncConfigService,
             SyncHandlerFactory handlerFactory,
             SyncFileService syncFileService,
-            uSyncEventService mutexService)
+            uSyncEventService mutexService,
+            AppCaches appCaches)
         {
             this._logger = logger;
 
@@ -54,6 +59,8 @@ namespace uSync.BackOffice
             this._handlerFactory = handlerFactory;
             this._syncFileService = syncFileService;
             this._mutexService = mutexService;
+
+            this._appCache = appCaches.RuntimeCache;
 
             uSyncTriggers.DoExport += USyncTriggers_DoExport;
             uSyncTriggers.DoImport += USyncTriggers_DoImport;

--- a/uSync.BackOffice/Services/uSyncService_Handlers.cs
+++ b/uSync.BackOffice/Services/uSyncService_Handlers.cs
@@ -88,6 +88,9 @@ namespace uSync.BackOffice
                     _mutexService.FireBulkStarting(new uSyncExportStartingNotification());
                     break;
                 case HandlerActions.Import:
+                    // cleans any caches we might have set.
+                    _appCache.ClearByKey("usync_");
+
                     _mutexService.FireBulkStarting(new uSyncImportStartingNotification());
                     break;
                 case HandlerActions.Report:

--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentHandlerBase.cs
@@ -174,6 +174,29 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         }
 
 
+        protected override void CleanUp(TObject item, string newFile, string folder)
+        {
+            // for content this clean up check only catches when an item is moved from
+            // one location to another, if the site is setup to useGuidNames and a flat 
+            // structure that rename won't actually leave any old files on disk. 
+
+            bool quickCleanup = this.DefaultConfig.GetSetting("QuickCleanup", false);
+            if (quickCleanup)
+            {
+                logger.LogDebug("Quick cleanup is on, so not looking in all config files");
+                return;
+            }
+
+            // so we can skip this step and get a much quicker save process.
+            if (this.DefaultConfig.GuidNames && this.DefaultConfig.UseFlatStructure) return;
+
+            // check to see if we think this was a rename (so only do the clean up if we really have to)
+            if (item.WasPropertyDirty(nameof(item.Name)) || item.WasPropertyDirty(nameof(item.ParentId)))
+            {
+                base.CleanUp(item, newFile, folder);
+            }
+        }
+
     }
 
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -809,7 +809,7 @@ namespace uSync.BackOffice.SyncHandlers
             var duplicates = new List<uSyncAction>();
 
             // delete checks. 
-            foreach (var deleteAction in actions.Where(x => x.Change == ChangeType.Delete))
+            foreach (var deleteAction in actions.Where(x => x.Change != ChangeType.NoChange && x.Change == ChangeType.Delete))
             {
                 // todo: this is only matching by key, but non-tree based serializers also delete by alias.
                 // so this check actually has to be booted back down to the serializer.
@@ -1149,7 +1149,7 @@ namespace uSync.BackOffice.SyncHandlers
             var attempt = serializer.SerializeEmpty(item, SyncActionType.Delete, string.Empty);
             if (ShouldExport(attempt.Item, config))
             {
-                if (attempt.Success && attempt.Change > ChangeType.NoChange)
+                if (attempt.Success && attempt.Change != ChangeType.NoChange)
                 {
                     syncFileService.SaveXElement(attempt.Item, filename);
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1127,9 +1127,15 @@ namespace uSync.BackOffice.SyncHandlers
             {
                 var attempts = Export(item.Entity, Path.Combine(rootFolder, this.DefaultFolder), DefaultConfig);
 
-                foreach (var attempt in attempts.Where(x => x.Success))
+                if (!this.DefaultConfig.UseFlatStructure)
                 {
-                    this.CleanUp(item.Entity, attempt.FileName, Path.Combine(rootFolder, this.DefaultFolder));
+                    // moves only need cleaning up if we are not using flat, because 
+                    // with flat the file will always be in the same folder.
+
+                    foreach (var attempt in attempts.Where(x => x.Success))
+                    {
+                        this.CleanUp(item.Entity, attempt.FileName, Path.Combine(rootFolder, this.DefaultFolder));
+                    }
                 }
             }
         }
@@ -1144,7 +1150,14 @@ namespace uSync.BackOffice.SyncHandlers
             if (attempt.Success)
             {
                 syncFileService.SaveXElement(attempt.Item, filename);
-                this.CleanUp(item, filename, Path.Combine(rootFolder, this.DefaultFolder));
+
+                // so check - it shouldn't (under normal operation) 
+                // be possible for a clash to exist at delete, because nothing else 
+                // will have changed (like name or location) 
+
+                // we only then do this if we are not using flat structure. 
+                if (!DefaultConfig.UseFlatStructure)
+                    this.CleanUp(item, filename, Path.Combine(rootFolder, this.DefaultFolder));
             }
         }
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1147,17 +1147,20 @@ namespace uSync.BackOffice.SyncHandlers
             var filename = GetPath(folder, item, config.GuidNames, config.UseFlatStructure);
 
             var attempt = serializer.SerializeEmpty(item, SyncActionType.Delete, string.Empty);
-            if (attempt.Success)
+            if (ShouldExport(attempt.Item, config))
             {
-                syncFileService.SaveXElement(attempt.Item, filename);
+                if (attempt.Success && attempt.Change > ChangeType.NoChange)
+                {
+                    syncFileService.SaveXElement(attempt.Item, filename);
 
-                // so check - it shouldn't (under normal operation) 
-                // be possible for a clash to exist at delete, because nothing else 
-                // will have changed (like name or location) 
+                    // so check - it shouldn't (under normal operation) 
+                    // be possible for a clash to exist at delete, because nothing else 
+                    // will have changed (like name or location) 
 
-                // we only then do this if we are not using flat structure. 
-                if (!DefaultConfig.UseFlatStructure)
-                    this.CleanUp(item, filename, Path.Combine(rootFolder, this.DefaultFolder));
+                    // we only then do this if we are not using flat structure. 
+                    if (!DefaultConfig.UseFlatStructure)
+                        this.CleanUp(item, filename, Path.Combine(rootFolder, this.DefaultFolder));
+                }
             }
         }
 

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/settings/default.html
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/settings/default.html
@@ -73,8 +73,9 @@
             </usync-progress-view>
             <div ng-if="vm.perf > 0" class="text-center muted">{{vm.perf | number: 0 }}ms</div>
         </umb-box-content>
-        <umb-box-content>
-            <div ng-if="vm.warnings.message.length > 0" class="usync-warning usync-warning-{{vm.warnings.type}}">
+        <umb-box-content ng-if="vm.warnings.message.length > 0">
+            {{vm.warnings.message.length}}
+            <div class="usync-warning usync-warning-{{vm.warnings.type}}">
                 <span ng-bind-html="vm.warnings.message"></span>
             </div>
         </umb-box-content>

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.html
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.html
@@ -46,18 +46,6 @@
                         </div>
                     </div>
 
-
-                    <div class="umb-permission usync-setting-value">
-                        <div class="umb-permission__content">
-                            <div>Fail on Missing Parent</div>
-                            <div class="umb-permission__description">Import of an item will fail if it's parent is not already in Umbraco or the current Import</div>
-                        </div>
-                        <div class="umb-permission__value">
-                            <div ng-if="vm.settings.failOnMissingParent"><i class="icon icon-check color-green"></i></div>
-                            <div ng-if="!vm.settings.failOnMissingParent"><i class="icon icon-wrong color-red"></i></div>
-                        </div>
-                    </div>
-
                     <!--
     <div class="umb-permission usync-setting-value">
         <div class="umb-permission__content">
@@ -106,7 +94,7 @@
                     </div>
                     <div class="umb-permission usync-setting-value">
                         <div class="umb-permission__content">
-                            <div>use guids for filenames</div>
+                            <div>Use guids for filenames</div>
                             <div class="umb-permission__description">Use the guid of an item as the filename</div>
                         </div>
                         <div class="umb-permission__value">
@@ -139,6 +127,18 @@
                             </div>
                             <div ng-if="vm.handlerSet.disabledHandlers.length == 0">
                                 None
+                            </div>
+                        </div>
+                    </div>
+                    <div class="umb-permission usync-setting-value">
+                        <div class="umb-permission__content">
+                            <div>Fail on missing parent</div>
+                            <div class="umb-permission__description">If uSync can't find a item's parent don't import it (when off best fit is used)</div>
+                        </div>
+                        <div class="umb-permission__value">
+                            <div class="umb-permission__value">
+                                <div ng-if="vm.handlerSet.handlerDefaults.failOnMissingParent"><i class="icon icon-check color-green"></i></div>
+                                <div ng-if="!vm.handlerSet.handlerDefaults.failOnMissingParent"><i class="icon icon-wrong color-red"></i></div>
                             </div>
                         </div>
                     </div>

--- a/uSync.Community.Contrib/Mappers/DocTypeGridMapper.cs
+++ b/uSync.Community.Contrib/Mappers/DocTypeGridMapper.cs
@@ -128,7 +128,7 @@ namespace uSync8.Community.Contrib.Mappers
                 // as opposed to quite a few of these properties that 
                 // have it in 'escaped' json. so slightly diffrent 
                 // then a nested content, but not by much.
-                GetExportJsonValues(docValue, docType);
+                GetImportJsonValue(docValue, docType);
 
                 return JsonConvert.SerializeObject(jsonValue, Formatting.Indented);
             }

--- a/uSync.Core/Cache/CachedName.cs
+++ b/uSync.Core/Cache/CachedName.cs
@@ -1,0 +1,18 @@
+﻿
+using System;
+
+namespace uSync.Core.Cache
+{
+    public class CachedName
+    {
+        public CachedName() { }
+        public CachedName(Guid key, string name)
+        {
+            Key = key;
+            Name = name;
+        }
+
+        public Guid Key { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/uSync.Core/Cache/SyncEntityCache.cs
+++ b/uSync.Core/Cache/SyncEntityCache.cs
@@ -23,6 +23,7 @@ namespace uSync.Core.Cache
     {
         private readonly DictionaryAppCache cache = new DictionaryAppCache();
         private readonly DictionaryAppCache keyCache = new DictionaryAppCache();
+        private readonly DictionaryAppCache nameCache = new DictionaryAppCache();
 
         private readonly IEntityService entityService;
 
@@ -32,6 +33,20 @@ namespace uSync.Core.Cache
         {
             this.entityService = entityService;
             this._cacheEnabled = true;
+        }
+        public CachedName GetName(int id)
+        {
+            if (!_cacheEnabled) return default;
+            return cache.GetCacheItem<CachedName>(id.ToString());
+        }
+
+        public void AddName(int id, Guid guid, string name)
+        {
+            nameCache.ClearByKey(id.ToString());
+            nameCache.GetCacheItem(id.ToString(), () =>
+            {
+                return new CachedName(guid, name);
+            });
         }
 
         public IEntitySlim GetEntity(int id)
@@ -156,6 +171,7 @@ namespace uSync.Core.Cache
         {
             cache.Clear();
             keyCache.Clear();
+            nameCache.Clear();
         }
     }
 }

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -545,8 +545,7 @@ namespace uSync.Core.Serialization.Serializers
             var item = contentService.GetById(id);
             if (item != null)
             {
-                if (!this.nameCache.ContainsKey(id))
-                    this.nameCache[id] = new Tuple<Guid, string>(item.Key, item.Name);
+                AddToNameCache(id, item.Key, item.Name);
                 return item;
             }
             return null;

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -340,7 +340,7 @@ namespace uSync.Core.Serialization.Serializers
         protected virtual Attempt<string> DoSaveOrPublish(IContent item, XElement node, SyncSerializerOptions options)
         {
             var publishedNode = node.Element("Info")?.Element("Published");
-            if (publishedNode != null)
+            if (!item.Trashed && publishedNode != null)
             {
                 var schedules = GetSchedules(node.Element("Info")?.Element("Schedule"));
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -594,8 +594,7 @@ namespace uSync.Core.Serialization.Serializers
 
             if (aliasCache.Contains(alias))
             {
-                logger.LogInformation("Alias clash {alias} already exists", alias);
-                logger.LogInformation("Aliases {cache}", string.Join(",", aliasCache));
+                logger.LogDebug("Alias clash {alias} already exists", alias);
                 return $"{alias}_{Guid.NewGuid().ToShortKeyString(8)}";
             }
 
@@ -610,7 +609,7 @@ namespace uSync.Core.Serialization.Serializers
                     var sw = Stopwatch.StartNew();
                     var aliases = contentTypeService.GetAllContentTypeAliases().ToList();
                     sw.Stop();
-                    this.logger.LogInformation("Cache hit, 'usync_{id}' fetching all aliases {time}ms", this.Id, sw.ElapsedMilliseconds);
+                    this.logger.LogDebug("Cache hit, 'usync_{id}' fetching all aliases {time}ms", this.Id, sw.ElapsedMilliseconds);
                     return aliases;
                 });
 
@@ -629,7 +628,7 @@ namespace uSync.Core.Serialization.Serializers
 
             RefreshAliasCache();
 
-            logger.LogInformation("remove [{alias}] - {cache}", alias,
+            logger.LogDebug("remove [{alias}] - {cache}", alias,
                 aliasCache != null ? string.Join(",", aliasCache) : "Empty");
         }
 
@@ -647,7 +646,7 @@ namespace uSync.Core.Serialization.Serializers
                 aliasCache.Add(alias);
 
             RefreshAliasCache();
-            logger.LogInformation("Add [{aliaS}] - {cache}", alias, string.Join(",", aliasCache));
+            logger.LogDebug("Add [{aliaS}] - {cache}", alias, string.Join(",", aliasCache));
         }
 
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -982,12 +982,20 @@ namespace uSync.Core.Serialization.Serializers
         private void SetFolderFromElement(IContentTypeBase item, XElement folderNode)
         {
             var folder = folderNode.ValueOrDefault(string.Empty);
-            if (string.IsNullOrWhiteSpace(folder)) return;
-
-            var container = FindFolder(folderNode.GetKey(), folder);
-            if (container != null && container.Id != item.ParentId)
+            if (folder == null)
             {
-                item.SetParent(container);
+                if (item.ParentId != Constants.System.Root)
+                {
+                    item.ParentId = Constants.System.Root;
+                }
+            }
+            else
+            {
+                var container = FindFolder(folderNode.GetKey(), folder);
+                if (container != null && container.Id != item.ParentId)
+                {
+                    item.SetParent(container);
+                }
             }
         }
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -381,7 +381,7 @@ namespace uSync.Core.Serialization.Serializers
                         if (updatedValue.Success)
                         {
                             logger.LogDebug("Saving HistoryCleanup Value: {name} {value}", element.Name.LocalName, updatedValue.Result);
-                            changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current, updatedValue.Result, $"{_historyCleanupName}/{element.Name.LocalName}");
+                            changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current ?? "(Blank)", updatedValue.Result, $"{_historyCleanupName}/{element.Name.LocalName}");
                             property.SetValue(historyCleanup, updatedValue.Result);
                         }
                     }

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -207,8 +207,7 @@ namespace uSync.Core.Serialization.Serializers
             var item = mediaService.GetById(id);
             if (item != null)
             {
-                if (!this.nameCache.ContainsKey(id))
-                    this.nameCache[id] = new Tuple<Guid, string>(item.Key, item.Name);
+                AddToNameCache(id, item.Key, item.Name);
                 return item;
             }
             return null;

--- a/uSync.Core/uSyncCapabilityChecker.cs
+++ b/uSync.Core/uSyncCapabilityChecker.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core.Configuration;
+
+namespace uSync.Core
+{
+    /// <summary>
+    ///  a centralized way of telling if the current version of umbraco has 
+    ///  certain features or not. 
+    /// </summary>
+    public class uSyncCapabilityChecker
+    {
+        private readonly IUmbracoVersion _version;
+        public uSyncCapabilityChecker(IUmbracoVersion version)
+        {
+            _version = version;
+        }
+
+        /// <summary>
+        ///  History cleanup was introduced in Umbraco 9.1 
+        /// </summary>
+        /// <remarks>
+        ///  anything above v9.1 has history cleanup.
+        /// </remarks>
+        public bool HasHistoryCleanup
+            => _version.Version.Major != 9 || _version.Version.Minor >= 1;
+    }
+}

--- a/uSync.Core/uSyncCoreBuilderExtensions.cs
+++ b/uSync.Core/uSyncCoreBuilderExtensions.cs
@@ -33,6 +33,8 @@ namespace uSync.Core
             if (builder.Services.FirstOrDefault(x => x.ServiceType == typeof(SyncEntityCache)) != null)
                 return builder;
 
+            builder.Services.AddSingleton<uSyncCapabilityChecker>();
+
             // cache for entity items, we use it to speed up lookups.
             builder.Services.AddSingleton<SyncEntityCache>();
 

--- a/uSync.Site/App_Plugins/uSync/settings/default.html
+++ b/uSync.Site/App_Plugins/uSync/settings/default.html
@@ -73,8 +73,9 @@
             </usync-progress-view>
             <div ng-if="vm.perf > 0" class="text-center muted">{{vm.perf | number: 0 }}ms</div>
         </umb-box-content>
-        <umb-box-content>
-            <div ng-if="vm.warnings.message.length > 0" class="usync-warning usync-warning-{{vm.warnings.type}}">
+        <umb-box-content ng-if="vm.warnings.message.length > 0">
+            {{vm.warnings.message.length}}
+            <div class="usync-warning usync-warning-{{vm.warnings.type}}">
                 <span ng-bind-html="vm.warnings.message"></span>
             </div>
         </umb-box-content>

--- a/uSync.Site/App_Plugins/uSync/settings/settings.html
+++ b/uSync.Site/App_Plugins/uSync/settings/settings.html
@@ -46,18 +46,6 @@
                         </div>
                     </div>
 
-
-                    <div class="umb-permission usync-setting-value">
-                        <div class="umb-permission__content">
-                            <div>Fail on Missing Parent</div>
-                            <div class="umb-permission__description">Import of an item will fail if it's parent is not already in Umbraco or the current Import</div>
-                        </div>
-                        <div class="umb-permission__value">
-                            <div ng-if="vm.settings.failOnMissingParent"><i class="icon icon-check color-green"></i></div>
-                            <div ng-if="!vm.settings.failOnMissingParent"><i class="icon icon-wrong color-red"></i></div>
-                        </div>
-                    </div>
-
                     <!--
     <div class="umb-permission usync-setting-value">
         <div class="umb-permission__content">
@@ -106,7 +94,7 @@
                     </div>
                     <div class="umb-permission usync-setting-value">
                         <div class="umb-permission__content">
-                            <div>use guids for filenames</div>
+                            <div>Use guids for filenames</div>
                             <div class="umb-permission__description">Use the guid of an item as the filename</div>
                         </div>
                         <div class="umb-permission__value">
@@ -139,6 +127,18 @@
                             </div>
                             <div ng-if="vm.handlerSet.disabledHandlers.length == 0">
                                 None
+                            </div>
+                        </div>
+                    </div>
+                    <div class="umb-permission usync-setting-value">
+                        <div class="umb-permission__content">
+                            <div>Fail on missing parent</div>
+                            <div class="umb-permission__description">If uSync can't find a item's parent don't import it (when off best fit is used)</div>
+                        </div>
+                        <div class="umb-permission__value">
+                            <div class="umb-permission__value">
+                                <div ng-if="vm.handlerSet.handlerDefaults.failOnMissingParent"><i class="icon icon-check color-green"></i></div>
+                                <div ng-if="!vm.handlerSet.handlerDefaults.failOnMissingParent"><i class="icon icon-wrong color-red"></i></div>
                             </div>
                         </div>
                     </div>

--- a/uSync.Site/uSync/v9/Content/about-us-1-1.config
+++ b/uSync.Site/uSync/v9/Content/about-us-1-1.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="b2b3724f-3e0b-41be-9647-1f7a66dd9da3" Alias="About us (1) (1)" Change="Delete" Level="101" />

--- a/uSync.Site/uSync/v9/Content/about-us-1.config
+++ b/uSync.Site/uSync/v9/Content/about-us-1.config
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Content Key="b2b3724f-3e0b-41be-9647-1f7a66dd9da3" Alias="About us (1)" Level="2">
+  <Info>
+    <Parent Key="ca4249ed-2b23-4337-b522-63cabe5587d1">Home</Parent>
+    <Path>/Home/AboutUs1</Path>
+    <Trashed>false</Trashed>
+    <ContentType>contentPage</ContentType>
+    <CreateDate>2022-02-02T10:09:04</CreateDate>
+    <NodeName Default="About us (1)" />
+    <SortOrder>7</SortOrder>
+    <Published Default="true" />
+    <Schedule />
+    <Template Key="36b90024-6944-4edb-9226-8ac1da594bf1">contentPage</Template>
+  </Info>
+  <Properties>
+    <bodyText>
+      <Value><![CDATA[{
+  "name": "1 column layout",
+  "sections": [
+    {
+      "grid": "12",
+      "rows": []
+    }
+  ]
+}]]></Value>
+    </bodyText>
+    <keywords>
+      <Value><![CDATA[[]]]></Value>
+    </keywords>
+    <pageTitle>
+      <Value><![CDATA[A Second about us page.]]></Value>
+    </pageTitle>
+    <seoMetaDescription>
+      <Value><![CDATA[]]></Value>
+    </seoMetaDescription>
+    <umbracoNavihide>
+      <Value><![CDATA[0]]></Value>
+    </umbracoNavihide>
+  </Properties>
+</Content>

--- a/uSync.Site/uSync/v9/Content/about-us.config
+++ b/uSync.Site/uSync/v9/Content/about-us.config
@@ -28,7 +28,7 @@
               "grid": "12",
               "controls": [
                 {
-                  "value": "Oh Thats la la",
+                  "value": "Oooh la la",
                   "editor": {
                     "alias": "headline",
                     "view": "textstring"


### PR DESCRIPTION
Fixes when we have a clash of alias names in a doctype, mediaType or content type #343 . 

if you swap names somewhere upstream then when we get them we don't know that, so we have to swap them in place.
this PR does that, with the help of some caching so that we don't keep hitting the DB for the list of aliases.

when the name clases we set it to `alias_{shortstring}` and then on the second pass (as the end of all doctypes being processed) we set it back to the right thing. 

this might cause Umbraco to double load the content (which can be slow on a big site), but there isn't really another way to do it. and it should only do it this way when there is a clash. 
