### PR TITLE
#527 - Ignore sort order setting

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -186,9 +186,12 @@ namespace uSync.Core.Serialization.Serializers
 
             details.AddRange(propertiesAttempt.Result);
 
-            // sort order
-            var sortOrder = node.Element("Info").Element("SortOrder").ValueOrDefault(-1);
-            details.AddNotNull(HandleSortOrder(item, sortOrder));
+            if (!options.GetSetting<bool>("IgnoreSortOrder", false))
+            {
+                // sort order
+                var sortOrder = node.Element("Info").Element("SortOrder").ValueOrDefault(-1);
+                details.AddNotNull(HandleSortOrder(item, sortOrder));
+            }
 
             var publishTimer = Stopwatch.StartNew();
 

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -169,7 +169,10 @@ namespace uSync.Core.Serialization.Serializers
             }
             info.Add(title);
 
-            info.Add(new XElement(uSyncConstants.Xml.SortOrder, item.SortOrder));
+            if (!options.GetSetting<bool>("IgnoreSortOrder", false))
+            {
+                info.Add(new XElement(uSyncConstants.Xml.SortOrder, item.SortOrder));
+            }
 
             return info;
         }

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -74,8 +74,11 @@ namespace uSync.Core.Serialization.Serializers
 
             var info = node.Element("Info");
 
-            var sortOrder = info.Element("SortOrder").ValueOrDefault(-1);
-            HandleSortOrder(item, sortOrder);
+            if (!options.GetSetting<bool>("IgnoreSortOrder", false))
+            {
+                var sortOrder = info.Element("SortOrder").ValueOrDefault(-1);
+                HandleSortOrder(item, sortOrder);
+            }
 
 
             if (details.HasWarning() && options.FailOnWarnings())


### PR DESCRIPTION
Adds option to ignore the sort order (in content and media) .

```json
"uSync": {
    "Sets": {
        "Default": {
            "HandlerDefaults": {
                "Settings": {
                      "IgnoreSortOrder": true
                }
            },
        }
    }
}
```