### PR TITLE
Single pass - media/content

### DIFF
--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -68,12 +68,6 @@ namespace uSync.Core.Serialization.Serializers
                 details.AddNotNull( HandleTrashedState(item, trashed));
             }
 
-
-            return SyncAttempt<IMedia>.Succeed(item.Name, item, ChangeType.Import, details.ToList());
-        }
-
-        public override SyncAttempt<IMedia> DeserializeSecondPass(IMedia item, XElement node, SyncSerializerOptions options)
-        {
             var propertyAttempt = DeserializeProperties(item, node, options);
             if (!propertyAttempt.Success)
                 return SyncAttempt<IMedia>.Fail(item.Name, item, ChangeType.Fail, "Failed to save properties", propertyAttempt.Exception);
@@ -83,13 +77,12 @@ namespace uSync.Core.Serialization.Serializers
             var sortOrder = info.Element("SortOrder").ValueOrDefault(-1);
             HandleSortOrder(item, sortOrder);
 
-            var attempt = mediaService.Save(item);
-            if (!attempt.Success)
-                return SyncAttempt<IMedia>.Fail(item.Name, ChangeType.Fail, "");
+            var saveAttempt = mediaService.Save(item);
+            if (!saveAttempt.Success)
+                return SyncAttempt<IMedia>.Fail(item.Name, item, ChangeType.Fail, "", saveAttempt.Exception);
 
             // setting the saved flag on the attempt to true, stops base classes from saving the item.
-            return SyncAttempt<IMedia>.Succeed(item.Name, item, ChangeType.NoChange, propertyAttempt.Status, true,
-                propertyAttempt.Result);
+            return SyncAttempt<IMedia>.Succeed(item.Name, item, ChangeType.NoChange, "", true, propertyAttempt.Result);
         }
 
         protected override uSyncChange HandleTrashedState(IMedia item, bool trashed)

--- a/uSync.Core/Serialization/Serializers/RelationTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/RelationTypeSerializer.cs
@@ -91,7 +91,7 @@ namespace uSync.Core.Serialization.Serializers
 
             var hasBeenSaved = false;
             var message = "";
-            if (options.GetSetting<bool>("IncludeRelations", true))
+            if (options.GetSetting<bool>("IncludeRelations", false))
             {
                 // we have to save before we can add the relations. 
                 this.SaveItem(item);
@@ -177,7 +177,7 @@ namespace uSync.Core.Serialization.Serializers
                 new XElement("ChildType", GetGuidValue(item, nameof(item.ChildObjectType))),
                 new XElement("Bidirectional", item.IsBidirectional)));
 
-            if (options.GetSetting<bool>("IncludeRelations", true))
+            if (options.GetSetting<bool>("IncludeRelations", false))
             {
                 node.Add(SerializeRelations(item));
             }


### PR DESCRIPTION
Improves import speed of content and media by only requiring a single pass to perform the import. 

We can do this in v9 (and prob v8) because it doesn't matter if the items we link to inside the content are not there yet, we are just storing data in the content item, if the item subsequently appears then Umbraco picks it up at run time. 