### PR TITLE
Use suppression of notifications if configured

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -186,14 +186,11 @@ namespace uSync.BackOffice.Configuration
 
         /// <summary>
         ///  turns of use of the Notifications.Supress method, so notifications
-        ///  fire after every item is imported.
+        ///  are suppressed during the import
         /// </summary>
         /// <remarks>
-        ///  I am not sure this does what i think it does, it doesn't suppress
-        ///  then fire at the end , it just suppresses them all. 
-        ///  
-        ///  until we have had time to look at this , we will leave this as 
-        ///  disabled by default so all notification messages fire.
+        ///  this will result in no notifications being fired througout the import,
+        ///  use this if you are comfortable with the risks
         /// </remarks>
         [DefaultValue("false")]
         public bool DisableNotificationSuppression { get; set; } = false;

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -193,7 +193,7 @@ namespace uSync.BackOffice.Configuration
         ///  use this if you are comfortable with the risks
         /// </remarks>
         [DefaultValue("false")]
-        public bool DisableNotificationSuppression { get; set; } = false;
+        public bool EnableNotificationSuppression { get; set; } = false;
 
         /// <summary>
         ///  trigger all the notifications in a background thread, 

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -195,6 +195,18 @@ namespace uSync.BackOffice.Configuration
         [DefaultValue("false")]
         public bool EnableNotificationSuppression { get; set; } = false;
 
+		/// <summary>
+		///  suppress notifications by name 
+		/// </summary>
+		/// <remarks>
+		///  This will suppress notifications by name (e.g ContentTreeChangeNotification)
+        ///  These notifications will not fire during an uSync import. 
+        ///  
+        ///  You need to understand the consequences of notifications not firing on 
+        ///  other elements of Umbraco before setting this value. 
+		/// </remarks>
+		public string[] SuppressNamedNotifications { get; set; } = [];
+
         /// <summary>
         ///  trigger all the notifications in a background thread, 
         /// </summary>

--- a/uSync.BackOffice/Extensions/ScopeExtensions.cs
+++ b/uSync.BackOffice/Extensions/ScopeExtensions.cs
@@ -15,9 +15,9 @@ namespace uSync.BackOffice.Extensions;
 internal static class ScopeExtensions
 {
     public static IDisposable SuppressScopeByConfig(this ICoreScope scope, uSyncConfigService configService)
-        => configService.Settings.DisableNotificationSuppression
-            ? new DummyDisposable()
-            : scope.Notifications.Suppress();
+        => configService.Settings.EnableNotificationSuppression
+            ? scope.Notifications.Suppress()
+            : new DummyDisposable();
 
 
     public static ICoreScope CreateNotificationScope(

--- a/uSync.BackOffice/Services/uSyncService_Handlers.cs
+++ b/uSync.BackOffice/Services/uSyncService_Handlers.cs
@@ -63,6 +63,8 @@ namespace uSync.BackOffice
                         backgroundTaskQueue: _backgroundTaskQueue,
                         options.Callbacks?.Update);
 
+                    using var supression = scope.SuppressScopeByConfig(_uSyncConfig);
+
                     var results = handlerPair.Handler.ImportAll(folders, handlerPair.Settings, options);
                     
                     _logger.LogDebug("< Import Handler {handler}", handlerAlias);

--- a/uSync.BackOffice/Services/uSyncService_Single.cs
+++ b/uSync.BackOffice/Services/uSyncService_Single.cs
@@ -123,14 +123,16 @@ namespace uSync.BackOffice
 
                     var index = options.PageNumber * options.PageSize;
 
-                    using var scope = _scopeProvider.CreateNotificationScope(
+                    using (var scope = _scopeProvider.CreateNotificationScope(
                         eventAggregator: _eventAggregator,
                         loggerFactory: _loggerFactory, 
                         syncConfigService: _uSyncConfig,
                         syncEventService: _mutexService,
                         backgroundTaskQueue: _backgroundTaskQueue,
-                        options.Callbacks?.Update);
+                        options.Callbacks?.Update))
                     {
+                        using var suppression = scope.SuppressScopeByConfig(_uSyncConfig);
+                        
                         try
                         {
                             foreach (var item in orderedNodes.Skip(options.PageNumber * options.PageSize).Take(options.PageSize))
@@ -209,6 +211,8 @@ namespace uSync.BackOffice
                         backgroundTaskQueue: _backgroundTaskQueue,
                         options.Callbacks?.Update))
                     {
+                        using var suppression = scope.SuppressScopeByConfig(_uSyncConfig);
+                        
                         try
                         {
                             foreach (var action in actions.Skip(options.PageNumber * options.PageSize).Take(options.PageSize))


### PR DESCRIPTION
This enables the notification suppression functionality hidden in the `uSyncSettings`.
The XML documentation has been updated to reflect the purpose of the flag.

Currently we have a large import (~7000) media items that is hanging on processing the `MediaTreeChangedNotification`, we are not concerned for these at the moment and would prefer skipping entirely.

Risks:
- No tree changed notifications firing during the import which will mean the caches are not up-to-date.
- Any notifications typically handled by the application will not be raised (e.g. saved / published notifications that perform actions afterwards).