### PR TITLE
Ensure backoffice assets are copied on single publish

### DIFF
--- a/uSync.Backoffice.Assets/build/uSync.BackOffice.StaticAssets.targets
+++ b/uSync.Backoffice.Assets/build/uSync.BackOffice.StaticAssets.targets
@@ -5,7 +5,7 @@
         <uSyncPackageContentFilesPath>$(MSBuildThisFileDirectory)..\content\$(uSyncPluginFolder)\**\*.*</uSyncPackageContentFilesPath>
     </PropertyGroup>
 
-    <Target Name="CopyuSyncPackageAssets" BeforeTargets="Build">
+    <Target Name="CopyuSyncPackageAssets" BeforeTargets="BeforeBuild">
         <ItemGroup>
             <uSyncPackageContentFiles Include="$(uSyncPackageContentFilesPath)" />
         </ItemGroup>


### PR DESCRIPTION
This PR address the issue mentioned in https://github.com/umbraco/Umbraco-CMS/pull/11992.
Where if the consumer of the package does not commit the assets, then a two step build process will need to take place.

With this change, it should now be possible to, from a clean state, simply do a `dotnet publish`.