### PR TITLE
V10/sync variant info

### DIFF
--- a/uSync.Core/Sync/SyncLocalItem.cs
+++ b/uSync.Core/Sync/SyncLocalItem.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
+using System;
 using System.Collections.Generic;
 
 using Umbraco.Cms.Core;
@@ -43,7 +44,18 @@ namespace uSync.Core.Sync
         ///  when variants are present the user can be presented with 
         ///  the option of what languages they want to sync.
         /// </remarks>
+        [Obsolete("Use All Variants when returning variants so we know whas is avalible.")]
         public Dictionary<string, string> Variants { get; set; }
+
+        /// <summary>
+        ///  details of all variants, 
+        /// </summary>
+        /// <remarks>
+        ///  tells us if the variant exists is published or not, allows us to show 
+        ///  the unpublished variants in the UI and more importantly tell if they 
+        ///  exist. 
+        /// </remarks>
+        public Dictionary<string, SyncVariantInfo> AllVariants { get; set; }
 
         /// <summary>
         ///  Syncing of this item requires that the files be synced. 
@@ -72,6 +84,13 @@ namespace uSync.Core.Sync
         {
             Id = id.ToString();
         }
+    }
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class SyncVariantInfo
+    {
+        public string Name { get; set; }
+        public bool Published { get; set; }
     }
 
 }


### PR DESCRIPTION
Adds a `SyncVariantInfo` class to the `SyncLocalItem` object, this will allow us to offer more detail for a set of synced items when they are pushed/pulled between instances. 