### PR TITLE
V10/hide usync folder

### DIFF
--- a/uSync.BackOffice/Controllers/ViewModels/SyncActionOptions.cs
+++ b/uSync.BackOffice/Controllers/ViewModels/SyncActionOptions.cs
@@ -36,5 +36,10 @@ namespace uSync.BackOffice.Controllers
         /// </summary>
         public IEnumerable<uSyncAction> Actions { get; set; }
 
+        /// <summary>
+        ///  the folder (has to be in the uSync folder) you want to import
+        /// </summary>
+        public string Folder { get; set; }
+
     }
 }

--- a/uSync.BackOffice/Controllers/uSyncApiController_HandlerImports.cs
+++ b/uSync.BackOffice/Controllers/uSyncApiController_HandlerImports.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
+using Lucene.Net.Store;
+
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Web.BackOffice.Controllers;
 
@@ -62,7 +66,7 @@ namespace uSync.BackOffice.Controllers
                 {
                     Callbacks = hubClient.Callbacks(),
                     HandlerSet = handlerSet,
-                    RootFolder = _uSyncConfig.GetRootFolder(),                    
+                    RootFolder = GetValidImportFolder(options.Folder),                    
                 }).ToList();
 
             if (_uSyncConfig.Settings.SummaryDashboard || actions.Count > _uSyncConfig.Settings.SummaryLimit)
@@ -90,7 +94,7 @@ namespace uSync.BackOffice.Controllers
             { 
                 Callbacks = hubClient.Callbacks(),
                 HandlerSet = handlerSet,
-                RootFolder = _uSyncConfig.GetRootFolder(),
+                RootFolder = GetValidImportFolder(options.Folder),
                 PauseDuringImport = true,
                 Flags = options.Force ? Core.Serialization.SerializerFlags.Force : Core.Serialization.SerializerFlags.None
             }).ToList();
@@ -113,7 +117,7 @@ namespace uSync.BackOffice.Controllers
                 ? options.Set : _uSyncConfig.Settings.DefaultSet;
 
             var actions = _uSyncService.PerformPostImport(
-                _uSyncConfig.GetRootFolder(), 
+                GetValidImportFolder(options.Folder), 
                 handlerSet, 
                 options.Actions);
 
@@ -153,7 +157,7 @@ namespace uSync.BackOffice.Controllers
             {
                 Callbacks = hubClient.Callbacks(),
                 HandlerSet = handlerSet,
-                RootFolder = _uSyncConfig.GetRootFolder()
+                RootFolder = GetValidImportFolder(options.Folder)
             }).ToList();
 
             if (_uSyncConfig.Settings.SummaryDashboard || actions.Count > _uSyncConfig.Settings.SummaryLimit)
@@ -178,5 +182,30 @@ namespace uSync.BackOffice.Controllers
         [HttpPost]
         public void FinishProcess([FromQuery]HandlerActions action, IEnumerable<uSyncAction> actions)
             => _uSyncService.FinishBulkProcess(action, actions);
+
+
+
+
+        private string GetValidImportFolder(string folder)
+        {
+            if (string.IsNullOrWhiteSpace(folder)) return _uSyncConfig.GetRootFolder();
+
+            // else check its a valid folder. 
+            var fullPath = _syncFileService.GetAbsPath(folder);
+            var fullRoot = _syncFileService.GetAbsPath(_uSyncConfig.GetRootFolder());
+
+
+            var rootParent = Path.GetDirectoryName(fullRoot.TrimEnd(new char[] {'/', '\\'}));
+            _logger.LogDebug("Import Folder: {fullPath} {rootPath} {fullRoot}", fullPath, rootParent, fullRoot);
+
+            if (fullPath.StartsWith(rootParent))
+            {
+                _logger.LogInformation("Using Custom Folder: {fullPath}", folder);
+                return folder;
+            }
+
+
+            return string.Empty;
+        }
     }
 }

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/usync.service.js
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/usync.service.js
@@ -152,7 +152,8 @@
         function reportHandler(handler, options, clientId) {
             return $http.post(serviceRoot + 'ReportHandler', {
                 handler: handler,
-                clientId: clientId
+                clientId: clientId,
+                folder: options.folder
             });
         }
 
@@ -161,7 +162,8 @@
                 handler: handler,
                 clientId: clientId,
                 force: options.force,
-                set: options.set
+                set: options.set,
+                folder: options.folder
             });
         }
 
@@ -169,7 +171,8 @@
             return $http.post(serviceRoot + 'ImportPost', {
                 actions: actions,
                 clientId: clientId,
-                set: options.set
+                set: options.set,
+                folder: options.folder
             });
         }
 
@@ -177,7 +180,8 @@
             return $http.post(serviceRoot + 'ExportHandler', {
                 handler: handler,
                 clientId: clientId,
-                set: options.set
+                set: options.set,
+                folder: options.folder
             });
         }
 

--- a/uSync.Backoffice.Assets/build/uSync.BackOffice.Assets.targets
+++ b/uSync.Backoffice.Assets/build/uSync.BackOffice.Assets.targets
@@ -11,4 +11,17 @@
 		<RemoveDir Directories="@(uSyncPackageFolder)" ContinueOnError="true"></RemoveDir>
 	</Target>
 
+	<ItemGroup>
+		<Content Remove="uSync/**" />
+	</ItemGroup>
+
+	<Target Name="PublishuSyncFiles" BeforeTargets="PrepareForPublish">
+		<ItemGroup>
+			<uSyncFiles Include="uSync/**;" />
+		</ItemGroup>
+		<Message Text="Copying uSync files: #@(uSyncFiles->Count()) files" Importance="high" />
+		<Copy SourceFiles="@(uSyncFiles)" DestinationFolder="$(PublishDir)\uSync\%(RecursiveDir)" SkipUnchangedFiles="true" />
+	</Target>
+
+
 </Project>


### PR DESCRIPTION
Adds code to the targets file that hides the usync folder in visual studio .

the files in uSync will still get published, they just don't appear in the solution anymore. (like it use to be in v8) 