### PR TITLE
Fix #501 - Download fails when root folder is outside of site root.

### DIFF
--- a/uSync.BackOffice/Services/uSyncService_Files.cs
+++ b/uSync.BackOffice/Services/uSyncService_Files.cs
@@ -18,10 +18,12 @@ public partial class uSyncService
     /// <returns>Stream of zip file for folder</returns>
     public MemoryStream CompressFolder(string folder)
     {
-        if (!Directory.Exists(folder))
-            throw new DirectoryNotFoundException(folder);
+        var fullPath = _syncFileService.GetAbsPath(folder);
 
-        var directoryInfo = new DirectoryInfo(folder);
+        if (!Directory.Exists(fullPath))
+            throw new DirectoryNotFoundException(fullPath);
+
+        var directoryInfo = new DirectoryInfo(fullPath);
         var files = directoryInfo.GetFiles("*.*", SearchOption.AllDirectories);
 
         var stream = new MemoryStream();
@@ -29,7 +31,7 @@ public partial class uSyncService
         {
             foreach (var file in files)
             {
-                var relativePath = GetRelativePath(folder, file.FullName);
+                var relativePath = GetRelativePath(fullPath, file.FullName);
                 archive.CreateEntryFromFile(file.FullName, relativePath);
             }
         }


### PR DESCRIPTION
Fixes #501 

When the root folder is outside of the site, the download function wasn't resolving the path correctly , this adds the call to the uSync file service `GetAbsPath` method to resolve it .