### PR TITLE
Fix - don't treat angular expressions as json when saving.

### DIFF
--- a/uSync.Core/Extensions/JsonExtensions.cs
+++ b/uSync.Core/Extensions/JsonExtensions.cs
@@ -1,4 +1,6 @@
 ﻿
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -125,5 +127,8 @@ namespace uSync.Core
             if (!attempt) return default;
             return attempt.Result;
         }
+
+        public static bool IsAngularExpression(this string value)
+            => value.StartsWith("{{") && value.EndsWith("}}");
     }
 }

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -600,7 +600,7 @@ namespace uSync.Core.Serialization.Serializers
             // TODO: in a perfect world, this is the best answer, don't escape any buried JSON in anything
             // but there might be a couple of property value converters that don't like their nested JSON
             // to not be escaped so we would need to do proper testing. 
-            if (exportValue.DetectIsJson())
+            if (exportValue.DetectIsJson() && !exportValue.IsAngularExpression())
             {
                 var tokenValue = exportValue.GetJsonTokenValue().ExpandAllJsonInToken();
                 return JsonConvert.SerializeObject(tokenValue, Formatting.Indented);


### PR DESCRIPTION
For #430 for uSync v11 (will backport to v10 too).

Adds a `IsAngular` check  

previously (in Translation Manager!) we actually check if the detected json can be parsed, but that might cause us a performance hit as we would be reparsing all json content. Hopefully this actually captures the edge cases fore this issue and is quicker. 