### PR TITLE
#583 - removes `.substring(1)` from handler names

### DIFF
--- a/uSync.Backoffice.Assets/App_Plugins/uSync/components/usync.reportview.component.js
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/components/usync.reportview.component.js
@@ -106,7 +106,7 @@
 
         function getTypeName(typeName) {
             if (typeName !== undefined) {
-                return typeName.substring(1);
+                return typeName;
             }
             return "??";
         }


### PR DESCRIPTION
see https://github.com/KevinJump/uSync/issues/583

I'm uncertain if it's OK to just remove the line of code, as there may still be interfaces to remove the `I` from. 