### PR TITLE
Fix #372 - also return true when we find the parent but don't set it.

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1010,10 +1010,13 @@ namespace uSync.Core.Serialization.Serializers
             if (key != Guid.Empty)
             {
                 var entity = entityService.Get(key);
-                if (entity != null && entity.Id != item.ParentId)
+                if (entity != null)
                 {
-                    item.SetParent(entity);
-                    return true;
+                    if (entity.Id != item.ParentId)
+                    {
+                        item.SetParent(entity);
+                    }
+                    return true; 
                 }
             }
 

--- a/uSync.Site/uSync/v9/ContentTypes/childoftest.config
+++ b/uSync.Site/uSync/v9/ContentTypes/childoftest.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="1a3bd7cc-468b-4293-a622-0075ae1a58e6" Alias="childOfTest" Level="2">
+  <Info>
+    <Name>Child of Test</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <IsListView>False</IsListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Parent Key="b09cd86e-21f2-47f3-9ab1-bffca6231b9b">test</Parent>
+    <Compositions>
+      <Composition Key="b09cd86e-21f2-47f3-9ab1-bffca6231b9b">test</Composition>
+    </Compositions>
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties />
+  <Tabs />
+</ContentType>


### PR DESCRIPTION
Fixes issue where we where returning false for set master even if we did find the parent, this made usync think the parent was missing and move an item to the root. 