### PR TITLE
Solve Errors While saving DocTypesContaining Images

### DIFF
--- a/uSync.Community.Contrib/Mappers/DocTypeGridMapper.cs
+++ b/uSync.Community.Contrib/Mappers/DocTypeGridMapper.cs
@@ -96,7 +96,7 @@ namespace uSync8.Community.Contrib.Mappers
                 if (item.ContainsKey(property.Alias))
                 {
                     var value = item[property.Alias];
-                    if (value != null)
+                    if (value != null && value.HasValues)
                     {
                         var mappedVal = mapperCollection.Value.GetExportValue(value, property.PropertyEditorAlias).ToString();
                         item[property.Alias] = mappedVal.GetJsonTokenValue().ExpandAllJsonInToken();


### PR DESCRIPTION
Solve Errors While saving DocTypesContaining Images

(System.AggregateException - ReferenceNul in Umbraco Scope 