### PR TITLE
ContentType lookup cacheing in nested items.

### DIFF
--- a/uSync8.ContentEdition/Mapping/SyncNestedValueMapperBase.cs
+++ b/uSync8.ContentEdition/Mapping/SyncNestedValueMapperBase.cs
@@ -124,7 +124,7 @@ namespace uSync8.ContentEdition.Mapping
         /// </summary>
         protected uSyncDependency CreateDocTypeDependency(string alias, DependencyFlags flags)
         {
-            var item = contentTypeService.Get(alias);
+            var item = SyncValueMapperFactory.EnityCache.GetContentType(alias);
             if (item != null)
             {
                 return CreateDocTypeDependency(item, flags);
@@ -184,7 +184,7 @@ namespace uSync8.ContentEdition.Mapping
                 var attempt = json[keyAlias].TryConvertTo<Guid>();
                 if (attempt.Success)
                 {
-                    return contentTypeService.Get(attempt.Result);
+                    return SyncValueMapperFactory.EnityCache.GetContentType(attempt.Result);
                 }
             }
 
@@ -194,7 +194,7 @@ namespace uSync8.ContentEdition.Mapping
         protected IContentType GetDocType(string alias)
         {
             if (string.IsNullOrWhiteSpace(alias)) return default;
-            return contentTypeService.Get(alias);
+            return SyncValueMapperFactory.EnityCache.GetContentType(alias);
         }
 
 

--- a/uSync8.ContentEdition/Mapping/SyncValueMapperFactory.cs
+++ b/uSync8.ContentEdition/Mapping/SyncValueMapperFactory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 
+using uSync8.Core.Cache;
 using uSync8.Core.Dependency;
 
 namespace uSync8.ContentEdition.Mapping
@@ -59,6 +60,9 @@ namespace uSync8.ContentEdition.Mapping
                     .GetInstance<SyncValueMapperCollection>()
                     .GetImportValue(value, propertyMapInfo);
         }
+
+        public static SyncEntityCache EnityCache =>
+            Current.Factory.GetInstance<SyncValueMapperCollection>().EntityCache;
 
         public static IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
         {


### PR DESCRIPTION
Adds a content type lookup cache for calls inside nested content 'like' properties, makes the serialization of nasty big nested content blobs way quicker. 