### PR TITLE
V15/boot on appstarting fix

### DIFF
--- a/uSync.BackOffice/Boot/FirstBootMigration.cs
+++ b/uSync.BackOffice/Boot/FirstBootMigration.cs
@@ -59,7 +59,6 @@ public class FirstBootMigration : MigrationBase
         // first boot migration. 
         try
         {
-
             if (!_uSyncConfig.Settings.ImportOnFirstBoot)
                 return;
 

--- a/uSync.BackOffice/Boot/uSyncBootExtension.cs
+++ b/uSync.BackOffice/Boot/uSyncBootExtension.cs
@@ -36,7 +36,7 @@ internal static class uSyncBootExtension
         });
 
         // add notification handler to do the actual first boot run. 
-        builder.AddNotificationHandler<UmbracoApplicationStartedNotification, FirstBootAppStartingHandler>();
+        builder.AddNotificationHandler<UmbracoApplicationStartingNotification, FirstBootAppStartingHandler>();
 
         return builder;
     }
@@ -46,7 +46,7 @@ internal static class uSyncBootExtension
 ///  Handler to mange app starting for first boot migrations 
 /// </summary>
 internal class FirstBootAppStartingHandler
-    : INotificationHandler<UmbracoApplicationStartedNotification>
+    : INotificationHandler<UmbracoApplicationStartingNotification>
 {
 
     private readonly ICoreScopeProvider _scopeProvider;
@@ -69,7 +69,7 @@ internal class FirstBootAppStartingHandler
 
 
     /// <inheritdoc/>
-    public void Handle(UmbracoApplicationStartedNotification notification)
+    public void Handle(UmbracoApplicationStartingNotification notification)
     {
         if (_runtimeState.Level != Umbraco.Cms.Core.RuntimeLevel.Run) return;
 

--- a/uSync.BackOffice/Notifications/uSyncApplicationStartingHandler.cs
+++ b/uSync.BackOffice/Notifications/uSyncApplicationStartingHandler.cs
@@ -22,7 +22,7 @@ namespace uSync.BackOffice.Notifications;
 /// <summary>
 ///  Run uSync tasks when the site has started up. 
 /// </summary>
-internal class uSyncApplicationStartingHandler : INotificationAsyncHandler<UmbracoApplicationStartedNotification>
+internal class uSyncApplicationStartingHandler : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
 {
     private readonly ILogger<uSyncApplicationStartingHandler> _logger;
     private readonly IRuntimeState _runtimeState;
@@ -60,7 +60,7 @@ internal class uSyncApplicationStartingHandler : INotificationAsyncHandler<Umbra
     /// <summary>
     ///  Handle the application starting notification event.
     /// </summary>
-    public async Task HandleAsync(UmbracoApplicationStartedNotification notification, CancellationToken cancellationToken)
+    public async Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
     {
         // we only run uSync when the site is running, and we 
         // are not running on a replica.

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -76,7 +76,7 @@ public static class uSyncBackOfficeBuilderExtensions
         builder.AdduSyncFirstBoot();
 
         // register for the notifications 
-        builder.AddNotificationAsyncHandler<UmbracoApplicationStartedNotification, uSyncApplicationStartingHandler>();
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, uSyncApplicationStartingHandler>();
         builder.AddHandlerNotifications();
 
         builder.Services.AddSingleton<uSyncHubRoutes>();

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -251,7 +251,7 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     public override async Task<SyncAttempt<ITemplate>> DeserializeSecondPassAsync(ITemplate item, XElement node, SyncSerializerOptions options)
     {
         var details = new List<uSyncChange>();
-        var saved = false;
+        var saved = true;
 
         if (ViewsAreCompiled(options))
         {

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Lucene.Net.Queries.Function.ValueSources;
+
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -212,6 +214,21 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
 
     public string GetContentFromFile(string templatePath)
     {
+        try
+        {
+            var templateFilePath = _viewFileSystem?.GetFullPath(templatePath);
+            if (System.IO.File.Exists(templateFilePath) is true)
+            {
+                // read it locally, (quicker less likely to lock).
+                return System.IO.File.ReadAllText(templateFilePath);
+            }
+        }
+        catch(Exception ex)
+        {
+            logger.LogWarning(ex, "Error reading template, will read from filesystem provider instead");
+        }
+        
+        // via the file system, which does work, but occasionaly it locks.
         var content = "";
         using (var stream = _viewFileSystem?.OpenFile(templatePath))
         {


### PR DESCRIPTION
Moving the startup events back from ApplicationStarted to ApplicationStarting. 

there is something odd between starting and started (even though they are like two lines of code appart).

If firstboot or Import at startup, run via started then the content is in the backoffice, but not on the front end (and i've tried to refresh cachese, databases etc). 

if we move this 'back' to ApplicationStarting, then it works and the content is there. 

I created static code to create a doctype, template and content page and it behaves the sameway, so i don't think its a uSync thing rather a caching somewhere in umbraco thing. 

anyway, we originally moved from Starting to Started in v10 release candidates because something about localization and the dictionary was off, but its better to have that issue then have the content not there (and i am not even sure that is an issue anymore)(.

related to #738 - this means the content actually shows up reliably on the front end too! 