### PR TITLE
v11: Schema Inclusion.

### DIFF
--- a/dist/build-package.ps1
+++ b/dist/build-package.ps1
@@ -69,6 +69,8 @@ dotnet pack ..\uSync.BackOffice\uSync.BackOffice.csproj  --no-build  --no-restor
 
 dotnet pack ..\uSync.AutoTemplates\uSync.AutoTemplates.csproj --no-build --no-restore -c $env -o $outFolder /p:$buildParams
 
+dotnet pack ..\uSync.BackOffice.Targets\uSync.BackOffice.Targets.csproj --no-build --no-restore -c $env -o $outFolder /p:$buildParams
+
 dotnet pack ..\uSync\uSync.csproj  --no-build  --no-restore -c $env -o $outFolder /p:$buildParams
 # .\nuget pack "..\uSync\uSync.nuspec" -version $fullVersion -OutputDirectory $outFolder
 

--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -3,7 +3,7 @@
   "title": "uSyncAppSettings",
   "type": "object",
   "properties": {
-    "USync": {
+    "uSync": {
       "$ref": "#/definitions/USyncuSyncDefinition"
     }
   },

--- a/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.props
+++ b/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.props
@@ -1,0 +1,5 @@
+﻿<Project>
+	<ItemGroup>
+		<UmbracoJsonSchemaFiles Include="$(MSBuildThisFileDirectory)..\appsettings-schema.usync.json" Weight="-80" />
+	</ItemGroup>
+</Project>

--- a/uSync.BackOffice.Targets/uSync.BackOffice.Targets.csproj
+++ b/uSync.BackOffice.Targets/uSync.BackOffice.Targets.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<EnableDefaultContentItems>false</EnableDefaultContentItems>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+		<IncludeSymbols>false</IncludeSymbols>	
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Content Include="buildTransitive\**" PackagePath="buildTransitive" />
+		<Content Include="appsettings-schema.usync.json" PackagePath="" />
+	</ItemGroup>
+
+</Project>

--- a/uSync.Backoffice.Assets/uSync.Backoffice.Assets.csproj
+++ b/uSync.Backoffice.Assets/uSync.Backoffice.Assets.csproj
@@ -26,6 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\uSync.BackOffice.Targets\uSync.BackOffice.Targets.csproj" />
 		<ProjectReference Include="..\uSync.BackOffice\uSync.BackOffice.csproj" />
 	</ItemGroup>
 

--- a/uSync.SchemaGenerator/Options.cs
+++ b/uSync.SchemaGenerator/Options.cs
@@ -6,7 +6,7 @@ namespace uSync
     {
         [Option('o', "outputFile", Required = false,
             HelpText = "",
-            Default = "..\\uSync.Backoffice.Assets\\appsettings-schema.usync.json")]
+            Default = "..\\uSync.Backoffice.Targets\\appsettings-schema.usync.json")]
         public string OutputFile { get; set; }
     }
 }

--- a/uSync.SchemaGenerator/Program.cs
+++ b/uSync.SchemaGenerator/Program.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Threading.Tasks;
 using CommandLine;
 
+using NPoco.fastJSON;
+
 namespace uSync
 {
     /// <summary>
@@ -28,7 +30,11 @@ namespace uSync
         private static async Task Execute(Options options)
         {
             var generator = new uSyncSchemaGenerator();
-            var schema = generator.Generate();
+            // very specific, for uSync we want everything but the first element
+            // to be upper cased, it doesn't really matter but it looks "right"
+
+            var schema = generator.Generate()
+                .Replace("\"USync\"", "\"uSync\"");
 
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, options.OutputFile));
             Console.WriteLine("Path to use {0}", path);

--- a/uSync.SchemaGenerator/uSyncSchemaGenerator.cs
+++ b/uSync.SchemaGenerator/uSyncSchemaGenerator.cs
@@ -20,7 +20,8 @@ namespace uSync
 
         public uSyncSchemaGenerator()
         {
-            _schemaGenerator = new JsonSchemaGenerator(new uSyncSchemaGeneratorSettings());
+            _schemaGenerator = new JsonSchemaGenerator(
+                new uSyncSchemaGeneratorSettings());
         }
 
         public string Generate() 

--- a/uSync.sln
+++ b/uSync.sln
@@ -29,9 +29,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uSync.Tests", "uSync.Tests\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uSync.SchemaGenerator", "uSync.SchemaGenerator\uSync.SchemaGenerator.csproj", "{1E5B64E5-E8A6-42F2-9079-FB71D6D237D6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uSync.Backoffice.Assets", "uSync.Backoffice.Assets\uSync.Backoffice.Assets.csproj", "{4ECC3DFD-5BCB-4095-8D06-DE482DF4C6A1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uSync.BackOffice.Assets", "uSync.Backoffice.Assets\uSync.BackOffice.Assets.csproj", "{4ECC3DFD-5BCB-4095-8D06-DE482DF4C6A1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "uSync.Site", "uSync.Site\uSync.Site.csproj", "{0A1CBCE0-4EBA-4C76-BE08-CAAD33A76540}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "uSync.BackOffice.Targets", "uSync.BackOffice.Targets\uSync.BackOffice.Targets.csproj", "{B09F319A-7066-4B1B-B97D-F609B558C9F4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -79,6 +81,10 @@ Global
 		{0A1CBCE0-4EBA-4C76-BE08-CAAD33A76540}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A1CBCE0-4EBA-4C76-BE08-CAAD33A76540}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A1CBCE0-4EBA-4C76-BE08-CAAD33A76540}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B09F319A-7066-4B1B-B97D-F609B558C9F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B09F319A-7066-4B1B-B97D-F609B558C9F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B09F319A-7066-4B1B-B97D-F609B558C9F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B09F319A-7066-4B1B-B97D-F609B558C9F4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/uSync/uSync.csproj
+++ b/uSync/uSync.csproj
@@ -33,7 +33,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\uSync.Backoffice.Assets\uSync.Backoffice.Assets.csproj" />
+		<ProjectReference Include="..\uSync.Backoffice.Assets\uSync.BackOffice.Assets.csproj" />
 		<ProjectReference Include="..\uSync.BackOffice\uSync.BackOffice.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
Adds uSync.BackOffice.Targets project to add the appsettings-schema.,usync.json file to the list of schema files Umbraco use to build the appsettings-schema.json file on a site. 