### PR TITLE
Fix: SignalR root missing on first install/upgrade

### DIFF
--- a/uSync.BackOffice/Hubs/uSyncHubRoutes.cs
+++ b/uSync.BackOffice/Hubs/uSyncHubRoutes.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
@@ -47,8 +48,15 @@ namespace uSync.BackOffice.Hubs
         /// </summary>
         public void CreateRoutes(IEndpointRouteBuilder endpoints)
         {
-            if (_runtimeState.Level == Umbraco.Cms.Core.RuntimeLevel.Run) 
-                endpoints.MapHub<SyncHub>(GetuSyncHubRoute());
+            switch (_runtimeState.Level)
+            {
+                case RuntimeLevel.Install:
+                case RuntimeLevel.Upgrade:
+                case RuntimeLevel.Run:
+                    endpoints.MapHub<SyncHub>(GetuSyncHubRoute());
+                    break;
+
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When an Umbraco site is installed or upgraded the SignalR route can be missing. 

this is because the signalR root is setup during boot, and when you install/upgrade the Runtime state isn't run.
It is run once the install is complete but things like routes are not revisited during the 'soft' reboot that Umbraco does.

as per the fix here : https://github.com/umbraco/Umbraco-CMS/pull/13551 the answer is to initialize the route during install and upgrade. 

this isn't an issue as the route has no dependencies on anything runtime, it just needs to be there so uSync can send out its update messages. 

