### PR TITLE
V15/first import fixes

### DIFF
--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -20,6 +20,12 @@ public static class uSyncActionExtensions
         => actions.Any(x => x.Change != Core.ChangeType.Hidden && x.Change >= Core.ChangeType.Fail || !x.Success);
 
     /// <summary>
+    ///  does this list of actions have any that in an error state?
+    /// </summary>
+    public static int CountErrors(this IEnumerable<uSyncAction> actions)
+        => actions.Count(x => x.Change != Core.ChangeType.Hidden && x.Change >= Core.ChangeType.Fail || !x.Success);
+
+    /// <summary>
     ///  count how many actions in this list are for changes
     /// </summary>
     public static int CountChanges(this IEnumerable<uSyncAction> actions)

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -192,7 +192,7 @@ public partial class SyncService : ISyncService
         handlerOptions ??= new SyncHandlerOptions();
         handlerOptions.Action = HandlerActions.Import;
         var handlers = _handlerFactory.GetValidHandlers(handlerOptions);
-        
+
         var changes = await ImportAsync(folders, force, handlers, handlerOptions, callbacks);
 
         // on first boot, we refresh the snapshot cache if we have imported any content 
@@ -200,7 +200,7 @@ public partial class SyncService : ISyncService
         if (changes.Any(x => x.Change > ChangeType.NoChange && x.ItemType == "IContent"))
             _distributedCache.RefreshAllPublishedSnapshot();
 
-        return changes; 
+        return changes;
     }
 
     /// <inheritdoc/>>
@@ -269,6 +269,9 @@ public partial class SyncService : ISyncService
                 actions.Count,
                 actions.CountChanges(),
             sw.ElapsedMilliseconds);
+
+            if (actions.ContainsErrors())
+                _logger.LogWarning("uSync Import: Errors detected in import : {count}", actions.CountErrors());
 
             callbacks?.Update?.Invoke($"Processed {actions.Count} items in {sw.ElapsedMilliseconds}ms", 1, 1);
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -252,7 +252,7 @@ public abstract class SyncHandlerBase<TObject>
         // logger.LogDebug("Cache miss [{key}]", cacheKey);
         if (key == Guid.Empty)
         {
-            var result = await Task.FromResult(entityService.GetChildren(null, objectType));
+            var result = entityService.GetChildren(-1, objectType);
             return result;
         }
         else

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -102,6 +102,9 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             item = attempt.Result;
             details.AddNew(alias, alias, "Template");
             logger.LogDebug("New Template: {alias} {path}", item.Alias, item.Path);
+
+            // don't need to go through the process, the create also saves it.
+            return SyncAttempt<ITemplate>.Succeed(name, item, ChangeType.Import, "Created", true, details);
         }
 
         if (item is null)
@@ -306,25 +309,17 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     {
         var userKey = Constants.Security.SuperUserKey;
 
-        var existing = await _templateService.GetAsync(item.Alias);
-        if (existing is not null)
+        if (item.HasIdentity)
         {
-            item.Key = existing.Key;
-            item.Id = existing.Id;
-            item.CreateDate = existing.CreateDate;
-            item.UpdateDate = existing.UpdateDate;
-        }
-
-        logger.LogDebug("Saving: {alias} {path}", item.Alias, item.Path);
-
-        if (existing is null)
-        {
-            var result = await _templateService.CreateAsync(item.Name ?? item.Alias, item.Alias, item.Content, userKey, item.Key);
-            logger.LogDebug("Create Template Result: [{key}] {result} {status}", result.Result.Key, result.Success, result.Status);
+            // update
+            logger.LogDebug("Saving: {alias} {path}", item.Alias, item.Path);
+            var result = await _templateService.UpdateAsync(item, userKey);
+            logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
         }
         else
         {
-            var result = await _templateService.UpdateAsync(item, userKey);
+            logger.LogDebug("Creating: {alias} {path}", item.Alias, item.Path);
+            var result = await _templateService.CreateAsync(item.Name ?? item.Alias, item.Alias, item.Content, userKey, item.Key);
             logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
         }
     }

--- a/uSync.Core/Serialization/SyncContainerSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncContainerSerializerBase.cs
@@ -229,6 +229,7 @@ public abstract class SyncContainerSerializerBase<TObject>
         if (entityTypeContainerTypeService is null) return Attempt<EntityContainer?, EntityContainerOperationStatus>.Fail(EntityContainerOperationStatus.InvalidObjectType);
 
         int parentLevel = 1;
+        int parentId = -1;
         Guid? parentKeyValue = parentKey == Guid.Empty ? null : parentKey;
 
         if (parentKeyValue is not null)
@@ -237,20 +238,17 @@ public abstract class SyncContainerSerializerBase<TObject>
             if (parent is null || parent.Name is null)
                 return Attempt<EntityContainer?, EntityContainerOperationStatus>.Fail(EntityContainerOperationStatus.ParentNotFound);
 
+            parentId = parent.Id;
             parentLevel = parent.Level;
         }
 
-        var existing = (await entityTypeContainerTypeService.GetAsync(name, parentLevel)).FirstOrDefault(x => x.Name.InvariantEquals(name));
-        if (existing is null || existing.Name is null)
-        {
-            var result = await entityTypeContainerTypeService.CreateAsync(Guid.NewGuid(), name, parentKeyValue, Constants.Security.SuperUserKey);
-            return result;
-        }
-        else
-        {
-            var result = await entityTypeContainerTypeService.UpdateAsync(existing.Key, existing.Name, Constants.Security.SuperUserKey);
-            return result;
-        }
+        var existing = (await entityTypeContainerTypeService.GetAsync(name, parentLevel))
+            .FirstOrDefault(x => x.Name.InvariantEquals(name) && (parentId == -1 || x.ParentId == parentId));
+
+        var result = existing?.Name is null 
+            ? await entityTypeContainerTypeService.CreateAsync(Guid.NewGuid(), name, parentKeyValue, Constants.Security.SuperUserKey)
+            : await entityTypeContainerTypeService.UpdateAsync(existing.Key, existing.Name, Constants.Security.SuperUserKey);
+        return result;
     }
 
     protected virtual async Task<EntityContainer?> FindFolderAsync(Guid key, string path)


### PR DESCRIPTION
Not 100% sure why, but during startup we added code to check for empty containers (so empty folders in doctypes, datatypes etc).

by extension this code runs on firstboot (although strictly it shouldn't be needed).

during the cleaning of datatypes we start at the root folder, and we pass in 'null' as the guid value to `entityService.GetChildren`. 

some debugging later - if we use the other overloaded method and pass in -1 (old school root id) then the import works. 

I am guessing some caching is happening and the guid to id lookups that are in the core are causing something to happen on this first boot, that means we loose sight of the things. 

