### PR TITLE
Fix #722 - Contain based types don't delete since we moved delete to …

### DIFF
--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -70,4 +70,16 @@ public static class uSyncActionExtensions
         action = actions.FirstOrDefault(x => $"{x.Key}_{x.HandlerAlias}" == $"{key}_{handlerAlias}", new uSyncAction { Key = Guid.Empty });
         return action.Key != Guid.Empty;
     }
+
+
+    public static List<uSyncAction> Merge(this List<uSyncAction> a, List<uSyncAction> b)
+    {
+        // quicker than doing all that link.
+        if (b.Count == 0) return a;
+        if (a.Count == 0) return b;
+
+        // everythin that is in a but not b.
+        var actions = a.Where(x => b.Any(y => x.Key == y.Key && x.HandlerAlias == y.HandlerAlias) is false).ToList();
+        return [.. actions, .. b];
+    }
 }

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -193,7 +193,9 @@ internal class SyncActionService : ISyncActionService
 
         request.Callbacks?.Update?.Invoke("Process completed", 1, 1);
 
-        return new SyncActionResult(request.Actions.ToList());
+        // for speed we return an empty list. the merge will just take 
+        // what we where passed in, and we avoid a whole copy and compare step
+        return new SyncActionResult([]);
     }
 
     public Stream GetExportFolderAsStream()

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -275,7 +275,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
             options.Callbacks?.Update?.Invoke($"Importing {Path.GetFileNameWithoutExtension(item.Path)}", count, total);
 
-            var result = await ImportElementAsync(item.Node, item.Path, config, options);
+            var result = await ImportElementAsync(item.Node, item.FileName, config, options);
             foreach (var attempt in result)
             {
                 if (attempt.Success)

--- a/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
@@ -221,7 +221,7 @@ internal class uSyncManagementService : ISyncManagementService
         return new PerformActionResponse
         {
             RequestId = requestId.ToString(),
-            Actions = allActions.Select(x => x.ToActionView()),
+            Actions = allActions.Where(x => x.Change != Core.ChangeType.Hidden).Select(x => x.ToActionView()),
             // results.Actions.Select(x => x.ToActionView()),
             Status = GetSummaries(action, handlers, actionRequest.StepNumber, allActions), // results.Actions.ToList()),
             Complete = false
@@ -243,16 +243,21 @@ internal class uSyncManagementService : ISyncManagementService
             Username = username ?? ""
         };
 
+        List<uSyncAction> actionResults = [.. finalActions];
+
         foreach (var step in finalSteps)
         {
+            request.Actions = actionResults;
             var result = await step(request);
+            // merge the actions here...
+            actionResults = actionResults.Merge(result.Actions);
         }
 
         // when complete we clean out our action cache.
         _syncManagementCache.Clear(requestId);
 
         callbacks?.Update?.Invoke("Finished", 1, 1);
-        return finalActions;
+        return [.. actionResults.Where(x => x.Change != Core.ChangeType.Hidden)];
     }
 
     private IEnumerable<Func<SyncFinalActionRequest, Task<SyncActionResult>>> GetFinalStep(HandlerActions action)

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -17,7 +17,7 @@ using uSync.Core.Models;
 
 namespace uSync.Core.Serialization.Serializers;
 
-[SyncSerializer("B3F7F247-6077-406D-8480-DB1004C8211C", "ContentTypeSerializer", uSyncConstants.Serialization.ContentType)]
+[SyncSerializer("B3F7F247-6077-406D-8480-DB1004C8211C", "ContentTypeSerializer", uSyncConstants.Serialization.ContentType, IsTwoPass = true)]
 public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, ISyncSerializer<IContentType>
 {
     private readonly IContentTypeService _contentTypeService;

--- a/uSync.Core/Serialization/Serializers/MediaTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaTypeSerializer.cs
@@ -16,7 +16,7 @@ using uSync.Core.Models;
 
 namespace uSync.Core.Serialization.Serializers;
 
-[SyncSerializer("B3073706-5037-4FBD-A015-DF38D61F2934", "MediaTypeSerializer", uSyncConstants.Serialization.MediaType)]
+[SyncSerializer("B3073706-5037-4FBD-A015-DF38D61F2934", "MediaTypeSerializer", uSyncConstants.Serialization.MediaType, IsTwoPass = true)]
 public class MediaTypeSerializer : ContentTypeBaseSerializer<IMediaType>, ISyncSerializer<IMediaType>
 {
     private readonly IMediaTypeService _mediaTypeService;

--- a/uSync.Core/Serialization/Serializers/MemberTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MemberTypeSerializer.cs
@@ -16,7 +16,7 @@ using uSync.Core.Models;
 
 namespace uSync.Core.Serialization.Serializers;
 
-[SyncSerializer("F45B5C7B-C206-4971-858B-6D349E153ACE", "MemberTypeSerializer", uSyncConstants.Serialization.MemberType)]
+[SyncSerializer("F45B5C7B-C206-4971-858B-6D349E153ACE", "MemberTypeSerializer", uSyncConstants.Serialization.MemberType, IsTwoPass = true)]
 public class MemberTypeSerializer : ContentTypeBaseSerializer<IMemberType>, ISyncSerializer<IMemberType>
 {
     private readonly IMemberTypeService _memberTypeService;


### PR DESCRIPTION
When we moved the delete's for content types, media types to a last action 
(to fix a race where delete could happening after something that might recreate an item in a diffrent location). it stopped them firing because we didn't mark the types as two pass (so they didn't fire the delete 🤦 ).

Fixed here, along with other things like accurate reporting of the delete as a second action and not showing the action as 'hidden' which is what we do mid step so it gets pushed to the end.
