### PR TITLE
Updated NuGet README with v10

### DIFF
--- a/uSync/readme.txt
+++ b/uSync/readme.txt
@@ -3,18 +3,18 @@
             |  ||  |`.  `-. \  '  / |      \| .--' 
             '  ''  '.-'    | \   '  |  ||  |\ `--. 
              `----' `-----'.-'  /   `--''--' `---' 
-                           `---'  v9.x                                        
+                           `---'  v10.x            
 
-               Welcome to uSync 9 for Umbraco 9
+               Welcome to uSync 10 for Umbraco 10
 
-!! This is the .NetCore version of uSync for the .NetCore version of Umbraco !! 
+!! This is the .NetCore version of uSync for the .NetCore version of Umbraco !!
 
-   Thanks for Installing uSync 9, All the bits of your Umbraco settings 
+   Thanks for Installing uSync 10, All the bits of your Umbraco settings 
    and content will now be saved to disk.
 
 !! uSync.ContentEdition has been merged into uSync its all one package now !!
- 
-   Repo   : https://github.com/KevinJump/uSync8/tree/core/main
+
+   Repo   : https://github.com/KevinJump/uSync/tree/v10/dev
    Docs   : https://docs.jumoo.co.uk/usync/intro
    Forums : https://our.umbraco.com/packages/developer-tools/usync/usync/
 
@@ -22,5 +22,4 @@
    as many times as your like. 
 
 - 🦄🎈🎂 🥇🥾-
-
 


### PR DESCRIPTION
Whilst installing the latest uSync 10-rc5, I noticed that the NuGet README had references to v9, so took the liberty of updating them. Feel free to ignore if you've already got this in hand.