### PR TITLE
Use IsValidJsonString, inplace of DetectIsJson - more reliable.

### DIFF
--- a/uSync.Community.Contrib/Mappers/ContentmentContentBlocks.cs
+++ b/uSync.Community.Contrib/Mappers/ContentmentContentBlocks.cs
@@ -55,11 +55,12 @@ namespace uSync.Community.Contrib.Mappers
         public override IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
         {
             var stringValue = GetValueAs<string>(value);
-            if (stringValue.IsValidJsonString() is false)
+
+            if (stringValue.TryParseValidJsonString(out JArray elements) is false)
                 return Enumerable.Empty<uSyncDependency>();
 
-            var elements = JsonConvert.DeserializeObject<JArray>(stringValue);
-            if (elements == null || !elements.Any()) return Enumerable.Empty<uSyncDependency>();
+            if (elements == null || !elements.Any())
+                return Enumerable.Empty<uSyncDependency>();
 
             var dependencies = new List<uSyncDependency>();
 

--- a/uSync.Community.Contrib/Mappers/ContentmentContentBlocks.cs
+++ b/uSync.Community.Contrib/Mappers/ContentmentContentBlocks.cs
@@ -7,8 +7,8 @@ using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
+using uSync.Core;
 using uSync.Core.Dependency;
 using uSync.Core.Mapping;
 
@@ -55,7 +55,8 @@ namespace uSync.Community.Contrib.Mappers
         public override IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
         {
             var stringValue = GetValueAs<string>(value);
-            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson()) return Enumerable.Empty<uSyncDependency>();
+            if (stringValue.IsValidJsonString() is false)
+                return Enumerable.Empty<uSyncDependency>();
 
             var elements = JsonConvert.DeserializeObject<JArray>(stringValue);
             if (elements == null || !elements.Any()) return Enumerable.Empty<uSyncDependency>();

--- a/uSync.Core/Extensions/JsonExtensions.cs
+++ b/uSync.Core/Extensions/JsonExtensions.cs
@@ -1,5 +1,6 @@
 ﻿
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Net.Http.Headers;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -127,6 +128,34 @@ namespace uSync.Core
                 return false; 
             }
         }
+        
+        public static bool TryParseValidJsonString(this string value, out JToken token)
+            => TryParseValidJsonString<JToken>(value, out token);
+       
+        /// <summary>
+        ///  parse a value and return the JSON - only if it's valid JSON 
+        /// </summary>
+        /// <remarks>
+        ///  this value will return false for strings that don't look like json strings (e.g "hello" is false) 
+        /// </remarks>
+        public static bool TryParseValidJsonString<TResult>(this string value, out TResult result)
+            where TResult : JToken
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(value) || !value.DetectIsJson())
+                return false;
+
+            try
+            {
+                result = JsonConvert.DeserializeObject<TResult>(value);
+                return true;
+            }
+            catch
+            {
+                return false; 
+            }
+        }
+
 
 
         public static JToken GetJTokenFromObject(this object value)

--- a/uSync.Core/Extensions/JsonExtensions.cs
+++ b/uSync.Core/Extensions/JsonExtensions.cs
@@ -111,6 +111,23 @@ namespace uSync.Core
             return stringValue.GetJsonTokenValue();
         }
 
+        public static bool IsValidJsonString(this string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || !value.DetectIsJson())
+                return false; 
+
+            // umbraco thinks it's json, but is it ? 
+
+            try
+            {
+                JToken.Parse(value);
+                return true;
+            }
+            catch {
+                return false; 
+            }
+        }
+
 
         public static JToken GetJTokenFromObject(this object value)
         {

--- a/uSync.Core/Mapping/Mappers/BlockListMapper.cs
+++ b/uSync.Core/Mapping/Mappers/BlockListMapper.cs
@@ -8,7 +8,6 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Extensions;
 
 using uSync.Core.Dependency;
 
@@ -42,22 +41,20 @@ namespace uSync.Core.Mapping
             if (value == null) return null;
 
             var stringValue = value.GetValueAs<string>();
-            if (stringValue == null || !stringValue.DetectIsJson())
+            if (stringValue.IsValidJsonString() is false)
                 return stringValue;
 
             // we have to get the json, the serialize the json,
             // this is to make sure we don't serizlize any formatting
             // (like indented formatting). because that would 
             // register changes that are not there.
-            var b = JsonConvert.SerializeObject(value.GetJTokenFromObject(), Formatting.None);
-
-            return b;
+            return JsonConvert.SerializeObject(value.GetJTokenFromObject(), Formatting.None);
         }
 
 
         protected override JToken GetExportProperty(string value)
         {
-            if (string.IsNullOrWhiteSpace(value) || !value.DetectIsJson()) return value;
+            if (!value.IsValidJsonString()) return value;
             return value.GetJsonTokenValue();
         }
 

