### PR TITLE
Fix #224 - Observe root folder value in rootfolder array

### DIFF
--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -94,7 +94,7 @@ namespace uSync.BackOffice
             {
                 if (options.Folders == null || options.Folders.Length == 0)
                 {
-                    options.Folders = ["uSync/Root/", "uSync/v9/"];
+                    options.Folders = ["uSync/Root/", options.RootFolder];
                 }
             });
 


### PR DESCRIPTION
the `RootFolder` value should be the last value in the Folders array. so if set to a custom value, it will be observed and not be a breaking change.

See : https://github.com/Jumoo/uSync.Complete.Issues/issues/224