### PR TITLE
V11/userinfo - [De]Serialize the user information 

### DIFF
--- a/uSync.BackOffice/Models/uSyncImportOptions.cs
+++ b/uSync.BackOffice/Models/uSyncImportOptions.cs
@@ -54,6 +54,11 @@ namespace uSync.BackOffice
         ///  should we pause the uSync export events during the import ?
         /// </summary>
         public bool PauseDuringImport { get; set; } = true;
+
+        /// <summary>
+        ///  the user doing the import. 
+        /// </summary>
+        public int UserId { get; set; } = -1;
     }
 
     /// <summary>

--- a/uSync.BackOffice/Services/uSyncService_Single.cs
+++ b/uSync.BackOffice/Services/uSyncService_Single.cs
@@ -242,7 +242,8 @@ namespace uSync.BackOffice
             {
                 using (var pause = _mutexService.ImportPause(options.PauseDuringImport))
                 {
-                    SyncHandlerOptions syncHandlerOptions = new SyncHandlerOptions(options.HandlerSet);
+                    SyncHandlerOptions syncHandlerOptions = new SyncHandlerOptions(
+                        options.HandlerSet, options.UserId);
 
                     var cleans = actions
                         .Where(x => x.Change == ChangeType.Clean && !string.IsNullOrWhiteSpace(x.FileName))
@@ -274,7 +275,7 @@ namespace uSync.BackOffice
         }
 
         private SyncHandlerOptions HandlerOptionsFromPaged(uSyncPagedImportOptions options)
-            => new SyncHandlerOptions(options.HandlerSet)
+            => new SyncHandlerOptions(options.HandlerSet, options.UserId)
             {
                 IncludeDisabled = options.IncludeDisabledHandlers
             };

--- a/uSync.BackOffice/SyncHandlers/Models/SyncHandlerOptions.cs
+++ b/uSync.BackOffice/SyncHandlers/Models/SyncHandlerOptions.cs
@@ -28,7 +28,12 @@ namespace uSync.BackOffice.SyncHandlers
         /// <summary>
         ///  include handlers that are by default disabled 
         /// </summary>
-        public bool IncludeDisabled { get; set; } = false; 
+        public bool IncludeDisabled { get; set; } = false;
+
+        /// <summary>
+        ///  the user id doing all the work.
+        /// </summary>
+        public int UserId { get; set; } = -1;
 
         /// <summary>
         /// Default constructor
@@ -44,14 +49,26 @@ namespace uSync.BackOffice.SyncHandlers
             this.Set = setName;
         }
 
+        public SyncHandlerOptions(string setName, int userId)
+            :this(setName)
+        {
+            this.UserId = userId;
+        }
+
         /// <summary>
         /// Construct options with set and handler action set.
         /// </summary>
         public SyncHandlerOptions(string setName, HandlerActions action)
-            : this()
+            : this(setName)
         {
             this.Set = setName;
             this.Action = action;
+        }
+
+        public SyncHandlerOptions(string setName, HandlerActions action, int userId)
+            : this(setName, action)
+        {
+            this.UserId = userId;
         }
     }
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -414,7 +414,7 @@ namespace uSync.BackOffice.SyncHandlers
             try
             {
                 // merge the options from the handler and any import options into our serializer options.
-                var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings);
+                var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings, options.UserId);
                 serializerOptions.MergeSettings(options.Settings);
 
                 // get the item.
@@ -522,7 +522,7 @@ namespace uSync.BackOffice.SyncHandlers
                 if (item == null) return Enumerable.Empty<uSyncAction>();
 
                 // merge the options from the handler and any import options into our serializer options.
-                var serializerOptions = new SyncSerializerOptions(options?.Flags ?? SerializerFlags.None, settings.Settings);
+                var serializerOptions = new SyncSerializerOptions(options?.Flags ?? SerializerFlags.None, settings.Settings, options?.UserId ?? -1);
                 serializerOptions.MergeSettings(options?.Settings);
 
                 // do the second pass on this item
@@ -1078,7 +1078,7 @@ namespace uSync.BackOffice.SyncHandlers
                 var actions = new List<uSyncAction>();
 
                 // get the serializer options
-                var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings);
+                var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings, options.UserId);
                 serializerOptions.MergeSettings(options.Settings);
 
                 // check if this item is current (the provided XML and exported XML match)

