### PR TITLE
V12/block grid independence

### DIFF
--- a/uSync.Core/Extensions/JsonExtensions.cs
+++ b/uSync.Core/Extensions/JsonExtensions.cs
@@ -115,7 +115,8 @@ namespace uSync.Core
         public static JToken GetJTokenFromObject(this object value)
         {
             var stringValue = value.GetValueAs<string>();
-            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson()) return null;
+            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson())
+                return stringValue;
 
             try
             {
@@ -128,7 +129,7 @@ namespace uSync.Core
             }
         }
 
-        private static TObject GetValueAs<TObject>(this object value)
+        public static TObject GetValueAs<TObject>(this object value)
         {
             if (value == null) return default;
             var attempt = value.TryConvertTo<TObject>();

--- a/uSync.Core/Mapping/Mappers/BlockListMapper.cs
+++ b/uSync.Core/Mapping/Mappers/BlockListMapper.cs
@@ -54,6 +54,13 @@ namespace uSync.Core.Mapping
             return b;
         }
 
+
+        protected override JToken GetExportProperty(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || !value.DetectIsJson()) return value;
+            return value.GetJsonTokenValue();
+        }
+
         protected override string ProcessValues(JToken jsonValue, string editorAlias, Func<JObject, IContentType, JObject> GetPropertiesMethod)
         {
             if (jsonValue is JObject jObjectValue)

--- a/uSync.Core/Mapping/Mappers/BlockListMapper.cs
+++ b/uSync.Core/Mapping/Mappers/BlockListMapper.cs
@@ -7,8 +7,8 @@ using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
-using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 using uSync.Core.Dependency;
 
@@ -36,6 +36,23 @@ namespace uSync.Core.Mapping
             Constants.PropertyEditors.Aliases.BlockList,
             "Umbraco.BlockGrid"
         };
+
+        protected override JToken GetImportProperty(object value)
+        {
+            if (value == null) return null;
+
+            var stringValue = value.GetValueAs<string>();
+            if (stringValue == null || !stringValue.DetectIsJson())
+                return stringValue;
+
+            // we have to get the json, the serialize the json,
+            // this is to make sure we don't serizlize any formatting
+            // (like indented formatting). because that would 
+            // register changes that are not there.
+            var b = JsonConvert.SerializeObject(value.GetJTokenFromObject(), Formatting.None);
+
+            return b;
+        }
 
         protected override string ProcessValues(JToken jsonValue, string editorAlias, Func<JObject, IContentType, JObject> GetPropertiesMethod)
         {


### PR DESCRIPTION
Investigating: #538

Change how we serialize information *back info* umbraco for block lists.

note: The current way "works" but deploy doesn't like it (do we cares what deploy likes 😉 ) 

current we serialize the Json in and out as Json all the way down a blocklist. This makes it look nice, and it's easier to track changes, and source code commits, and Umbraco works with this being stuck back into the db. 

but technically, block list child values are escaped Json in the DB. this is probibly more efficient 😛 - but it makes for hard to decipher text. 

This update now puts the values into the DB in their ugly form. 
but it forces the uSync file format to be nice Json, so we keep our nice diff/source control. 

The main thing here is separating Blocklist a bit more from the way Nested Content does things, I was going to completely separate it, but in reality, two new abstract methods `GetImportProperty` and `GetExportProperty` are enough as they give us the granular control over what we do with a value once it's been mapped. 





