### PR TITLE
Fix #653 - Check for null 'allowedContentTypes'

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -180,6 +180,8 @@ namespace uSync.Core.Serialization.Serializers
             var node = new XElement("Structure");
             List<KeyValuePair<string, string>> items = new List<KeyValuePair<string, string>>();
 
+            if (item.AllowedContentTypes is null) return node;
+
             foreach (var allowedType in item.AllowedContentTypes.OrderBy(x => x.SortOrder))
             {
                 var allowedItem = FindItem(allowedType.Id.Value);


### PR DESCRIPTION
fixes missing null check for allowed Content types. 