### PR TITLE
Fix issue with block lists and values that start with { or [ and end with ] or }, but aren't JSON

### DIFF
--- a/uSync.Core/Mapping/Mappers/BlockListMapper.cs
+++ b/uSync.Core/Mapping/Mappers/BlockListMapper.cs
@@ -45,11 +45,16 @@ namespace uSync.Core.Mapping
             if (stringValue == null || !stringValue.DetectIsJson())
                 return stringValue;
 
+            var jsonObject = value.GetJTokenFromObject();
+
+            if (jsonObject == null)
+                return stringValue;
+
             // we have to get the json, the serialize the json,
             // this is to make sure we don't serizlize any formatting
             // (like indented formatting). because that would 
             // register changes that are not there.
-            var b = JsonConvert.SerializeObject(value.GetJTokenFromObject(), Formatting.None);
+            var b = JsonConvert.SerializeObject(jsonObject, Formatting.None);
 
             return b;
         }


### PR DESCRIPTION
After upgrading to 12.2 on our staging environment, we were having problems with uSync losing the values of some properties in block lists and replacing them with a string that says "null" (i.e the actual word, not a null value - the string would be shown in the textbox in the Umbraco back office).

I've looked through the recent changes, and I think it's because in the block list, when a value is imported it uses Umbraco's "DetectIsJson" method (which detects many other things as well as Json), and if that is true, then the value will always be read as JSON and then serialised - if it's invalid because it isn't JSON, that means it comes back as a string saying "null".

I'm suggesting the attached change, unless you can see any issues? It seems to work in my case, which is that we have values like:
{{Name}}

Happy if you have a better fix, just what I could come up with!