### PR TITLE
V11/settings dictionary case

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -53,7 +53,7 @@ namespace uSync.BackOffice.Configuration
         /// <summary>
         /// Additional settings for the handler
         /// </summary>
-        public Dictionary<string, string> Settings { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> Settings { get; set; } = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ namespace uSync.BackOffice.Configuration
         public static void AddSetting<TObject>(this HandlerSettings settings, string key, TObject value)
         {
             if (settings.Settings == null)
-                settings.Settings = new Dictionary<string, string>();
+                settings.Settings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
             settings.Settings[key] = value.ToString();
         }
@@ -109,7 +109,7 @@ namespace uSync.BackOffice.Configuration
                 UseFlatStructure = settings.UseFlatStructure,
                 Group = settings.Group,
                 GuidNames = settings.GuidNames,
-                Settings = new Dictionary<string, string>(settings.Settings)
+                Settings = new Dictionary<string, string>(settings.Settings, StringComparer.InvariantCultureIgnoreCase)
             };
         }
 

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 using Umbraco.Extensions;
@@ -19,7 +20,7 @@ namespace uSync.Core.Serialization
 
         public SyncSerializerOptions(Dictionary<string, string> settings)
         {
-            this.Settings = settings != null ? new Dictionary<string, string>(settings) : new Dictionary<string, string>();
+            this.Settings = settings != null ? new Dictionary<string, string>(settings) : new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
         }
 
@@ -119,7 +120,7 @@ namespace uSync.Core.Serialization
         /// </summary>
         public void MergeSettings(Dictionary<string, string> newSettings)
         {
-            if (Settings == null) Settings = new Dictionary<string, string>();
+            if (Settings == null) Settings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             if (newSettings != null)
             {
                 foreach (var kvp in newSettings)


### PR DESCRIPTION
Makes the settings dictionaries use a case Incentive comparer, so we don't have to worry about keys mis matched. 