### PR TITLE
V12/generic hub

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -96,6 +96,7 @@ namespace uSync.BackOffice.Configuration
         /// location of SignalR hub script
         /// </summary>
         [DefaultValue("")]
+        [Obsolete("Will remove the option to move the route in v13")]
         public string SignalRRoot { get; set; } = string.Empty;
 
         /// <summary>

--- a/uSync.BackOffice/Hubs/uSyncHubRoutes.cs
+++ b/uSync.BackOffice/Hubs/uSyncHubRoutes.cs
@@ -15,7 +15,7 @@ using uSync.BackOffice.Configuration;
 namespace uSync.BackOffice.Hubs
 {
     /// <summary>
-    /// Handles SignlarR routes for uSync
+    /// Handles SignalR routes for uSync
     /// </summary>
     public class uSyncHubRoutes : IAreaRoutes
     {
@@ -33,6 +33,7 @@ namespace uSync.BackOffice.Hubs
         {
             _runtimeState = runtimeState;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (!string.IsNullOrWhiteSpace(uSyncSettings.Value?.SignalRRoot))
             {
                 _umbracoPathSegment = uSyncSettings.Value.SignalRRoot;
@@ -41,6 +42,7 @@ namespace uSync.BackOffice.Hubs
             {
                 _umbracoPathSegment = globalSettings.Value.GetUmbracoMvcArea(hostingEnvironment);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/usync.hub.js
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/usync.hub.js
@@ -18,6 +18,10 @@
         //////////////
 
         function initHub(callback) {
+            initializeHub(Umbraco.Sys.ServerVariables.uSync.signalRHub, callback);
+        }
+
+        function initializeHub(url, callback) { 
 
             callbacks.push(callback);
 
@@ -34,7 +38,7 @@
                         .then(function () {
                             while (callbacks.length) {
                                 var cb = callbacks.pop();
-                                hubSetup(cb);
+                                hubSetup(url, cb);
                             }
                             starting = false;
                         });
@@ -42,17 +46,17 @@
                 else {
                     while (callbacks.length) {
                         var cb = callbacks.pop();
-                        hubSetup(cb);
+                        hubSetup(url, cb);
                     }
                     starting = false;
                 }
             }
         }
 
-        function hubSetup(callback) {
+        function hubSetup(url, callback) {
 
             $.connection = new signalR.HubConnectionBuilder()
-                .withUrl(Umbraco.Sys.ServerVariables.uSync.signalRHub)
+                .withUrl(url)
                 .withAutomaticReconnect()
                 .configureLogging(signalR.LogLevel.Warning)
                 .build();


### PR DESCRIPTION
Makes SignalR hub in core uSync generic, meaning same code can be used to listen on different hub end points. 