### PR TITLE
Adds UI to the report to make it eaiser to spot sources.

### DIFF
--- a/uSync.BackOffice/BackOfficeConstants.cs
+++ b/uSync.BackOffice/BackOfficeConstants.cs
@@ -30,6 +30,11 @@ namespace uSync.BackOffice
         public const string ReleaseSuffix = "";
 
         /// <summary>
+        ///  folder we say things are in when we have merged them.
+        /// </summary>
+        public const string MergedFolderName = "Combined";
+
+        /// <summary>
         ///  ordering of the handler items (what gets done when)
         /// </summary>
         public static class Priorites

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -506,6 +506,7 @@ namespace uSync.BackOffice.Services
                     {
                         // merge these files.
                         item.Value.SetNode(trackerBase.MergeFiles(elements[item.Key].Node, item.Value.Node));
+                        item.Value.FileName = $"{uSyncConstants.MergedFolderName}/{Path.GetFileName(item.Value.FileName)}";
                     }
 
                     elements[item.Key] = item.Value;

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/changedialog.html
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/changedialog.html
@@ -20,6 +20,12 @@
                 </umb-box-header>
                 <umb-box-container>
                     <umb-box-content>
+                        <div ng-if="vm.item.path != 'Combined'" class="usync-path-source-summary">
+                            Update file from the <strong>{{vm.item.path}}</strong> folder.
+                        </div>
+                        <div ng-if="vm.item.path == 'Combined'" class="usync-path-source-summary">
+                            Update is the result of combining two or more files from disk.
+                        </div>
                         <div ng-if="vm.item.detailMessage.length > 0" class="usync-item-detail-message">
                             <div ng-bind-html="vm.item.detailMessage"></div>
                         </div>

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/components/usync.reportview.html
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/components/usync.reportview.html
@@ -51,11 +51,11 @@
                                     <div class="umb-table-cell">
                                         {{result._typename}}
                                     </div>
+                                    <div class="umb-table-cell">
+                                        <em class="usync-path-name {{result.path}}">{{result.path}}</em>
+                                    </div>
                                     <div class="umb-table-cell umb-table__name">
-                                        <div>
-                                            {{result.name}}
-                                            <div class="muted" ng-if="result.path.length > 0"> > {{result.itemType.substring(1)}}{{result.path}}</div>
-                                        </div>
+                                        {{result.name}}
                                     </div>
                                     <div class="umb-table-cell">
                                         {{result.change}}

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/usync.css
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/usync.css
@@ -634,3 +634,26 @@ ul.usync-action-list {
 .usync-summary-expand.active .icon {
     transform: rotateX(180deg);
 }
+
+.usync-path-source-summary {
+    margin: 5px 0;
+    font-style: italic;
+    border: 1px solid #eee;
+    border-left: 4px solid #ddd;
+    padding: 5px 10px;
+}
+
+.usync-path-name {
+    padding: 3px 5px;
+    border-radius: 4px;
+}
+
+    .usync-path-name.Combined {
+        background-color: #FF7043;
+        color: white;
+    }
+
+    .usync-path-name.Root {
+        background-color: #27b171;
+        color: white;
+    }


### PR DESCRIPTION
Feature #597 

One for @NikRimington 😃 

Adds some labels to the report page so you can see where things are coming from when using roots. 

![image](https://github.com/KevinJump/uSync/assets/431231/c06350ff-457e-4e80-8cd1-6b4408be260b)

Adds some text to the details page to also tell you where a thing is importing from. 

![image](https://github.com/KevinJump/uSync/assets/431231/15ebea98-e72e-4e7f-a4ac-e2c00e942f70)

![image](https://github.com/KevinJump/uSync/assets/431231/c0821af9-a6d2-4e3c-a00b-d0cfcf4229d3)


At the moment the labels are styled based on the folder name

so we have styles for root and combined, we are not styling v9 as that is the default that most people will see. 

_(Combined is the special path, returned when files have been merged by the uSync roots processes)_

if you wanted your own-coloured labels you would have to have your own backoffice stylesheet with them in. 

e.g 

```css
.usync-path-name.MyRootFolder{
    background-color: #27b171;
    color: white;
}
```

