### PR TITLE
blank the merged blockgroups if they are blank (makes the compare slightly better

### DIFF
--- a/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
+++ b/uSync.Core/Roots/Configs/BlockGridConfigMerger.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Collections.Immutable;
+using System.Text.Json.Nodes;
 
 using Umbraco.Cms.Core;
 
@@ -54,21 +55,21 @@ internal class BlockGridConfigMerger : BlockListMergerBase, ISyncConfigMerger
         return targetConfig;
     }
 
-    private static JsonArray GetGroupDiffrences(JsonObject rootConfig, JsonObject targetConfig)
+    private static JsonArray? GetGroupDiffrences(JsonObject rootConfig, JsonObject targetConfig)
     {
         rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
         targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
 
         var groupDiffrences = GetJsonArrayDifferences(rootGroups, targetGroups, "name", "name");
-        return groupDiffrences ?? [];
+        return groupDiffrences?.Count > 0 ? groupDiffrences : null;
     }
 
-    private static JsonArray MergeGroups(JsonObject rootConfig, JsonObject targetConfig)
+    private static JsonArray? MergeGroups(JsonObject rootConfig, JsonObject targetConfig)
     {
         rootConfig.TryGetPropertyAsArray("blockGroups", out var rootGroups);
         targetConfig.TryGetPropertyAsArray("blockGroups", out var targetGroups);
         var mergedGroups = MergeJsonArrays(rootGroups, targetGroups, "name", "name");
-        return mergedGroups ?? [];
+        return mergedGroups?.Count > 0 ? mergedGroups : null;
     }
 
 }

--- a/uSync.Core/Roots/Configs/BlockListMergerBase.cs
+++ b/uSync.Core/Roots/Configs/BlockListMergerBase.cs
@@ -6,21 +6,25 @@ namespace uSync.Core.Roots.Configs;
 
 internal abstract class BlockListMergerBase : SyncConfigMergerBase
 {
-    protected JsonArray GetMergedBlocks(JsonObject rootConfig, JsonObject targetConfig)
+    protected JsonArray? GetMergedBlocks(JsonObject rootConfig, JsonObject targetConfig)
     {
         rootConfig.TryGetPropertyAsArray("blocks", out var rootBlocks);
         targetConfig.TryGetPropertyAsArray("blocks", out var targetBlocks);
 
-        return MergeJsonArrays(rootBlocks, targetBlocks,
-            "contentElementTypeKey", "label") ?? [];
+        var merged = MergeJsonArrays(rootBlocks, targetBlocks,
+            "contentElementTypeKey", "label");
+
+        return merged?.Count > 0 ? merged : null;
     }
 
-    protected JsonArray GetBlockDifferences(JsonObject rootConfig, JsonObject targetConfig)
+    protected JsonArray? GetBlockDifferences(JsonObject rootConfig, JsonObject targetConfig)
     {
         rootConfig.TryGetPropertyAsArray("blocks", out var rootBlocks);
         targetConfig.TryGetPropertyAsArray("blocks", out var targetBlocks);
 
-        return GetJsonArrayDifferences(rootBlocks, targetBlocks,
+        var diffrences = GetJsonArrayDifferences(rootBlocks, targetBlocks,
                         "contentElementTypeKey", "label") ?? [];
+
+        return diffrences?.Count > 0 ? diffrences : null;
     }
 }


### PR DESCRIPTION
Doesn't change how the merge works, but if the blockgroup is empty we write 'null' just means the compares are less likely to throw up false positives (they still will sometimes, because of sort order)