### PR TITLE
V15/root merge fix

### DIFF
--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -17,7 +17,7 @@ public static class uSyncActionExtensions
     ///  does this list of actions have any that in an error state?
     /// </summary>
     public static bool ContainsErrors(this IEnumerable<uSyncAction> actions)
-        => actions.Any(x => x.Change >= Core.ChangeType.Fail || !x.Success);
+        => actions.Any(x => x.Change != Core.ChangeType.Hidden && x.Change >= Core.ChangeType.Fail || !x.Success);
 
     /// <summary>
     ///  count how many actions in this list are for changes

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1088,7 +1088,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
                     var differences = syncFileService.GetDifferences(nodes, trackers.FirstOrDefault());
                     if (differences is not null && differences.HasElements)
                     {
-                        await syncFileService.SaveXElementAsync(attempt.Item, filename);
+                        await syncFileService.SaveXElementAsync(differences, filename);
                     }
                     else
                     {

--- a/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
+++ b/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
@@ -27,16 +27,11 @@ internal class BlockGridConfigMerger : BlockListMergerBase, ISyncConfigMerger
         if (rootConfig is null) return target;
         if (targetConfig is null) return root;
 
+        // merge groups
+        targetConfig["blockGroups"] = MergeGroups(rootConfig, targetConfig);
+
         // merge blocks 
         targetConfig["blocks"] = GetMergedBlocks(rootConfig, targetConfig);
-
-        // merge block groups
-        rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
-        targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
-
-        var mergedGroups = MergeJsonArrays(rootGroups, targetGroups, "name", "name");
-        if (mergedGroups?.Count > 0)
-            targetConfig["blockGroups"] = mergedGroups;
 
         return targetConfig;
     }
@@ -49,17 +44,31 @@ internal class BlockGridConfigMerger : BlockListMergerBase, ISyncConfigMerger
         if (targetConfig is null) return target;
         if (rootConfig is null) return target;
 
+        // differences in block groups
+        targetConfig["blockGroups"] = GetGroupDiffrences(rootConfig, targetConfig);
+
         // differences in blocks
         targetConfig["blocks"] = GetBlockDifferences(rootConfig, targetConfig);
 
-        // differences in block groups
+
+        return targetConfig;
+    }
+
+    private static JsonArray GetGroupDiffrences(JsonObject rootConfig, JsonObject targetConfig)
+    {
         rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
         targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
 
         var groupDiffrences = GetJsonArrayDifferences(rootGroups, targetGroups, "name", "name");
-        if (groupDiffrences?.Count > 0)
-            targetConfig["blockGroups"] = groupDiffrences;
-
-        return targetConfig;
+        return groupDiffrences ?? [];
     }
+
+    private static JsonArray MergeGroups(JsonObject rootConfig, JsonObject targetConfig)
+    {
+        rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
+        targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
+        var mergedGroups = MergeJsonArrays(rootGroups, targetGroups, "name", "name");
+        return mergedGroups ?? [];
+    }
+
 }

--- a/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
+++ b/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
@@ -33,8 +33,10 @@ internal class BlockGridConfigMerger : BlockListMergerBase, ISyncConfigMerger
         // merge block groups
         rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
         targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
-        targetConfig["blockGroups"] = MergeJsonArrays(rootGroups, targetGroups,
-                        "name", "name") ?? [];
+
+        var mergedGroups = MergeJsonArrays(rootGroups, targetGroups, "name", "name");
+        if (mergedGroups?.Count > 0)
+            targetConfig["blockGroups"] = mergedGroups;
 
         return targetConfig;
     }
@@ -54,8 +56,9 @@ internal class BlockGridConfigMerger : BlockListMergerBase, ISyncConfigMerger
         rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
         targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
 
-        targetConfig["blockGroups"] = GetJsonArrayDifferences(rootGroups, targetGroups,
-                                    "name", "name") ?? [];
+        var groupDiffrences = GetJsonArrayDifferences(rootGroups, targetGroups, "name", "name");
+        if (groupDiffrences?.Count > 0)
+            targetConfig["blockGroups"] = groupDiffrences;
 
         return targetConfig;
     }

--- a/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
+++ b/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Nodes;
+﻿using Json.More;
+
+using System.Text.Json.Nodes;
 
 using Umbraco.Extensions;
 
@@ -93,7 +95,7 @@ internal class SyncConfigMergerBase
             targetOnly.Add(removedItem.Value);
         }
 
-        return [.. targetOnly];
+        return targetOnly.ToJsonArray();
     }
 
     protected static JsonArray? MergeJsonArrays(JsonArray? sourceArray, JsonArray? targetArray, string key, string removeProperty)
@@ -112,7 +114,7 @@ internal class SyncConfigMergerBase
             if (sourceObject.TryGetPropertyAsObject(key, out var sourceKey) is false) continue;
 
             var targetObject = targetArray.FirstOrDefault(
-                x => (x as JsonObject)?.TryGetPropertyAsObject(key, out var targetKey) == true && targetKey == sourceKey) as JsonObject;
+                x => (x as JsonObject)?.TryGetPropertyAsObject(key, out var targetKey) == true && targetKey.GetValueAsString(key) == sourceKey.GetValueAsString(key)) as JsonObject;
 
             if (targetObject is null)
             {


### PR DESCRIPTION
fixes datatypes blocklist and blockgrid merging for root sites. 

the merge was failing silently, when the JsonObjects where being put backinto the merged array, 
the update here fixes that.