### PR TITLE
Fix: Custom root folders are just added to existing root folders when set.

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -23,10 +23,7 @@ namespace uSync.BackOffice.Configuration
         ///  collection of folders uSync looks in when performing imports.
         /// </summary>
         [DefaultValue("uSync/Root/, uSync/v9")]
-        public string[] Folders { get; set; } = [
-            "uSync/Root/",
-            "uSync/v9/"
-        ];
+        public string[] Folders { get; set; } = [ ];
 
         /// <summary>
         ///  Sets this site to be the root site (so it will save into "uSync/root/")

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -90,6 +90,14 @@ namespace uSync.BackOffice
 
             builder.Services.AddTransient<ISyncActionService, SyncActionService>();
 
+            _ = builder.Services.PostConfigure<uSyncSettings>(options =>
+            {
+                if (options.Folders == null || options.Folders.Length == 0)
+                {
+                    options.Folders = ["uSync/Root/", "uSync/v9/"];
+                }
+            });
+
             return builder;
         }
 


### PR DESCRIPTION
When you have arrays in the appsettings they are cumulative (so they add to the default values).

This fix. 
- Makes the 'default' value be an empty array. 
- Uses post configure to add the default values to the array if its empty. 

so.

```json
"uSync": {
  "Settings": {
    "Folders":  ["uSync/main", "uSync/Site"],
  }
}
```

will now only set two folders not four. 