--- a/uSync.Core/Mapping/Mappers/BlockListMapper.cs
+++ b/uSync.Core/Mapping/Mappers/BlockListMapper.cs
@@ -39,24 +39,21 @@ namespace uSync.Core.Mapping
         protected override JToken GetImportProperty(object value)
         {
             if (value == null) return null;
-
             var stringValue = value.GetValueAs<string>();
-            if (stringValue.IsValidJsonString() is false)
+          
+            if (stringValue.TryParseValidJsonString(out JToken tokenValue) is false)
                 return stringValue;
 
             // we have to get the json, the serialize the json,
             // this is to make sure we don't serizlize any formatting
             // (like indented formatting). because that would 
             // register changes that are not there.
-            return JsonConvert.SerializeObject(value.GetJTokenFromObject(), Formatting.None);
+            return JsonConvert.SerializeObject(tokenValue, Formatting.None);
         }
 
 
         protected override JToken GetExportProperty(string value)
-        {
-            if (!value.IsValidJsonString()) return value;
-            return value.GetJsonTokenValue();
-        }
+            => value.TryParseValidJsonString(out JToken tokenValue) is true ? tokenValue : value;
 
         protected override string ProcessValues(JToken jsonValue, string editorAlias, Func<JObject, IContentType, JObject> GetPropertiesMethod)
         {

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -74,30 +74,26 @@ namespace uSync.Core.Mapping
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
 
-            if (stringValue.DetectIsJson())
-            {
-                // json, 
-                var json = JsonConvert.DeserializeObject<JObject>(stringValue);
-                if (json != null)
-                {
-                    var source = json.Value<string>("src");
-                    if (!string.IsNullOrWhiteSpace(source))
-                    {
-                        // strip any virtual directory stuff from it.
-                        json["src"] = StripSitePath(source);
-                        return JsonConvert.SerializeObject(json);
-                    }
-                }
+            if (stringValue.IsValidJsonString() is false)
+                return StripSitePath(stringValue);
 
-                // we always reserialize if we can, because you can get inconsitancies, 
-                // and spaces in the json (especially from the starterkit)
-                // this just ensures it looks the same across sites (where possible).
-                return JsonConvert.SerializeObject(json, Formatting.Indented);
+            // json, 
+            var json = JsonConvert.DeserializeObject<JObject>(stringValue);
+            if (json != null)
+            {
+                var source = json.Value<string>("src");
+                if (!string.IsNullOrWhiteSpace(source))
+                {
+                    // strip any virtual directory stuff from it.
+                    json["src"] = StripSitePath(source);
+                    return JsonConvert.SerializeObject(json);
+                }
             }
 
-
-            // else .
-            return StripSitePath(stringValue);
+            // we always reserialize if we can, because you can get inconsitancies, 
+            // and spaces in the json (especially from the starterkit)
+            // this just ensures it looks the same across sites (where possible).
+            return JsonConvert.SerializeObject(json, Formatting.Indented);
         }
 
         private string StripSitePath(string filepath)
@@ -177,7 +173,7 @@ namespace uSync.Core.Mapping
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
 
-            if (stringValue.DetectIsJson())
+            if (stringValue.IsValidJsonString())
             {
                 // json, 
                 var json = JsonConvert.DeserializeObject<JObject>(stringValue);
@@ -228,7 +224,7 @@ namespace uSync.Core.Mapping
 
         private string GetImagePath(string stringValue)
         {
-            if (stringValue.DetectIsJson())
+            if (stringValue.IsValidJsonString())
             {
                 // json, 
                 var json = JsonConvert.DeserializeObject<JObject>(stringValue);

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -74,11 +74,10 @@ namespace uSync.Core.Mapping
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
 
-            if (stringValue.IsValidJsonString() is false)
+            if (stringValue.TryParseValidJsonString<JObject>(out JObject json) is false)
                 return StripSitePath(stringValue);
 
             // json, 
-            var json = JsonConvert.DeserializeObject<JObject>(stringValue);
             if (json != null)
             {
                 var source = json.Value<string>("src");
@@ -171,26 +170,17 @@ namespace uSync.Core.Mapping
         public override string GetImportValue(string value, string editorAlias)
         {
             var stringValue = value?.ToString();
-            if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
+            if (string.IsNullOrWhiteSpace(stringValue) is true) return stringValue;
 
-            if (stringValue.IsValidJsonString())
-            {
-                // json, 
-                var json = JsonConvert.DeserializeObject<JObject>(stringValue);
-                if (json != null)
-                {
-                    var source = json.Value<string>("src");
-                    if (!string.IsNullOrWhiteSpace(source))
-                    {
-                        // strip any virtual directory stuff from it.
-                        json["src"] = PrePendSitePath(source);
-                        return JsonConvert.SerializeObject(json);
-                    }
-                }
-            }
-            else
-            {
+            if (stringValue.TryParseValidJsonString(out JObject json) is false)
                 return PrePendSitePath(stringValue);
+
+            var source = json.Value<string>("src");
+            if (string.IsNullOrWhiteSpace(source) is false)
+            {
+                // strip any virtual directory stuff from it.
+                json["src"] = PrePendSitePath(source);
+                return JsonConvert.SerializeObject(json);
             }
 
             return stringValue;
@@ -224,15 +214,10 @@ namespace uSync.Core.Mapping
 
         private string GetImagePath(string stringValue)
         {
-            if (stringValue.IsValidJsonString())
+            if (stringValue.TryParseValidJsonString(out JObject json))
             {
-                // json, 
-                var json = JsonConvert.DeserializeObject<JObject>(stringValue);
-                if (json != null)
-                {
-                    var source = json.Value<string>("src");
-                    if (!string.IsNullOrWhiteSpace(source)) return source;
-                }
+                var source = json.Value<string>("src");
+                if (string.IsNullOrWhiteSpace(source) is false) return source;
             }
             else
             {

--- a/uSync.Core/Mapping/Mappers/MacroMapper.cs
+++ b/uSync.Core/Mapping/Mappers/MacroMapper.cs
@@ -61,10 +61,8 @@ namespace uSync.Core.Mapping
 
         private MacroValue LoadMacroValue(string macroString)
         {
-            if (!macroString.DetectIsJson())
-            {
+            if (macroString.IsValidJsonString() is false)
                 return LoadFromMarkup(macroString);
-            }
 
             return JsonConvert.DeserializeObject<MacroValue>(macroString);
         }

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -30,9 +30,9 @@ namespace uSync.Core.Mapping.Mappers
         public override string GetExportValue(object value, string editorAlias)
         {
             var stringValue = value?.ToString();
-            if (string.IsNullOrEmpty(stringValue)) return null;
+            if (string.IsNullOrEmpty(stringValue) is true) return null;
 
-            if (!stringValue.DetectIsJson()) return stringValue;
+            if (stringValue.IsValidJsonString() is false) return stringValue;
 
             // re-formatting the json in the picker.
             // 
@@ -63,7 +63,7 @@ namespace uSync.Core.Mapping.Mappers
         {
             // validate string 
             var stringValue = value?.ToString();
-            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson())
+            if (!stringValue.IsValidJsonString())
                 return Enumerable.Empty<uSyncDependency>();
 
             // convert to an array. 

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -32,7 +32,8 @@ namespace uSync.Core.Mapping.Mappers
             var stringValue = value?.ToString();
             if (string.IsNullOrEmpty(stringValue) is true) return null;
 
-            if (stringValue.IsValidJsonString() is false) return stringValue;
+            if (stringValue.TryParseValidJsonString(out JArray json) is false)
+                return stringValue;
 
             // re-formatting the json in the picker.
             // 
@@ -45,17 +46,12 @@ namespace uSync.Core.Mapping.Mappers
 
             try
             {
-                var json = JsonConvert.DeserializeObject<JArray>(value.ToString());
-                if (json != null)
-                    return JsonConvert.SerializeObject(json, Formatting.Indented);
+                return JsonConvert.SerializeObject(json, Formatting.Indented);
             }
             catch
             {
                 return stringValue;
             }
-
-            return stringValue;
-
         }
             
 
@@ -63,11 +59,9 @@ namespace uSync.Core.Mapping.Mappers
         {
             // validate string 
             var stringValue = value?.ToString();
-            if (!stringValue.IsValidJsonString())
+            if (!stringValue.TryParseValidJsonString(out JArray images) is false)
                 return Enumerable.Empty<uSyncDependency>();
 
-            // convert to an array. 
-            var images = JsonConvert.DeserializeObject<JArray>(value.ToString());
             if (images == null || !images.Any())
                 return Enumerable.Empty<uSyncDependency>();
 

--- a/uSync.Core/Mapping/Mappers/NestedContentMapper.cs
+++ b/uSync.Core/Mapping/Mappers/NestedContentMapper.cs
@@ -55,10 +55,9 @@ namespace uSync.Core.Mapping
         public override IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
         {
             var stringValue = GetValueAs<string>(value);
-            if (stringValue.IsValidJsonString() is false)
+            if (stringValue.TryParseValidJsonString(out JArray nestedJson) is false)
                 return Enumerable.Empty<uSyncDependency>();
 
-            var nestedJson = JsonConvert.DeserializeObject<JArray>(stringValue);
             if (nestedJson == null || !nestedJson.Any())
                 return Enumerable.Empty<uSyncDependency>();
 

--- a/uSync.Core/Mapping/Mappers/NestedContentMapper.cs
+++ b/uSync.Core/Mapping/Mappers/NestedContentMapper.cs
@@ -55,7 +55,7 @@ namespace uSync.Core.Mapping
         public override IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
         {
             var stringValue = GetValueAs<string>(value);
-            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson())
+            if (stringValue.IsValidJsonString() is false)
                 return Enumerable.Empty<uSyncDependency>();
 
             var nestedJson = JsonConvert.DeserializeObject<JArray>(stringValue);

--- a/uSync.Core/Mapping/Mappers/RepeatableValueMapper.cs
+++ b/uSync.Core/Mapping/Mappers/RepeatableValueMapper.cs
@@ -23,7 +23,7 @@ namespace uSync.Core.Mapping
 
         public override string GetImportValue(string value, string editorAlias)
         {
-            if (value.DetectIsJson())
+            if (value.IsValidJsonString() is true)
             {
                 try
                 {

--- a/uSync.Core/Mapping/SyncValueMapperCollection.cs
+++ b/uSync.Core/Mapping/SyncValueMapperCollection.cs
@@ -88,12 +88,11 @@ namespace uSync.Core.Mapping
         /// </summary>
         private string GetCleanFlatJson(string stringValue)
         {
-            if (stringValue.IsValidJsonString() is false) 
+            if (stringValue.TryParseValidJsonString(out JToken result) is false) 
                 return stringValue;
-
             try
             {
-                return JsonConvert.SerializeObject(JsonConvert.DeserializeObject<JToken>(stringValue));
+                return JsonConvert.SerializeObject(result);
             }
             catch
             {

--- a/uSync.Core/Mapping/SyncValueMapperCollection.cs
+++ b/uSync.Core/Mapping/SyncValueMapperCollection.cs
@@ -88,7 +88,8 @@ namespace uSync.Core.Mapping
         /// </summary>
         private string GetCleanFlatJson(string stringValue)
         {
-            if (string.IsNullOrWhiteSpace(stringValue) || !stringValue.DetectIsJson()) return stringValue;
+            if (stringValue.IsValidJsonString() is false) 
+                return stringValue;
 
             try
             {

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -660,7 +660,7 @@ namespace uSync.Core.Serialization.Serializers
             // TODO: in a perfect world, this is the best answer, don't escape any buried JSON in anything
             // but there might be a couple of property value converters that don't like their nested JSON
             // to not be escaped so we would need to do proper testing. 
-            if (exportValue.DetectIsJson() && !exportValue.IsAngularExpression())
+            if (exportValue.IsValidJsonString() is true)
             {
                 var tokenValue = exportValue.GetJsonTokenValue().ExpandAllJsonInToken();
                 return JsonConvert.SerializeObject(tokenValue, Formatting.Indented);

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -8,6 +8,7 @@ using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
@@ -660,9 +661,8 @@ namespace uSync.Core.Serialization.Serializers
             // TODO: in a perfect world, this is the best answer, don't escape any buried JSON in anything
             // but there might be a couple of property value converters that don't like their nested JSON
             // to not be escaped so we would need to do proper testing. 
-            if (exportValue.IsValidJsonString() is true)
+            if (exportValue.TryParseValidJsonString(out JToken tokenValue) is true)
             {
-                var tokenValue = exportValue.GetJsonTokenValue().ExpandAllJsonInToken();
                 return JsonConvert.SerializeObject(tokenValue, Formatting.Indented);
             }
             logger.LogTrace("Export Value {PropertyEditorAlias} {exportValue}", propertyType.PropertyEditorAlias, exportValue);

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -90,7 +90,8 @@ namespace uSync.Core.Serialization.Serializers
             }
 
             var saveAttempt = _mediaService.Save(item);
-            if (!saveAttempt.Success) {
+            if (!saveAttempt.Success)
+            {
                 var errors = saveAttempt.Result?.EventMessages?.FormatMessages() ?? "";
                 return SyncAttempt<IMedia>.Fail(item.Name, item, ChangeType.Fail, errors, saveAttempt.Exception);
             }
@@ -194,19 +195,17 @@ namespace uSync.Core.Serialization.Serializers
 
         private string GetFilePath(string value)
         {
-            if (value.DetectIsJson())
+            if (value.IsValidJsonString() is false)
+                return value;
+
+            // image cropper.
+            var imageCrops = JsonConvert.DeserializeObject<ImageCropperValue>(value, new JsonSerializerSettings
             {
-                // image cropper.
-                var imageCrops = JsonConvert.DeserializeObject<ImageCropperValue>(value, new JsonSerializerSettings
-                {
-                    Culture = CultureInfo.InvariantCulture,
-                    FloatParseHandling = FloatParseHandling.Decimal
-                });
+                Culture = CultureInfo.InvariantCulture,
+                FloatParseHandling = FloatParseHandling.Decimal
+            });
 
-                return imageCrops.Src;
-            }
-
-            return value;
+            return imageCrops.Src;
         }
 
         protected override Attempt<IMedia> CreateItem(string alias, ITreeEntity parent, string itemType)

--- a/uSync.Core/Tracking/SyncXmlTracker.cs
+++ b/uSync.Core/Tracking/SyncXmlTracker.cs
@@ -290,7 +290,7 @@ namespace uSync.Core.Tracking
 
         private uSyncChange Compare(string target, string source, string path, string name, bool maskValue)
         {
-            if (source.DetectIsJson())
+            if (source.IsValidJsonString() is true)
             {
                 return JsonChange(target, source, path, name, maskValue);
             }

--- a/uSync.Tests/Extensions/JsonDetectionTests.cs
+++ b/uSync.Tests/Extensions/JsonDetectionTests.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using uSync.Core;
+
+namespace uSync.Tests.Extensions;
+
+[TestFixture]
+internal class JsonDetectionTests
+{
+    [TestCase("String value")]
+    [TestCase("12")]
+    [TestCase("\"Quoted string\"")]
+    [TestCase("20230101T12:00")]
+    [TestCase("")]
+    // DetectJson will return true, but its not json
+    [TestCase("[SQUARE]")]
+    [TestCase("{{angular-variable}}")]
+    [TestCase("{{angular | filter : value}}")]
+    [TestCase("{thing}")]
+    public void StringValuesAreStrings(string value)
+    {
+        var result = value.IsValidJsonString();
+        Assert.IsFalse(result);
+    }
+
+    [TestCase("{ \"name\": \"Test\" }")]
+    [TestCase("{ \"Age\": 30 }")]
+    [TestCase("{\r\n\"employee\":{\"name\":\"John\", \"age\":30, \"city\":\"New York\"}\r\n}")]
+    [TestCase("{\"middlename\":null}\r\n")]
+    [TestCase("[1,2,3]")]
+    [TestCase("[\"one\",\"two\",\"three\"]")]
+    public void JsonValueIsJson(string value)
+    {
+        var result = value.IsValidJsonString();
+        Assert.IsTrue(result);
+    }
+
+    [TestCase("[]")]
+    [TestCase("{}")]
+    public void EmptyJsonIsJson(string value)
+    {
+        var result = value.IsValidJsonString();
+        Assert.IsTrue(result);
+    }
+
+    [TestCase("{}")]
+    [TestCase("")]
+    [TestCase("[]")]
+    [TestCase("{ \"name\": \"Test\" }")]
+    [TestCase("[1,2,3]")]
+    [TestCase("[\"one\",\"two\",\"three\"]")]
+    public void CanBeCastToJToken(object value)
+    {
+        var result = value.GetJTokenFromObject();
+
+        Assert.IsNotNull(result);
+        Assert.IsInstanceOf<JToken>(result);
+    }
+
+    [TestCase("[SQUARE]")]
+    public void BadJsonReturnsNull(object value)
+    {
+        var result = value.GetJTokenFromObject();
+        Assert.IsNull(result);
+    }
+
+}

--- a/uSync.Tests/Extensions/JsonDetectionTests.cs
+++ b/uSync.Tests/Extensions/JsonDetectionTests.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Lucene.Net.Documents;
+
+using Newtonsoft.Json.Linq;
 
 using NUnit.Framework;
 
@@ -60,10 +62,63 @@ internal class JsonDetectionTests
     }
 
     [TestCase("[SQUARE]")]
+    [TestCase("{\"One\", \"Two\"}")]
     public void BadJsonReturnsNull(object value)
     {
         var result = value.GetJTokenFromObject();
         Assert.IsNull(result);
+    }
+
+    [TestCase("{}")]
+    [TestCase("[]")]
+    [TestCase("{ \"name\": \"Test\" }")]
+    [TestCase("[1,2,3]")]
+    [TestCase("[\"one\",\"two\",\"three\"]")]
+    public void JTokenValuesCanBeParsed(string value)
+    {
+        var result = value.TryParseValidJsonString(out JToken token);
+
+        Assert.IsTrue(result);
+        Assert.IsInstanceOf<JToken>(token);
+    }
+
+    [TestCase("Hello")]
+    [TestCase("")]
+    [TestCase("[SQUARE]")]
+    [TestCase("{{angular-variable}}")]
+    [TestCase("{{angular | filter : value}}")]
+    [TestCase("{thing}")]
+    [TestCase(null)]
+    public void StringIsNotParsed(string value)
+    {
+        var result = value.TryParseValidJsonString(out JToken token);
+
+        Assert.IsFalse(result);
+        Assert.IsNull(token);
+    }
+
+    [TestCase("[]", 0)]
+    [TestCase("[1,2,3]", 3)]
+    [TestCase("[\"one\",\"two\",\"three\"]", 3)]
+    public void JArrayValuesCanBeParsed(string value, int expectedLength)
+    {
+        var result = value.TryParseValidJsonString<JArray>(out JArray array);
+
+        Assert.IsTrue(result);
+        Assert.IsInstanceOf<JArray>(array);
+        Assert.AreEqual(array.Count, expectedLength);
+    }
+
+    [TestCase("{ \"name\": \"Test\" }")]
+    [TestCase("{ \"Age\": 30 }")]
+    [TestCase("{\r\n\"employee\":{\"name\":\"John\", \"age\":30, \"city\":\"New York\"}\r\n}")]
+    [TestCase("{\"middlename\":null}\r\n")]
+    public void JObjectValuesCanBeParsed(string value)
+    {
+        var result = value.TryParseValidJsonString<JObject>(out JObject obj);
+
+        Assert.IsTrue(result);
+        Assert.IsInstanceOf<JObject>(obj);
     }
 
 }


### PR DESCRIPTION
inspired by #566 from @paulwoodland . stop using `DetectIsJson` because it can give you false positives. 

instead, we are using `IsValidJson` in all places (outside of the actual extensions).  

this can mean in some cases we end up parsing the json twice (once to detect it, and then later on when we actuall use it.

i wonder if we shoud really have a try parse ??  