### PR TITLE
fix #605 - check delete by serializing item one last time.

### DIFF
--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1614,7 +1614,8 @@ namespace uSync.BackOffice.SyncHandlers
                 // don't do anything this thing exists at a higher level. ! 
                 return;
             }
-            
+
+            if (ShouldExportDeletedFile(item, config) is false) return;
 
             var attempt = serializer.SerializeEmpty(item, SyncActionType.Delete, string.Empty);
             if (ShouldExport(attempt.Item, config))
@@ -1634,10 +1635,24 @@ namespace uSync.BackOffice.SyncHandlers
             }
         }
 
-        /// <summary>
-        ///  get all the possible folders for this handlers 
-        /// </summary>
-        protected string[] GetDefaultHandlerFolders()
+        private bool ShouldExportDeletedFile(TObject item, HandlerSettings config)
+        {
+			try
+			{
+				var deletingAttempt = serializer.Serialize(item, new SyncSerializerOptions(config.Settings));
+                return ShouldExport(deletingAttempt.Item, config);
+			}
+			catch (Exception ex)
+			{
+				logger.LogWarning(ex, "Failed to calculate if this item should be exported when deleted, the common option is yes, so we will");
+                return true;
+			}
+		}
+
+		/// <summary>
+		///  get all the possible folders for this handlers 
+		/// </summary>
+		protected string[] GetDefaultHandlerFolders()
             => rootFolders.Select(f => Path.Combine(f, DefaultFolder)).ToArray();
 
 


### PR DESCRIPTION
Fixes #605 

for a delete we normally create an empty xml node, but this doesn't contain things like the items content type, so the rules break.

this fix serialized a node normally (into memory) one last time so we can do checks against the rules using this full export node, before calculating if we indeed do need to export the clean 'empty' xml node for the delete. 