### PR TITLE
Update link to the docs in the settings.controller.js

### DIFF
--- a/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.controller.js
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/settings/settings.controller.js
@@ -11,7 +11,7 @@
         vm.loading = true;
         vm.readonly = true;
 
-        vm.docslink = "https://docs.jumoo.co.uk/uSync/v9/settings/";
+        vm.docslink = "https://docs.jumoo.co.uk/usync/reference/config/";
 
         vm.umbracoVersion = Umbraco.Sys.ServerVariables.application.version;
 


### PR DESCRIPTION
Hi @KevinJump.

There is a broken link in the **'appsettings.json snippet'**

I expect the new url should be:

https://docs.jumoo.co.uk/usync/reference/config/ 