--- a/uSync.Core/CompatibilitySuppressions.xml
+++ b/uSync.Core/CompatibilitySuppressions.xml
@@ -1,10 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-	<!-- DI Constructor for ImagePathMapper now included GlobalSettings-->
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:uSync.Core.Mapping.ImagePathMapper.#ctor(Microsoft.Extensions.Configuration.IConfiguration,Umbraco.Cms.Core.Services.IEntityService,Microsoft.Extensions.Logging.ILogger{uSync.Core.Mapping.ImagePathMapper})</Target>
+    <Left>lib/net7.0/uSync.Core.dll</Left>
+    <Right>lib/net7.0/uSync.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:uSync.Core.Serialization.Serializers.ContentSerializer.#ctor(Umbraco.Cms.Core.Services.IEntityService,Umbraco.Cms.Core.Services.ILocalizationService,Umbraco.Cms.Core.Services.IRelationService,Umbraco.Cms.Core.Strings.IShortStringHelper,Microsoft.Extensions.Logging.ILogger{uSync.Core.Serialization.Serializers.ContentSerializer},Umbraco.Cms.Core.Services.IContentService,Umbraco.Cms.Core.Services.IFileService,uSync.Core.Mapping.SyncValueMapperCollection)</Target>
+    <Left>lib/net7.0/uSync.Core.dll</Left>
+    <Right>lib/net7.0/uSync.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:uSync.Core.Serialization.Serializers.ContentSerializer.PublishItem(Umbraco.Cms.Core.Models.IContent)</Target>
+    <Left>lib/net7.0/uSync.Core.dll</Left>
+    <Right>lib/net7.0/uSync.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:uSync.Core.Serialization.Serializers.ContentTemplateSerializer.#ctor(Umbraco.Cms.Core.Services.IEntityService,Umbraco.Cms.Core.Services.ILocalizationService,Umbraco.Cms.Core.Services.IRelationService,Umbraco.Cms.Core.Strings.IShortStringHelper,Microsoft.Extensions.Logging.ILogger{uSync.Core.Serialization.Serializers.ContentTemplateSerializer},Umbraco.Cms.Core.Services.IContentService,Umbraco.Cms.Core.Services.IFileService,Umbraco.Cms.Core.Services.IContentTypeService,uSync.Core.Mapping.SyncValueMapperCollection)</Target>
     <Left>lib/net7.0/uSync.Core.dll</Left>
     <Right>lib/net7.0/uSync.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/uSync.Core/Extensions/DictionaryExtensions.cs
+++ b/uSync.Core/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Umbraco.Cms.Core.Models.Membership;
+
+namespace uSync.Core.Extensions;
+internal static class DictionaryExtensions
+{
+    /// <summary>
+    ///  get the username
+    /// </summary>
+    /// <param name="usernames"></param>
+    /// <param name="id"></param>
+    /// <param name="findMethod"></param>
+    /// <returns></returns>
+
+    public static string GetUsername(this Dictionary<int, string> usernames, int? id, Func<int, IUser> findMethod)
+    {
+        if (usernames == null || id == null) return "unknown";
+
+        usernames[id.Value] = usernames.ContainsKey(id.Value)
+            ? usernames[id.Value]
+            : findMethod(id.Value)?.Email ?? "unknown";
+
+        return usernames[id.Value];
+    }
+
+    public static int GetEmails(this Dictionary<string, int> emails, string email, Func<string, IUser> findMethod)
+    {
+        if (emails == null || string.IsNullOrEmpty(email)) return -1;
+
+        emails[email] = emails.ContainsKey(email)
+            ? emails[email]
+            : findMethod(email)?.Id ?? -1;
+
+        return emails[email];
+    }
+}

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -69,7 +69,7 @@ namespace uSync.Core.Serialization.Serializers
             info.Add(SerializeSchedule(item, options));
             info.Add(SerializeTemplate(item, options));
 
-            if (options.GetSetting<bool>("IncludeUserInfo", true))
+            if (options.GetSetting<bool>("IncludeUserInfo", false))
             {
                 info.Add(SerializerWriterInfo(item, options));
             }

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -30,8 +30,9 @@ namespace uSync.Core.Serialization.Serializers
             IContentService contentService,
             IFileService fileService,
             IContentTypeService contentTypeService,
-            SyncValueMapperCollection syncMappers)
-            : base(entityService, localizationService, relationService, shortStringHelper, logger, contentService, fileService, syncMappers)
+            SyncValueMapperCollection syncMappers,
+            IUserService userService)
+            : base(entityService, localizationService, relationService, shortStringHelper, logger, contentService, fileService, syncMappers, userService)
         {
             _contentTypeService = contentTypeService;
             this.umbracoObjectType = UmbracoObjectTypes.DocumentBlueprint;
@@ -143,7 +144,7 @@ namespace uSync.Core.Serialization.Serializers
 
         protected override Attempt<string> DoSaveOrPublish(IContent item, XElement node, SyncSerializerOptions options)
         {
-            contentService.SaveBlueprint(item);
+            contentService.SaveBlueprint(item, options.UserId);
             return Attempt.Succeed<string>("blueprint saved");
         }
 

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -11,6 +11,9 @@ namespace uSync.Core.Serialization
     /// </summary>
     public class SyncSerializerOptions
     {
+        // the user who is doing the serialization 
+        public int UserId = -1;
+
         public SyncSerializerOptions() { }
 
         public SyncSerializerOptions(SerializerFlags flags)

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
 
+using Org.BouncyCastle.Bcpg.Sig;
+
 using Umbraco.Extensions;
 
 namespace uSync.Core.Serialization
@@ -31,6 +33,12 @@ namespace uSync.Core.Serialization
             : this(settings)
         {
             this.Flags = flags;
+        }
+
+        public SyncSerializerOptions(SerializerFlags flags, Dictionary<string, string> settings, int userId)
+            : this(flags, settings)
+        {
+            UserId = userId;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds the ability for us to serialize and deserialize the creator, writer and publisher of a peice of content. 
it also adds the ability for the user to be passed in the uSyncImportOptions so the user can be set on a remote call. 

1. let you preserve user information between syncs if you want to (and the users exist)
2. Let uSync.Complete push the user who is making changes from one site to another. 

Additional Setting to turn this on in uSync: 

```json
"ContemtHandler": {
  "Settings": {
    "IncludeUserInfo": true
  }
},
```

