### PR TITLE
#483 Support DoNoSerialize by pattern

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -207,17 +207,17 @@ namespace uSync.Core.Serialization.Serializers
                 || options.GetSetting(uSyncConstants.DefaultsKey, false);
 
             var excludedProperties = GetExcludedProperties(options);
-            var excludedPropertyPattern = GetExcludedPropertyPattern(options);
+            var excludedPropertiesPattern = GetExcludedPropertiesPattern(options);
             var availableCultures = item.AvailableCultures.ToList();
 
             var node = new XElement("Properties");
             var includedProperties = item.Properties
                 .Where(x => !excludedProperties.InvariantContains(x.Alias));
 
-            if(excludedPropertyPattern is not null)
+            if(excludedPropertiesPattern is not null)
             {
                 includedProperties = includedProperties
-                 .Where(x => !excludedPropertyPattern.IsMatch(x.Alias));
+                 .Where(x => !excludedPropertiesPattern.IsMatch(x.Alias));
             }
 
             foreach (var property in includedProperties.OrderBy(x => x.Alias))
@@ -983,7 +983,7 @@ namespace uSync.Core.Serialization.Serializers
             return exclude;
         }
 
-        private Regex GetExcludedPropertyPattern(SyncSerializerOptions options)
+        private Regex GetExcludedPropertiesPattern(SyncSerializerOptions options)
         {
             const string settingsKey = "DoNotSerializePattern";
 

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -985,7 +985,7 @@ namespace uSync.Core.Serialization.Serializers
 
         private Regex GetExcludedPropertyPattern(SyncSerializerOptions options)
         {
-            const string settingsKey = "DoNotSerializePatterns";
+            const string settingsKey = "DoNotSerializePattern";
 
             string pattern = options.GetSetting<string>(settingsKey, "");
             if (string.IsNullOrWhiteSpace(pattern))


### PR DESCRIPTION
Introduced a new settings key "DoNotSerializePattern" which can be used to exclude properties based on a regex expression. 

Reason for not using the existing settings entry is not to mess with the performance of the serialization in any way (unless consumer opts in for use the pattern exclusion).

Example value:
```JSON
{
    "Settings": {
        "DoNotSerialize": "serverName,supportEmail", 
        "DoNotSerializePattern": "(?i)[a-z]+_(localProp|envProp)" 
    }
}
```` 