### PR TITLE
Update the logic for repetable strings.

### DIFF
--- a/uSync.Core/Mapping/Mappers/RepeatableValueMapper.cs
+++ b/uSync.Core/Mapping/Mappers/RepeatableValueMapper.cs
@@ -1,5 +1,8 @@
-﻿using Umbraco.Cms.Core;
+﻿using Newtonsoft.Json;
+
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace uSync.Core.Mapping
 {
@@ -14,12 +17,26 @@ namespace uSync.Core.Mapping
 
         public override string Name => "Repeatable Text Mapper";
 
-        public override string[] Editors => new string[] { 
+        public override string[] Editors => new string[] {
             Constants.PropertyEditors.Aliases.MultipleTextstring
         };
 
         public override string GetImportValue(string value, string editorAlias)
         {
+            if (value.DetectIsJson())
+            {
+                try
+                {
+                    var result = JsonConvert.SerializeObject(JsonConvert.DeserializeObject<object>(value));
+                    return result;
+                }
+                catch
+                {
+                    return value;
+                }
+            }
+
+
             if (!value.Contains('\r'))
             {
                 return value.Replace("\n", "\r\n");

--- a/uSync.Core/Mapping/SyncNestedValueMapperBase.cs
+++ b/uSync.Core/Mapping/SyncNestedValueMapperBase.cs
@@ -52,7 +52,8 @@ namespace uSync.Core.Mapping
                     if (value != null)
                     {
                         var mappedVal = mapperCollection.Value.GetImportValue(value.ToString(), property.PropertyEditorAlias);
-                        item[property.Alias] = mappedVal?.ToString() ?? null; // .GetJsonTokenValue();
+                        item[property.Alias] = // mappedVal?.ToString() ?? null;
+                                               mappedVal?.ToString().GetJsonTokenValue() ?? null;
                     }
                 }
             }


### PR DESCRIPTION
Fixes logic for when a repeatable string is 
  "inside a nested content item - inside a nested content item - inside a doctype grid editor - inside a Grid."

- this does change how we seariaze nested content slightly (it returns the JToken to the upper level not an object of string).

## Testing required before merge!!!

I *think* we returned a string here because a) it worked and b) it might have had a knock on effect to Block List or Contentment Blocks. - so before release we will need to confirm they don't get effected , although i think they now have override methods in place so don't use this base method for the final extraction of their string. 