### PR TITLE
Add serializers and handlers for webhooks.

### DIFF
--- a/uSync.BackOffice/BackOfficeConstants.cs
+++ b/uSync.BackOffice/BackOfficeConstants.cs
@@ -118,6 +118,11 @@ namespace uSync.BackOffice
             /// RelationTypes priority
             /// </summary>
             public const int RelationTypes = USYNC_RESERVED_LOWER + 230;
+
+            /// <summary>
+            ///  Webhooks priority.
+            /// </summary>
+            public const int Webhooks = USYNC_RESERVED_LOWER + 250;
         }
 
         /// <summary>
@@ -243,6 +248,11 @@ namespace uSync.BackOffice
             /// TemplateHandler Name
             /// </summary>
             public const string TemplateHandler = "TemplateHandler";
+
+            /// <summary>
+            ///  WebhooksHandler name
+            /// </summary>
+            public const string WebhookHandler = "WebhookHandler";
 
 
         }

--- a/uSync.BackOffice/SyncHandlers/Handlers/WebhookHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/WebhookHandler.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.Core;
+
+using static Umbraco.Cms.Core.Constants;
+
+namespace uSync.BackOffice.SyncHandlers.Handlers;
+
+[SyncHandler(uSyncConstants.Handlers.WebhookHandler, "Webhooks", "Webhooks",
+	uSyncConstants.Priorites.Webhooks, 
+	Icon = "icon-filter-arrows", 
+	EntityType = UdiEntityType.Webhook, 
+	IsTwoPass = false	
+)]
+public class WebhookHandler : SyncHandlerRoot<IWebhook, IWebhook>, ISyncHandler,
+	INotificationHandler<SavedNotification<IWebhook>>,
+	INotificationHandler<DeletedNotification<IWebhook>>,
+	INotificationHandler<SavingNotification<IWebhook>>,
+	INotificationHandler<DeletingNotification<IWebhook>>
+{
+	private readonly IWebhookService _webhookService;
+
+	public WebhookHandler(
+		ILogger<SyncHandlerRoot<IWebhook, IWebhook>> logger,
+		AppCaches appCaches,
+		IShortStringHelper shortStringHelper,
+		SyncFileService syncFileService,
+		uSyncEventService mutexService,
+		uSyncConfigService uSyncConfig,
+		ISyncItemFactory itemFactory,
+		IWebhookService webhookService)
+		: base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+	{
+		_webhookService = webhookService;
+	}
+
+	protected override IEnumerable<uSyncAction> DeleteMissingItems(IWebhook parent, IEnumerable<Guid> keysToKeep, bool reportOnly)
+	{
+		return [];
+	}
+
+	protected override IEnumerable<IWebhook> GetChildItems(IWebhook parent)
+	{
+		if (parent == null)
+		{
+			return _webhookService.GetAllAsync(0, 1000).Result.Items;
+		}
+
+		return [];
+	}
+
+	protected override IEnumerable<IWebhook> GetFolders(IWebhook parent) => [];
+
+	protected override IWebhook GetFromService(IWebhook item)
+		=> _webhookService.GetAsync(item.Key).Result;
+
+	protected override string GetItemName(IWebhook item) => item.Key.ToString();
+}

--- a/uSync.BackOffice/SyncHandlers/Handlers/WebhookHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/WebhookHandler.cs
@@ -21,6 +21,9 @@ using static Umbraco.Cms.Core.Constants;
 
 namespace uSync.BackOffice.SyncHandlers.Handlers;
 
