### PR TITLE
Readme said Eleven instead of Twelve

### DIFF
--- a/uSync/readme.txt
+++ b/uSync/readme.txt
@@ -5,7 +5,7 @@
                 \__,_/____/\__, /_/ /_/\___/  
                           /____/  v12.x            
 
-   Thanks for Installing uSync Eleven, 
+   Thanks for Installing uSync Twelve, 
    
    All the bits of your Umbraco settings and content will now be saved to disk.
 


### PR DESCRIPTION
I had just installed this on a v12 site and it greeted me with Eleven (was that a Stranger Things joke? 😅).