### PR TITLE
fix #749 - be less agressive when tiding up value json.

### DIFF
--- a/uSync.Core/Mapping/SyncValueMapperCollection.cs
+++ b/uSync.Core/Mapping/SyncValueMapperCollection.cs
@@ -95,8 +95,9 @@ public class SyncValueMapperCollection
     /// </summary>
     private static string GetCleanFlatJson(string stringValue)
     {
-        if (stringValue.TryConvertToJsonNode(out var result) is false || result is null)
-            return stringValue.Trim(_trimChars);
+        // fix #749 be less aggressive about cleaning up json (let strings be strings)
+        if (stringValue.TryParseToJsonNode(out var result) is false || result is null)
+            return stringValue;
 
         if (result.TrySerializeJsonNode(out var jsonString, indent: false) is true)
             return jsonString.Trim(_trimChars);


### PR DESCRIPTION
fixed #749, by not tring to clean everything as if its json. 

previously we would clean all values and assume they were json, and trim them, when the string value contains quotes (e.g "'one'") this would end up with encoding in the value or removing trailing quotes when we didn't want them (e.g "this is a string 'one'" would become "this is a string 'one")

this stops that, i don't think there are cases where we actually expected the string to be treated as its own bit of json so we should be ok.
