### PR TITLE
listen for ContainerRename events

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentTypeHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentTypeHandler.cs
@@ -28,7 +28,8 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         INotificationHandler<SavedNotification<IContentType>>,
         INotificationHandler<DeletedNotification<IContentType>>,
         INotificationHandler<MovedNotification<IContentType>>,
-        INotificationHandler<EntityContainerSavedNotification>
+        INotificationHandler<EntityContainerSavedNotification>,
+        INotificationHandler<EntityContainerRenamedNotification>
     {
         private readonly IContentTypeService contentTypeService;
 

--- a/uSync.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
@@ -31,7 +31,8 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         INotificationHandler<SavedNotification<IDataType>>,
         INotificationHandler<MovedNotification<IDataType>>,
         INotificationHandler<DeletedNotification<IDataType>>,
-        INotificationHandler<EntityContainerSavedNotification>
+        INotificationHandler<EntityContainerSavedNotification>,
+        INotificationHandler<EntityContainerRenamedNotification>
     {
         private readonly IDataTypeService dataTypeService;
 

--- a/uSync.BackOffice/SyncHandlers/Handlers/MediaTypeHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/MediaTypeHandler.cs
@@ -28,7 +28,8 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         INotificationHandler<SavedNotification<IMediaType>>,
         INotificationHandler<DeletedNotification<IMediaType>>,
         INotificationHandler<MovedNotification<IMediaType>>,
-        INotificationHandler<EntityContainerSavedNotification>
+        INotificationHandler<EntityContainerSavedNotification>,        
+        INotificationHandler<EntityContainerRenamedNotification>
     // INotificationHandler<MediaTypeSavedNotification>
     {
         private readonly IMediaTypeService mediaTypeService;

--- a/uSync.BackOffice/SyncHandlers/Handlers/MemberTypeHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/MemberTypeHandler.cs
@@ -27,7 +27,9 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
     public class MemberTypeHandler : SyncHandlerContainerBase<IMemberType, IMemberTypeService>, ISyncHandler,
         INotificationHandler<SavedNotification<IMemberType>>,
         INotificationHandler<MovedNotification<IMemberType>>,
-        INotificationHandler<DeletedNotification<IMemberType>>
+        INotificationHandler<DeletedNotification<IMemberType>>,
+        INotificationHandler<EntityContainerSavedNotification>,
+        INotificationHandler<EntityContainerRenamedNotification>
     {
         private readonly IMemberTypeService memberTypeService;
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -144,7 +144,18 @@ namespace uSync.BackOffice.SyncHandlers
         {
             if (_mutexService.IsPaused) return;
 
-            foreach (var folder in notification.SavedEntities)
+            ProcessContainerChanges(notification.SavedEntities);
+        }
+
+        public virtual void Handle(EntityContainerRenamedNotification notification)
+        {
+            if (_mutexService.IsPaused) return;
+            ProcessContainerChanges(notification.Entities);
+        }
+
+        private void ProcessContainerChanges(IEnumerable<EntityContainer> containers)
+        {
+            foreach (var folder in containers)
             {
                 if (folder.ContainedObjectType == this.itemObjectType.GetGuid())
                 {

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -127,20 +127,25 @@ namespace uSync.BackOffice
             builder.AddNotificationHandler<DataTypeDeletedNotification, DataTypeHandler>();
             builder.AddNotificationHandler<DataTypeMovedNotification, DataTypeHandler>();
             builder.AddNotificationHandler<EntityContainerSavedNotification, DataTypeHandler>();
+            builder.AddNotificationHandler<EntityContainerRenamedNotification, DataTypeHandler>();
 
             builder.AddNotificationHandler<ContentTypeSavedNotification, ContentTypeHandler>();
             builder.AddNotificationHandler<ContentTypeDeletedNotification, ContentTypeHandler>();
             builder.AddNotificationHandler<ContentTypeMovedNotification, ContentTypeHandler>();
             builder.AddNotificationHandler<EntityContainerSavedNotification, ContentTypeHandler>();
+            builder.AddNotificationHandler<EntityContainerRenamedNotification, ContentTypeHandler>();
 
             builder.AddNotificationHandler<MediaTypeSavedNotification, MediaTypeHandler>();
             builder.AddNotificationHandler<MediaTypeDeletedNotification, MediaTypeHandler>();
             builder.AddNotificationHandler<MediaTypeMovedNotification, MediaTypeHandler>();
             builder.AddNotificationHandler<EntityContainerSavedNotification, MediaTypeHandler>();
+            builder.AddNotificationHandler<EntityContainerRenamedNotification, MediaTypeHandler>();
 
             builder.AddNotificationHandler<MemberTypeSavedNotification, MemberTypeHandler>();
             builder.AddNotificationHandler<MemberTypeSavedNotification, MemberTypeHandler>();
             builder.AddNotificationHandler<MemberTypeMovedNotification, MemberTypeHandler>();
+            builder.AddNotificationHandler<EntityContainerSavedNotification, MemberTypeHandler>();
+            builder.AddNotificationHandler<EntityContainerRenamedNotification, MemberTypeHandler>();
 
             builder.AddNotificationHandler<LanguageSavingNotification, LanguageHandler>();
             builder.AddNotificationHandler<LanguageSavedNotification, LanguageHandler>();


### PR DESCRIPTION
As per #523 we have to listed for rename events because save events don't fire.