### PR TITLE
Add a media picker 3 config serializer #458

### DIFF
--- a/uSync.Community.DataTypeSerializers/CoreTypes/MediaPicker3ConfigSerializer.cs
+++ b/uSync.Community.DataTypeSerializers/CoreTypes/MediaPicker3ConfigSerializer.cs
@@ -1,0 +1,65 @@
+﻿using System;
+
+using Newtonsoft.Json;
+
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.DataTypes;
+
+namespace uSync8.Community.DataTypeSerializers.CoreTypes
+{
+    public class MediaPicker3ConfigSerializer : SyncDataTypeSerializerBase, IConfigurationSerializer
+    {
+        public MediaPicker3ConfigSerializer(IEntityService entityService)
+            : base(entityService)
+        { }
+
+        public string Name => "MediaPicker3NodeSerializer";
+
+        public string[] Editors => new string[] { "Umbraco.MediaPicker3" };
+
+        public override string SerializeConfig(object configuration)
+        {
+
+            if (configuration is MediaPicker3Configuration pickerConfig)
+            {
+                var mediaPickerConfig = new MappedPathConfigBase<MediaPicker3Configuration>();
+                mediaPickerConfig.Config = new MediaPicker3Configuration()
+                {
+                    EnableLocalFocalPoint = pickerConfig.EnableLocalFocalPoint,
+                    Crops = pickerConfig.Crops,
+                    Filter = pickerConfig.Filter,
+                    IgnoreUserStartNodes = pickerConfig.IgnoreUserStartNodes,
+                    Multiple = pickerConfig.Multiple,
+                    ValidationLimit = pickerConfig.ValidationLimit
+                };
+
+                if (pickerConfig.StartNodeId != null)
+                    mediaPickerConfig.MappedPath = UdiToEntityPath(pickerConfig.StartNodeId);
+                return base.SerializeConfig(mediaPickerConfig);
+            }
+
+            return base.SerializeConfig(configuration);
+
+        }
+
+
+        public override object DeserializeConfig(string config, Type configType)
+        {
+            if (configType == typeof(MediaPicker3Configuration))
+            {
+                var mappedConfig = JsonConvert.DeserializeObject<MappedPathConfigBase<MediaPicker3Configuration>>(config);
+
+                if (!string.IsNullOrWhiteSpace(mappedConfig.MappedPath))
+                {
+                    mappedConfig.Config.StartNodeId = PathToUdi(mappedConfig.MappedPath);
+                }
+
+                return mappedConfig.Config;
+            }
+
+            return base.DeserializeConfig(config, configType);
+        }
+    }
+}

--- a/uSync.Community.DataTypeSerializers/uSync.Community.DataTypeSerializers.csproj
+++ b/uSync.Community.DataTypeSerializers/uSync.Community.DataTypeSerializers.csproj
@@ -21,7 +21,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\uSync.BackOffice\uSync.BackOffice.csproj" />
+		<PackageReference Include="uSync.BackOffice" Version="10.0.0" />
+		<!-- <ProjectReference Include="..\uSync.BackOffice\uSync.BackOffice.csproj" /> -->
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds a media picker 3 config serializer to sync the start node (if you are not syncing content).