### PR TITLE
breaking: change the settings dictionary to string,object #493

### DIFF
--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -251,9 +251,7 @@
         "Settings": {
           "type": "object",
           "description": "Additional settings for the handler",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "additionalProperties": {}
         }
       }
     },

--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -53,7 +53,7 @@ namespace uSync.BackOffice.Configuration
         /// <summary>
         /// Additional settings for the handler
         /// </summary>
-        public Dictionary<string, string> Settings { get; set; } = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+        public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ namespace uSync.BackOffice.Configuration
         public static void AddSetting<TObject>(this HandlerSettings settings, string key, TObject value)
         {
             if (settings.Settings == null)
-                settings.Settings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+                settings.Settings = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
 
             settings.Settings[key] = value.ToString();
         }
@@ -109,7 +109,7 @@ namespace uSync.BackOffice.Configuration
                 UseFlatStructure = settings.UseFlatStructure,
                 Group = settings.Group,
                 GuidNames = settings.GuidNames,
-                Settings = new Dictionary<string, string>(settings.Settings, StringComparer.InvariantCultureIgnoreCase)
+                Settings = new Dictionary<string, object>(settings.Settings, StringComparer.InvariantCultureIgnoreCase)
             };
         }
 

--- a/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
@@ -182,8 +182,6 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         }
 
         private bool IsOneWay(HandlerSettings config)
-        {
-            return (config.Settings.ContainsKey("OneWay") && config.Settings["OneWay"].InvariantEquals("true"));
-        }
+            => config.GetSetting<bool>("OneWay", false);
     }
 }

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -18,13 +18,13 @@ namespace uSync.Core.Serialization
             this.Flags = flags;
         }
 
-        public SyncSerializerOptions(Dictionary<string, string> settings)
+        public SyncSerializerOptions(Dictionary<string, object> settings)
         {
-            this.Settings = settings != null ? new Dictionary<string, string>(settings) : new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            this.Settings = settings != null ? new Dictionary<string, object>(settings) : new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
 
         }
 
-        public SyncSerializerOptions(SerializerFlags flags, Dictionary<string, string> settings)
+        public SyncSerializerOptions(SerializerFlags flags, Dictionary<string, object> settings)
             : this(settings)
         {
             this.Flags = flags;
@@ -46,7 +46,7 @@ namespace uSync.Core.Serialization
         /// <summary>
         ///  Parameterized options, custom for each handler
         /// </summary>
-        public Dictionary<string, string> Settings { get; internal set; }
+        public Dictionary<string, object> Settings { get; internal set; }
 
         /// <summary>
         ///  flag properties, we can move this away from flags if we want to.
@@ -102,7 +102,7 @@ namespace uSync.Core.Serialization
 
         public string SwapValue(string key, string newValue)
         {
-            string oldValue = null;
+            object oldValue = null;
 
             if (!this.Settings.ContainsKey(key))
                 oldValue = this.Settings[key];
@@ -112,7 +112,7 @@ namespace uSync.Core.Serialization
             else
                 this.Settings[key] = newValue;
 
-            return oldValue;
+            return oldValue.ToString();
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace uSync.Core.Serialization
         /// </summary>
         public void MergeSettings(Dictionary<string, string> newSettings)
         {
-            if (Settings == null) Settings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+            if (Settings == null) Settings = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
             if (newSettings != null)
             {
                 foreach (var kvp in newSettings)


### PR DESCRIPTION
DRAFT - to be merged into v12 . (when ready).

Changes the settings object from `string,string` dictionary to `string,object` - not significant change but it fixes the schema generation. 

but its a breaking change, so should be reserved for a major release.