### PR TITLE
FIx: better null checking in PostCleanFiles

### DIFF
--- a/uSync.BackOffice/Services/uSyncService_Single.cs
+++ b/uSync.BackOffice/Services/uSyncService_Single.cs
@@ -211,16 +211,16 @@ namespace uSync.BackOffice
 
         public IEnumerable<uSyncAction> ImportPostCleanFiles(IEnumerable<uSyncAction> actions, uSyncPagedImportOptions options)
         {
+            if (actions == null) return Enumerable.Empty<uSyncAction>();
+
             lock (_importLock)
             {
                 using (var pause = _mutexService.ImportPause())
                 {
                     SyncHandlerOptions syncHandlerOptions = new SyncHandlerOptions(options.HandlerSet);
 
-                    var aliases = actions.Select(x => x.HandlerAlias).Distinct();
-
                     var cleans = actions
-                        .Where(x => x.Change == ChangeType.Clean)
+                        .Where(x => x.Change == ChangeType.Clean && !string.IsNullOrWhiteSpace(x.FileName))
                         .Select(x => new { alias = x.HandlerAlias, folder = Path.GetDirectoryName(x.FileName), actions = x })
                         .SafeDistinctBy(x => x.folder)
                         .GroupBy(x => x.alias)


### PR DESCRIPTION
Just making sure we null check actions and filenames before we do the post clean up (no actual bug caused by this - but cleaned up in debuggin)