### PR TITLE
Use folders provided in options over config

### DIFF
--- a/uSync.BackOffice/Models/SyncActionOptions.cs
+++ b/uSync.BackOffice/Models/SyncActionOptions.cs
@@ -46,7 +46,6 @@ namespace uSync.BackOffice.Models
         /// <summary>
         ///  array of usync folders you want to import - files will be merged as part of the process.
         /// </summary>
-        public string[] Folders { get; set; }
-
+        public string[] Folders { get; set; } = [];
     }
 }

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 
 using Microsoft.Extensions.Logging;
-
+using Umbraco.Extensions;
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Models;
 using uSync.BackOffice.SyncHandlers;
@@ -70,7 +70,7 @@ internal class SyncActionService : ISyncActionService
         var handlerSet = !string.IsNullOrWhiteSpace(options.Set)
                        ? options.Set : _uSyncConfig.Settings.DefaultSet;
 
-        var folders = _uSyncConfig.GetFolders();
+        var folders = GetFolders(options);
 
         var actions = _uSyncService.ReportHandler(options.Handler,
             new uSyncImportOptions
@@ -86,13 +86,23 @@ internal class SyncActionService : ISyncActionService
         return new SyncActionResult(actions);
     }
 
+    private string[] GetFolders(SyncActionOptions options)
+    {
+        if (options.Folders.Any())
+            return options.Folders;
 
+        if (!string.IsNullOrEmpty(options.Folder))
+            return options.Folder.AsEnumerableOfOne().ToArray();
+
+        return _uSyncConfig.GetFolders();
+    }
+    
     public SyncActionResult ImportHandler(SyncActionOptions options, uSyncCallbacks callbacks)
     {
         var handlerSet = !string.IsNullOrWhiteSpace(options.Set)
                   ? options.Set : _uSyncConfig.Settings.DefaultSet;
 
-        var folders = _uSyncConfig.GetFolders();
+        var folders = GetFolders(options);
 
         var actions = _uSyncService.ImportHandler(options.Handler, new uSyncImportOptions
         {
@@ -175,8 +185,7 @@ internal class SyncActionService : ISyncActionService
             _logger.LogDebug("Using Custom Folder: {fullPath}", folder);
             return folder;
         }
-
-
+        
         return string.Empty;
     }
 

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -87,7 +87,7 @@ internal class SyncActionService : ISyncActionService
 
     private string[] GetFolders(SyncActionOptions options)
     {
-        if (options.Folders.Any())
+        if (options.Folders.Length != 0)
             return options.Folders;
 
         if (!string.IsNullOrEmpty(options.Folder))
@@ -124,7 +124,7 @@ internal class SyncActionService : ISyncActionService
         var handlerSet = !string.IsNullOrWhiteSpace(options.Set)
             ? options.Set : _uSyncConfig.Settings.DefaultSet;
 
-        var folders = _uSyncConfig.GetFolders();
+        var folders = GetFolders(options);
 
         var actions = _uSyncService.PerformPostImport(
             folders,
@@ -141,7 +141,7 @@ internal class SyncActionService : ISyncActionService
         var handlerSet = !string.IsNullOrWhiteSpace(options.Set)
             ? options.Set : _uSyncConfig.Settings.DefaultSet;
 
-        var folders = _uSyncConfig.GetFolders();
+        var folders = GetFolders(options);
 
         var actions = _uSyncService.ExportHandler(options.Handler, new uSyncImportOptions
         {

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 
 using Microsoft.Extensions.Logging;
-using Umbraco.Extensions;
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Models;
 using uSync.BackOffice.SyncHandlers;
@@ -92,7 +91,7 @@ internal class SyncActionService : ISyncActionService
             return options.Folders;
 
         if (!string.IsNullOrEmpty(options.Folder))
-            return options.Folder.AsEnumerableOfOne().ToArray();
+            return [options.Folder];
 
         return _uSyncConfig.GetFolders();
     }


### PR DESCRIPTION
This fixes an issue when using uSync Migrations and uSync version 13.1.0 or newer.

Since the `folder` or `folders` value of the `SyncActionOptions` is not used when importing, this reintroduces the functionality respecting the following order if they are defined:

1. `SyncActionOptions.Folders`
2. `SyncActionOptions.Folder` - for backwards compatibility
3. `uSyncConfigService.GetConfig()` - for when no folder or folders are defined