### PR TITLE
Corrected the uSync page URL casing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 
 		<PackageIconUrl></PackageIconUrl>
 		<PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-		<PackageProjectUrl>https://jumoo.co.uk/uSync</PackageProjectUrl>
+		<PackageProjectUrl>https://jumoo.co.uk/usync</PackageProjectUrl>
 		<PackageTags>Umbraco</PackageTags>
 
 		<RepositoryUrl>https://github.com/KevinJump/uSync8/tree/core/main</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Database syncing tool for Umbraco
 
 uSync is a Umbraco package that reads and writes your Umbraco settings to and from disk. This allows you to source control and deploy changes you make inside Umbraco.
 
-https://jumoo.co.uk/uSync/
+https://jumoo.co.uk/usync/

--- a/uSync.Backoffice.Assets/App_Plugins/uSync/addons.txt
+++ b/uSync.Backoffice.Assets/App_Plugins/uSync/addons.txt
@@ -5,7 +5,7 @@
     "title":  "uSync Complete",
     "headline": "Get everything with uSync.Complete",
     "text": "uSync Complete brings together all the best bits of uSync into one place.",
-    "link": "https://jumoo.co.uk/uSync/complete/",
+    "link": "https://jumoo.co.uk/usync/complete/",
     "icons": [
       {
         "icon": "icon-arrow-up",

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/addons/addons.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/addons/addons.element.ts
@@ -53,7 +53,7 @@ export class uSyncAddOnsElement extends UmbElementMixin(LitElement) {
 
 						<div class="cta">
 							<uui-button
-								href="https://jumoo.co.uk/uSync/complete/"
+								href="https://jumoo.co.uk/usync/complete/"
 								target="_blank"
 								color="positive"
 								look="primary"

--- a/uSync/uSync.csproj
+++ b/uSync/uSync.csproj
@@ -15,7 +15,7 @@
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
 
 		<PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
-		<PackageProjectUrl>https://jumoo.co.uk/uSync</PackageProjectUrl>
+		<PackageProjectUrl>https://jumoo.co.uk/usync</PackageProjectUrl>
 
 		<PackageTags>umbraco usync umbraco-marketplace</PackageTags>
 

--- a/uSync/usync.nuspec
+++ b/uSync/usync.nuspec
@@ -8,7 +8,7 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MPL-2.0</license>
 		<licenseUrl>https://licenses.nuget.org/MPL-2.0</licenseUrl>
-		<projectUrl>https://jumoo.co.uk/uSync</projectUrl>
+		<projectUrl>https://jumoo.co.uk/usync</projectUrl>
 		<description>uSync from Umbraco CMS</description>
 		<releaseNotes>9.0 - Dotnet core version</releaseNotes>
 		<copyright>Jumoo @ 2013-2021</copyright>


### PR DESCRIPTION
If you click on the project URL when viewing the NuGet package in Visual Studio, you get a 404 error.  That's because it's using https://jumoo.co.uk/uSync which doesn't work, the URL needs to be https://jumoo.co.uk/usync (lower case u).  I have therefore updated the URL with a lower case u to fix that.