+/// <summary>
+///  handler for webhook events. 
+/// </summary>
 [SyncHandler(uSyncConstants.Handlers.WebhookHandler, "Webhooks", "Webhooks",
 	uSyncConstants.Priorites.Webhooks, 
 	Icon = "icon-filter-arrows", 
@@ -35,6 +38,9 @@ public class WebhookHandler : SyncHandlerRoot<IWebhook, IWebhook>, ISyncHandler,
 {
 	private readonly IWebhookService _webhookService;
 
+	/// <summary>
+	///  constructor
+	/// </summary>
 	public WebhookHandler(
 		ILogger<SyncHandlerRoot<IWebhook, IWebhook>> logger,
 		AppCaches appCaches,
@@ -49,11 +55,13 @@ public class WebhookHandler : SyncHandlerRoot<IWebhook, IWebhook>, ISyncHandler,
 		_webhookService = webhookService;
 	}
 
+	/// <inheritdoc/>
 	protected override IEnumerable<uSyncAction> DeleteMissingItems(IWebhook parent, IEnumerable<Guid> keysToKeep, bool reportOnly)
 	{
 		return [];
 	}
 
+	/// <inheritdoc/>
 	protected override IEnumerable<IWebhook> GetChildItems(IWebhook parent)
 	{
 		if (parent == null)
@@ -64,10 +72,13 @@ public class WebhookHandler : SyncHandlerRoot<IWebhook, IWebhook>, ISyncHandler,
 		return [];
 	}
 
+	/// <inheritdoc/>
 	protected override IEnumerable<IWebhook> GetFolders(IWebhook parent) => [];
 
+	/// <inheritdoc/>
 	protected override IWebhook GetFromService(IWebhook item)
 		=> _webhookService.GetAsync(item.Key).Result;
 
+	/// <inheritdoc/>
 	protected override string GetItemName(IWebhook item) => item.Key.ToString();
 }

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -166,6 +166,9 @@ namespace uSync.BackOffice
             builder.AddNotificationHandler<TemplateSavedNotification, TemplateHandler>();
             builder.AddNotificationHandler<TemplateDeletedNotification, TemplateHandler>();
 
+            builder.AddNotificationHandler<WebhookSavedNotification, WebhookHandler>();
+            builder.AddNotificationHandler<WebhookDeletedNotification, WebhookHandler>();
+
             // roots - pre-notifications for stopping things
             builder
                 .AddNotificationHandler<ContentTypeSavingNotification, ContentTypeHandler>()
@@ -202,7 +205,10 @@ namespace uSync.BackOffice
                 .AddNotificationHandler<MacroDeletingNotification, MacroHandler>()
 
                 .AddNotificationHandler<TemplateSavingNotification, TemplateHandler>()
-                .AddNotificationHandler<TemplateDeletingNotification, TemplateHandler>();
+                .AddNotificationHandler<TemplateDeletingNotification, TemplateHandler>()
+                
+                .AddNotificationHandler<WebhookSavingNotification, WebhookHandler>()
+                .AddNotificationHandler<WebhookDeletingNotification, WebhookHandler>();
 
 
             // content ones

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+using Lucene.Net.Queries.Function.ValueSources;
+
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.Models;
+
+namespace uSync.Core.Serialization.Serializers;
+
+[SyncSerializer("ED18C89D-A9FF-4217-9F8E-6898CA63ED81", "Webhook Serializer", uSyncConstants.Serialization.Webhook, IsTwoPass = false)]
+public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<IWebhook>
+{
+	private readonly IWebhookService _webhookService;
+
+	public WebhookSerializer(
+		IEntityService entityService,
+		ILogger<SyncSerializerBase<IWebhook>> logger,
+		IWebhookService webhookService) 
+		: base(entityService, logger)
+	{
+		_webhookService = webhookService;
+	}
+
+	public override void DeleteItem(IWebhook item)
+	{
+		_webhookService.DeleteAsync(item.Key).Wait();
+	}
+
+	public override IWebhook FindItem(int id) => null;
+
+	public override IWebhook FindItem(Guid key)
+		=> _webhookService.GetAsync(key).Result;
+
+	public override IWebhook FindItem(string alias)
+	{
+		if (Guid.TryParse(alias, out Guid key))
+			return FindItem(key);
+
+		return null;
+	}
+
+	public override string ItemAlias(IWebhook item)
+		=> item.Key.ToString();
+
+	public override void SaveItem(IWebhook item)
+	{
+		if (item.Id > 0)
+		{
+			_webhookService.UpdateAsync(item).Wait();
+		}
+		else
+		{
+			_webhookService.CreateAsync(item).Wait();
+		}
+	}
+
+	protected override SyncAttempt<IWebhook> DeserializeCore(XElement node, SyncSerializerOptions options)
+	{
+		var key = node.GetKey();
+		var alias = node.GetAlias();
+
+		var details = new List<uSyncChange>();
+
+		var item = FindItem(key);	
+		if (item == null)
+		{
+			// try and find by url/etc???
+		}
+
+		var url = node.Element("Url").ValueOrDefault(string.Empty);
+
+		if (item == null)
+		{
+			item = new Webhook(url);
+		}
+		
+		if (item.Key != key)
+		{
+			details.AddUpdate("Key", item.Key, key);
+			item.Key = key;
+		}
+
+		if (item.Url != url)
+		{
+			details.AddUpdate("Url", item.Url, url);
+			item.Url = url;
+		}
+
+		details.AddRange(DeserializeContentKeys(item, node));
+		details.AddRange(DeserializeEvents(item, node));
+		details.AddRange(DeserializeHeaders(item, node));
+
+		return SyncAttempt<IWebhook>.Succeed(node.GetAlias(), item, ChangeType.Import, details);
+	}
+	
+	private static List<uSyncChange> DeserializeContentKeys(IWebhook item, XElement node)
+	{
+		var details = new List<uSyncChange>();
+
+		var keys = node.Element("ContentTypeKeys");
+		if (keys == null) return details;
+
+		List<Guid> newKeys = [];
+
+		foreach (var key in keys.Elements("Key"))
+		{
+			var keyValue = key.ValueOrDefault(Guid.Empty);
+			if (keyValue == Guid.Empty) continue;
+			newKeys.Add(keyValue);
+		}
+
+		var newOrderedKeys = newKeys.Order().ToArray();
+		var existingOrderedKeys = item.ContentTypeKeys.Order().ToArray();
+
+		if (existingOrderedKeys.Equals(newOrderedKeys) is false)
+		{
+			details.AddUpdate("ContentTypeKeys", 
+				string.Join(",", existingOrderedKeys),
+				string.Join(",", newOrderedKeys)
+				, "/");
+			item.ContentTypeKeys = newOrderedKeys;
+		}
+
+		return details;
+
+	}
+
+	private static List<uSyncChange> DeserializeEvents(IWebhook item, XElement node)
+	{
+		var details = new List<uSyncChange>();
+
+		var keys = node.Element("Events");
+		if (keys == null) return details;
+
+		List<string> newKeys = [];
+
+		foreach (var eventNode in keys.Elements("Event"))
+		{
+			var eventValue = eventNode.ValueOrDefault(string.Empty);
+			if (eventValue == string.Empty) continue;
+			newKeys.Add(eventValue);
+		}
+
+		var newOrderedEvents = newKeys.Order().ToArray();
+		var existingOrderedEvents = item.Events.Order().ToArray();
+
+		if (existingOrderedEvents.Equals(newOrderedEvents) is false)
+		{
+			details.AddUpdate("Events", 
+				string.Join(",", existingOrderedEvents),
+				string.Join(",", newOrderedEvents)
+				, "/");
+			item.Events = newOrderedEvents;
+		}
+
+		return details;
+	}
+
+	private static List<uSyncChange> DeserializeHeaders(IWebhook item, XElement node)
+	{
+		var details = new List<uSyncChange>();
+
+		var keys = node.Element("Headers");
+		if (keys == null) return details;
+
+		Dictionary<string, string> newHeaders = new();
+
+		foreach (var header in keys.Elements("Header"))
+		{
+			var headerKey = header.Attribute("Key").ValueOrDefault(string.Empty);
+			var headerValue = header.ValueOrDefault(string.Empty);
+
+			if (headerKey == string.Empty) continue;
+			if (newHeaders.ContainsKey(headerKey)) continue; // stop duplicates.
+			newHeaders.Add(headerKey, headerValue);
+		}
+
+		var existingOrderedEvents = item.Headers.OrderBy(x => x.Key).ToDictionary();
+		var newOrderedHeaders = newHeaders.OrderBy(x => x.Key).ToDictionary();
+
+		if (existingOrderedEvents.Equals(newOrderedHeaders) is false)
+		{
+			details.AddUpdate("Events", 
+				string.Join(",", existingOrderedEvents),
+				string.Join(",", newOrderedHeaders)
+				, "/");
+			item.Headers = newOrderedHeaders;
+		}
+
+		return details;
+	}
+
+
+
+	protected override SyncAttempt<XElement> SerializeCore(IWebhook item, SyncSerializerOptions options)
+	{
+		var node = InitializeBaseNode(item, item.Url);
+
+		node.Add(new XElement("Url", item.Url));
+		node.Add(new XElement("Enabled", item.Enabled));
+		
+		node.Add(SerializeContentKeys(item));
+		node.Add(SerializeEvents(item));
+		node.Add(SerializeHeaders(item));
+
+		return SyncAttempt<XElement>.Succeed(item.Url, node, typeof(IWebhook), ChangeType.Export);
+		
+	}
+
+	private static XElement SerializeContentKeys(IWebhook item)
+	{
+		var keysNode = new XElement("ContentTypeKeys");
+		foreach (var contentTypeKey in item.ContentTypeKeys.Order())
+		{
+			keysNode.Add(new XElement("Key", contentTypeKey));
+		}
+
+		return keysNode;
+	}
+
+	private static XElement SerializeEvents(IWebhook item)
+	{
+		var eventsNode = new XElement("Events");
+		foreach(var eventItem in item.Events.Order())
+		{
+			eventsNode.Add(new XElement("Event", eventItem));
+		}
+		return eventsNode;
+	}
+
+	private static XElement SerializeHeaders(IWebhook item)
+	{
+		var headerNode = new XElement("Headers");
+		foreach(var headerItem in item.Headers.OrderBy(x => x.Key))
+		{
+			headerNode.Add(new XElement("Header",
+				 new XAttribute("Key", headerItem.Key),
+				 new XCData(headerItem.Value)));
+		}
+
+		return headerNode;
+	}
+}

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
-using Lucene.Net.Queries.Function.ValueSources;
-
 using Microsoft.Extensions.Logging;
 
 using Umbraco.Cms.Core.Models;
@@ -14,6 +12,9 @@ using uSync.Core.Models;
 
 namespace uSync.Core.Serialization.Serializers;
 
+/// <summary>
+///  serializing webhook events
+/// </summary>
 [SyncSerializer("ED18C89D-A9FF-4217-9F8E-6898CA63ED81", "Webhook Serializer", uSyncConstants.Serialization.Webhook, IsTwoPass = false)]
 public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<IWebhook>
 {
@@ -28,16 +29,20 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
 		_webhookService = webhookService;
 	}
 
+	/// <inheritdoc/>
 	public override void DeleteItem(IWebhook item)
 	{
 		_webhookService.DeleteAsync(item.Key).Wait();
 	}
 
+	/// <inheritdoc/>
 	public override IWebhook FindItem(int id) => null;
 
+	/// <inheritdoc/>
 	public override IWebhook FindItem(Guid key)
 		=> _webhookService.GetAsync(key).Result;
 
+	/// <inheritdoc/>
 	public override IWebhook FindItem(string alias)
 	{
 		if (Guid.TryParse(alias, out Guid key))
@@ -46,9 +51,11 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
 		return null;
 	}
 
+	/// <inheritdoc/>
 	public override string ItemAlias(IWebhook item)
 		=> item.Key.ToString();
 
+	/// <inheritdoc/>
 	public override void SaveItem(IWebhook item)
 	{
 		if (item.Id > 0)
@@ -61,6 +68,7 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
 		}
 	}
 
+	/// <inheritdoc/>
 	protected override SyncAttempt<IWebhook> DeserializeCore(XElement node, SyncSerializerOptions options)
 	{
 		var key = node.GetKey();

--- a/uSync.Core/Tracking/Impliment/DomainTracker.cs
+++ b/uSync.Core/Tracking/Impliment/DomainTracker.cs
@@ -6,7 +6,7 @@ using uSync.Core.Serialization;
 
 namespace uSync.Core.Tracking.Impliment
 {
-    public class DomainTracker : SyncXmlTracker<IDomain>, ISyncTracker<IDomain>
+	public class DomainTracker : SyncXmlTracker<IDomain>, ISyncTracker<IDomain>
     {
         public DomainTracker(SyncSerializerCollection serializers)
             : base(serializers)

--- a/uSync.Core/Tracking/Impliment/WebhookTracker.cs
+++ b/uSync.Core/Tracking/Impliment/WebhookTracker.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+using Umbraco.Cms.Core.Models;
+
+using uSync.Core.Serialization;
+
+namespace uSync.Core.Tracking.Impliment
+{
+	public class WebhookTracker : SyncXmlTracker<IWebhook>, ISyncTracker<IWebhook>
+	{
+		public WebhookTracker(SyncSerializerCollection serializers) : base(serializers)
+		{
+		}
+
+        public override List<TrackingItem> TrackingItems => [
+            TrackingItem.Single("Enabled", "/Enabled"),
+			TrackingItem.Many("Events", "/Events/Event", "Event"),
+			TrackingItem.Many("Headers", "/Headers/Header", "@Key"),
+			TrackingItem.Many("ContentKeys", "/ContentTypeKeys/Key", "Key"),
+		];
+	}
+}

--- a/uSync.Core/uSyncConstants.cs
+++ b/uSync.Core/uSyncConstants.cs
@@ -53,6 +53,8 @@
 
             public const string RelationType = "RelationType";
             public const string Relation = "Relation";
+
+            public const string Webhook = "Webhook";
         }
 
         /// <summary>


### PR DESCRIPTION
Adds the missing serializer and handler (and tracker) so we can import and export webhooks. 

notes: 
- webhooks don't have aliases, so there is no way to 'find' them reliably if the key is diffrent. so for now that could mean duplicates, if a webhook is setup on both sites before a sync. 

Nightly build of this branch is available for testing : https://dev.azure.com/jumoo/Public/_artifacts/feed/nightly/NuGet/uSync/overview/13.1.4-build.20240410.1