### PR TITLE
fix for the stylesheet toobar name changing.

### DIFF
--- a/uSync.Core/DataTypes/RichTextEditorConfigSerializerCore.cs
+++ b/uSync.Core/DataTypes/RichTextEditorConfigSerializerCore.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+
+using uSync.Core.Json;
+
+namespace uSync.Core.DataTypes;
+
+/// <summary>
+///  migration fix, sometime in v10 -> v13, the toolbar names 
+///  changed for stylesheets, so on import we now look for that
+///  and fix it. 
+/// </summary>
+internal class RichTextEditorConfigSerializerCore : ConfigurationSerializerBase, IConfigurationSerializer
+{
+    private static JsonSerializerSettings _jsonSettings = new JsonSerializerSettings()
+    {
+        ContractResolver = new uSyncContractResolver()
+    };
+
+    public string Name => "RichTextEditorSerializer";
+
+    public string[] Editors => [Constants.PropertyEditors.Aliases.TinyMce];
+
+    public override object DeserializeConfig(string config, Type configType)
+        => base.DeserializeConfig(config, configType);
+
+    public override string SerializeConfig(object configuration)
+    {
+        if (!(configuration is RichTextConfiguration richTextConfiguration))
+            return base.SerializeConfig(configuration);
+
+        var editorAttempt = richTextConfiguration.Editor.TryConvertTo<JObject>();
+
+        if (!editorAttempt.Success)
+            return base.SerializeConfig(configuration);
+
+        var toolbarAttempt = editorAttempt.Result.Value<JArray>("toolbar");
+
+        if (toolbarAttempt.Contains("styleselect"))
+        {
+            toolbarAttempt.Remove("styleselect");
+            toolbarAttempt.Add("styles");
+        }
+
+        editorAttempt.Result["toolbar"] = toolbarAttempt;
+
+        return JsonConvert.SerializeObject(richTextConfiguration, Formatting.Indented, _jsonSettings);
+    }
+}

--- a/uSync.Core/DataTypes/RichTextEditorConfigSerializerCore.cs
+++ b/uSync.Core/DataTypes/RichTextEditorConfigSerializerCore.cs
@@ -40,15 +40,18 @@ internal class RichTextEditorConfigSerializerCore : ConfigurationSerializerBase,
         if (!editorAttempt.Success)
             return base.SerializeConfig(configuration);
 
-        var toolbarAttempt = editorAttempt.Result.Value<JArray>("toolbar");
 
-        if (toolbarAttempt.Contains("styleselect"))
+        if (editorAttempt.Result.ContainsKey("toolbar") is false)
+            return base.SerializeConfig(configuration);
+
+        var toolbar = editorAttempt.Result.Value<JArray>("toolbar");
+        if (toolbar.Contains("styleselect"))
         {
-            toolbarAttempt.Remove("styleselect");
-            toolbarAttempt.Add("styles");
+            toolbar.Remove("styleselect");
+            toolbar.Add("styles");
         }
 
-        editorAttempt.Result["toolbar"] = toolbarAttempt;
+        editorAttempt.Result["toolbar"] = toolbar;
 
         return JsonConvert.SerializeObject(richTextConfiguration, Formatting.Indented, _jsonSettings);
     }


### PR DESCRIPTION
Sometime between v10 and v13 the TinyMCE names for the toobar styles button changed from "styleselect" to "styles"

if you import for v10 setup into v13 this isn't changed, so this pr adds a config serializer for the TimeMCE property that delves into the json and renames it. (we could have done a string rename, but less elegant more danger!)

