### PR TITLE
Feature: Pass user info over when syncing content and media

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -25,13 +25,14 @@ namespace uSync.Core.Serialization.Serializers
             IEntityService entityService,
             ILocalizationService localizationService,
             IRelationService relationService,
+            IUserService userService,
             IShortStringHelper shortStringHelper,
             ILogger<ContentTemplateSerializer> logger,
             IContentService contentService,
             IFileService fileService,
             IContentTypeService contentTypeService,
             SyncValueMapperCollection syncMappers)
-            : base(entityService, localizationService, relationService, shortStringHelper, logger, contentService, fileService, syncMappers)
+            : base(entityService, localizationService, relationService, userService, shortStringHelper, logger, contentService, fileService, syncMappers)
         {
             _contentTypeService = contentTypeService;
             this.umbracoObjectType = UmbracoObjectTypes.DocumentBlueprint;

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -32,11 +32,12 @@ namespace uSync.Core.Serialization.Serializers
             IEntityService entityService,
             ILocalizationService localizationService,
             IRelationService relationService,
+            IUserService userService,
             IShortStringHelper shortStringHelper,
             ILogger<MediaSerializer> logger,
             IMediaService mediaService,
             SyncValueMapperCollection syncMappers)
-            : base(entityService, localizationService, relationService, shortStringHelper, logger, UmbracoObjectTypes.Media, syncMappers)
+            : base(entityService, localizationService, relationService, userService, shortStringHelper, logger, UmbracoObjectTypes.Media, syncMappers)
         {
             this._mediaService = mediaService;
             this.relationAlias = Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias;
@@ -50,6 +51,18 @@ namespace uSync.Core.Serialization.Serializers
                 "umbracoWidth", "umbracoHeight", "umbracoBytes", "umbracoExtension"
             };
         }
+
+        [Obsolete("Use constructor that takes all parameters (will obsolete in v12)")]
+        public MediaSerializer(
+          IEntityService entityService,
+          ILocalizationService localizationService,
+          IRelationService relationService,
+          IShortStringHelper shortStringHelper,
+          ILogger<MediaSerializer> logger,
+          IMediaService mediaService,
+          SyncValueMapperCollection syncMappers)
+            : this(entityService, localizationService, relationService, null, shortStringHelper, logger, mediaService, syncMappers)
+        { }
 
         protected override SyncAttempt<IMedia> DeserializeCore(XElement node, SyncSerializerOptions options)
         {

--- a/uSync.Core/Serialization/SyncContainerSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncContainerSerializerBase.cs
@@ -223,12 +223,12 @@ namespace uSync.Core.Serialization
             _folderCache = new Dictionary<int, XElement>();
         }
 
-        public void InitializeCache()
+        public virtual void InitializeCache()
         {
             ClearFolderCache();
         }
 
-        public void DisposeCache()
+        public virtual void DisposeCache()
         {
             ClearFolderCache();
         }


### PR DESCRIPTION
Adds user info to the user and media configs, so we can have a go at preserving user info in syncs. 

- user info will be reliant on the users existing on the target site, so if users are not synced this will fail back to -1 (admin user).
- will remain off by default adding `"IncludeUserInfo"` setting to handlers will turn it on.
