### PR TITLE
Fix: Dependencies checks for blocks not passing correct value to sub dependencies.

### DIFF
--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -167,7 +167,9 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
         {
             var property = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == value.Alias);
             if (property == null) continue;
-            dependencies.AddRange(await _mapperCollection.Value.GetDependenciesAsync(value, property.PropertyEditorAlias, flags));
+
+            if (value.Value is null) continue;
+            dependencies.AddRange(await _mapperCollection.Value.GetDependenciesAsync(value.Value, property.PropertyEditorAlias, flags));
         }
         return dependencies;
     }


### PR DESCRIPTION
TLDR: Fixes media items not being picked up as dependencies of block items when pushing between servers (uSync.Complete)