### PR TITLE
force all xelement load and save's via the fileservice,

### DIFF
--- a/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
+++ b/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
@@ -85,7 +85,7 @@ public class SyncFolderIntegrityChecks : HealthCheck
         }
     }
 
-    private static List<string> CheckFolder(string folder)
+    private List<string> CheckFolder(string folder)
     {
         var _keys = new Dictionary<Guid, string>();
 
@@ -97,7 +97,7 @@ public class SyncFolderIntegrityChecks : HealthCheck
         {
             try
             {
-                var node = XElement.Load(file);
+                var node = _fileService.LoadXElementAsync(file).Result;
 
                 if (!node.IsEmptyItem())
                 {
@@ -146,7 +146,7 @@ public class SyncFolderIntegrityChecks : HealthCheck
         {
             try
             {
-                var node = XElement.Load(file);
+                var node = _fileService.LoadXElementAsync(file).Result;
             }
             catch (Exception ex)
             {

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 
 using Umbraco.Cms.Core.Extensions;
@@ -196,7 +197,10 @@ internal class SyncFileService : ISyncFileService
                 if (stream is null)
                     throw new FileNotFoundException($"Cannot create stream for {file}"); ;
 
-                return await XElement.LoadAsync(stream, LoadOptions.PreserveWhitespace, CancellationToken.None);
+                using (var xmlReader = XmlReader.Create(stream, _readerSettings))
+                {
+                    return await XElement.LoadAsync(xmlReader, LoadOptions.PreserveWhitespace, CancellationToken.None);    
+                }
             }
         }
         catch (Exception ex)
@@ -234,13 +238,33 @@ internal class SyncFileService : ISyncFileService
         }
     }
 
+    private static XmlReaderSettings _readerSettings = new XmlReaderSettings
+    {
+        CheckCharacters = false,
+        Async = true,
+    };
+
+    private static XmlWriterSettings _writerSettings = new XmlWriterSettings
+    {
+        Encoding = Encoding.UTF8,
+        CheckCharacters = false,
+        Async = true,
+        CloseOutput= false,
+        Indent = true,
+        
+
+    };
+
     /// <inheritdoc/>
     public async Task SaveXElementAsync(XElement node, string filename)
     {
         var localPath = GetAbsPath(filename);
         using (var stream = OpenWrite(localPath))
         {
-            await node.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
+            using (var writer = XmlWriter.Create(stream, _writerSettings))
+            {
+                await node.SaveAsync(writer, CancellationToken.None);
+            }
             await stream.FlushAsync();
             stream.Dispose();
         }
@@ -326,7 +350,7 @@ internal class SyncFileService : ISyncFileService
         {
             try
             {
-                var node = XElement.Load(file);
+                var node = LoadXElementAsync(file).Result;
 
                 if (!node.IsEmptyItem())
                 {
@@ -496,7 +520,7 @@ internal class SyncFileService : ISyncFileService
         }
         catch (Exception ex)
         {
-            // 1. diffrences shouldn't stop the process, they are nice to have but 
+            // 1. differences shouldn't stop the process, they are nice to have but 
             // not critical. 
             _logger.LogWarning(ex, "Error getting differences");
             return null;

--- a/uSync.BackOffice/Services/SyncService_Single.cs
+++ b/uSync.BackOffice/Services/SyncService_Single.cs
@@ -106,7 +106,7 @@ public partial class SyncService
                     {
                         foreach (var item in orderedNodes.Skip(options.PageNumber * options.PageSize).Take(options.PageSize))
                         {
-                            var node = item.Node ?? XElement.Load(item.FileName);
+                            var node = item.Node ?? await _syncFileService.LoadXElementAsync(item.FileName);
 
                             var itemType = node.GetItemType();
                             if (!itemType.InvariantEquals(lastType))

--- a/uSync.BackOffice/SyncHandlers/Handlers/LanguageHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/LanguageHandler.cs
@@ -90,7 +90,7 @@ public class LanguageHandler : SyncHandlerBase<ILanguage>, ISyncHandler,
             Dictionary<string, string> ordered = [];
             foreach (var file in files)
             {
-                var node = XElement.Load(file);
+                var node = syncFileService.LoadXElementAsync(file).Result;
                 var order = (node.Element("IsDefault").ValueOrDefault(false) ? "0" : "1") + Path.GetFileName(file);
                 ordered[file] = order;
             }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -651,7 +651,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
             foreach (var file in files)
             {
-                var node = XElement.Load(file);
+                var node = syncFileService.LoadXElementAsync(file).Result;
                 var key = node.GetKey();
                 if (key != Guid.Empty && !keys.Contains(key))
                 {
@@ -678,7 +678,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// </summary>
     protected async Task<TObject?> GetCleanParentAsync(string file)
     {
-        var node = XElement.Load(file);
+        var node = await syncFileService.LoadXElementAsync(file);
         var key = node.GetKey();
         if (key == Guid.Empty) return default;
         return await GetFromServiceAsync(key);
@@ -1294,7 +1294,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         {
             if (actions[i].Change != ChangeType.ParentMissing || actions[i].FileName is null) continue;
 
-            var node = XElement.Load(actions[i].FileName!);
+            var node = syncFileService.LoadXElementAsync(actions[i].FileName!).Result;
             var guid = node.GetParentKey();
 
             if (guid != Guid.Empty)


### PR DESCRIPTION
using the SyncFileService for the save / load of all XElement objects. 

this means we can add settings so we ignore invalid charecters for xml as part of the save and load. 
so in rare circumstances things with escape characters in them will still save and load as part of uSync. 

it does mean these files might not be strictly valid xml and fail to parse in other tools but they will work as text files and as part of the sync.