### PR TITLE
Small amend to the "view appsettings" dialog.

### DIFF
--- a/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.controller.js
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.controller.js
@@ -65,7 +65,7 @@
             uSync8DashboardService.getChangedSettings()
                 .then(function (result) {
                     var appSetting = {
-                        "uSync:": toPascal(result.data)
+                        "uSync": toPascal(result.data)
                     }
 
                     var options = {

--- a/uSync.Site/App_Plugins/uSync/settings/settings.controller.js
+++ b/uSync.Site/App_Plugins/uSync/settings/settings.controller.js
@@ -65,7 +65,7 @@
             uSync8DashboardService.getChangedSettings()
                 .then(function (result) {
                     var appSetting = {
-                        "uSync:": toPascal(result.data)
+                        "uSync": toPascal(result.data)
                     }
 
                     var options = {


### PR DESCRIPTION
Removal of the colon of the root "uSync" property shown within the "view appsettings" dialog. 

By installing uSync on Umbraco 9 for the first time and copying the snippet shown in the dialog it had me confused for ages as to why my settings weren't being detected in my appSettings.json.

Before:
![image](https://user-images.githubusercontent.com/82056925/156409448-a818b067-7732-45ad-9ae0-fba20d32b1af.png)

After:
![image](https://user-images.githubusercontent.com/82056925/156409227-c8c5e2eb-2e76-4cad-ae02-91f0094b6d34.png)
