### PR TITLE
V16/rte migrations

### DIFF
--- a/uSync.BackOffice/Configuration/ISyncFolder.cs
+++ b/uSync.BackOffice/Configuration/ISyncFolder.cs
@@ -1,0 +1,27 @@
+﻿namespace uSync.BackOffice.Configuration;
+
+/// <summary>
+///  folder type to define a folder for the site. 
+/// </summary>
+public interface ISyncFolder
+{
+    /// <summary>
+    ///  path to the folder we want to use. 
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    ///  weight in the list. 
+    /// </summary>
+    int Weight { get; }
+}
+
+
+
+/*
+public class TestSyncFolder: ISyncFolder
+{
+    public string Path => "uSync/TestFolder";
+    public int Weight => 100;
+}
+*/

--- a/uSync.BackOffice/Configuration/SyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/SyncConfigService.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.Extensions.Options;
 
+using System.Collections.Generic;
 using System.Linq;
+
+using Umbraco.Extensions;
 
 namespace uSync.BackOffice.Configuration;
 
@@ -8,6 +11,7 @@ namespace uSync.BackOffice.Configuration;
 internal class SyncConfigService : ISyncConfigService
 {
     private readonly IOptionsMonitor<uSyncHandlerSetSettings> _setOptionsMonitor;
+    private readonly SyncFolderCollection _syncFolders;
 
     /// <inheritdoc/>
     public uSyncSettings Settings { get; private set; }
@@ -17,7 +21,8 @@ internal class SyncConfigService : ISyncConfigService
     /// </summary>
     public SyncConfigService(
         IOptionsMonitor<uSyncSettings> settingsOptionsMonitor,
-        IOptionsMonitor<uSyncHandlerSetSettings> setOptionsMonitor)
+        IOptionsMonitor<uSyncHandlerSetSettings> setOptionsMonitor,
+        SyncFolderCollection syncFolders)
     {
         Settings = settingsOptionsMonitor.CurrentValue;
 
@@ -27,20 +32,56 @@ internal class SyncConfigService : ISyncConfigService
         });
 
         _setOptionsMonitor = setOptionsMonitor;
+        _syncFolders = syncFolders;
+    }
 
+    private string[] FetchFolders()
+    {
+        var folders = Settings.Folders
+            .Select((x, index) => new SyncFolderItem
+            {
+                Path = x.TrimStart('/').EnsureEndsWith('/'),
+                Weight = index * 1000
+            })
+            .ToList();
+
+        folders.AddRange(
+        _syncFolders.Select(x => new SyncFolderItem
+        {
+            Path = x.Path.TrimStart('/').EnsureEndsWith('/'),
+            Weight = x.Weight
+        }));
+
+        return folders.OrderBy(x => x.Weight)
+            .Select(x => x.Path)
+            .ToArray();
+    }
+
+    private class SyncFolderItem
+    {
+        public required string Path { get; set; }
+        public int Weight { get; set; }
     }
 
     /// <inheritdoc/>
     public string GetWorkingFolder()
-        => Settings.IsRootSite
-            ? Settings.Folders[0].TrimStart('/')
-            : Settings.Folders.Last().TrimStart('/');
+    {
+        var folders = FetchFolders();
+
+        return Settings.IsRootSite
+            ? folders[0].TrimStart('/')
+            : folders.Last().TrimStart('/');
+    }
 
     /// <inheritdoc/>
     public string[] GetFolders()
-        => Settings.IsRootSite
-            ? [Settings.Folders[0].TrimStart('/')]
-            : [.. Settings.Folders.Select(x => x.TrimStart('/'))];
+    {
+        var folders = FetchFolders();
+
+        return Settings.IsRootSite
+            ? [folders[0].TrimStart('/')]
+            : [.. folders.Select(x => x.TrimStart('/'))];
+    }
 
     /// <inheritdoc/>
     public uSyncHandlerSetSettings GetSetSettings(string setName)

--- a/uSync.BackOffice/Configuration/SyncFolderCollection.cs
+++ b/uSync.BackOffice/Configuration/SyncFolderCollection.cs
@@ -1,0 +1,37 @@
+﻿using J2N.Collections.Generic.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core.Composing;
+
+namespace uSync.BackOffice.Configuration;
+
+/// <summary>
+///  collection of folders loaded from extensions, merged into the 
+///  folders from settings at runtime. 
+/// </summary>
+public class SyncFolderCollection : BuilderCollectionBase<ISyncFolder>
+{
+    public SyncFolderCollection(Func<IEnumerable<ISyncFolder>> items)
+        : base(items)
+    { }
+
+    /// <summary>
+    ///  returns an array of all the folders in the collection.
+    /// </summary>
+    /// <returns></returns>
+    public ISyncFolder[] GetFolders()
+        => this.ToArray();
+}
+
+/// <summary>
+///  collection builder to mange folders. 
+/// </summary>
+public class SyncFolderCollectionBuilder
+    : SetCollectionBuilderBase<SyncFolderCollectionBuilder, SyncFolderCollection, ISyncFolder>
+{
+    protected override SyncFolderCollectionBuilder This => this;
+}
+

--- a/uSync.BackOffice/Configuration/SyncFolderCollection.cs
+++ b/uSync.BackOffice/Configuration/SyncFolderCollection.cs
@@ -14,6 +14,7 @@ namespace uSync.BackOffice.Configuration;
 /// </summary>
 public class SyncFolderCollection : BuilderCollectionBase<ISyncFolder>
 {
+    /// <inheritdoc/>
     public SyncFolderCollection(Func<IEnumerable<ISyncFolder>> items)
         : base(items)
     { }
@@ -32,6 +33,8 @@ public class SyncFolderCollection : BuilderCollectionBase<ISyncFolder>
 public class SyncFolderCollectionBuilder
     : SetCollectionBuilderBase<SyncFolderCollectionBuilder, SyncFolderCollection, ISyncFolder>
 {
+
+    /// <inheritdoc/>
     protected override SyncFolderCollectionBuilder This => this;
 }
 

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using OpenIddict.Validation.AspNetCore;
 
@@ -60,6 +61,11 @@ public static class uSyncBackOfficeBuilderExtensions
         // Setup uSync core.
         builder.AdduSyncCore();
 
+        // folder collection, so you can inject folders into the sync process.
+        builder.WithCollectionBuilder<SyncFolderCollectionBuilder>()
+            .Add(builder.TypeLoader.GetTypes<ISyncFolder>());
+
+
         // Setup the back office.
         builder.Services.AddSingleton<ISyncEventService, SyncEventService>();
         builder.Services.AddSingleton<ISyncConfigService, SyncConfigService>();
@@ -89,6 +95,7 @@ public static class uSyncBackOfficeBuilderExtensions
         builder.Services.AddAuthorization(o => CreatePolicies(o));
 
         builder.Services.AddTransient<ISyncActionService, SyncActionService>();
+
 
         _ = builder.Services.PostConfigure<uSyncSettings>(options =>
         {

--- a/uSync.Backoffice.Management.Api/Controllers/Settings/uSyncSettingsController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Settings/uSyncSettingsController.cs
@@ -20,7 +20,11 @@ public class uSyncSettingsController : uSyncControllerBase
     [HttpGet("Settings")]
     [ProducesResponseType(typeof(uSyncSettings), 200)]
     public uSyncSettings GetSettings()
-        => _configService.Settings;
+    {
+        var settings = _configService.Settings;
+        settings.Folders = _configService.GetFolders();
+        return settings;
+    }
 
     [HttpGet("HandlerSettings")]
     [ProducesResponseType(typeof(uSyncHandlerSetSettings), 200)]

--- a/uSync.Core/DataTypes/ConfigurationSerializerCollectionBuilder.cs
+++ b/uSync.Core/DataTypes/ConfigurationSerializerCollectionBuilder.cs
@@ -23,4 +23,20 @@ public class ConfigurationSerializerCollection :
 
     public IEnumerable<IConfigurationSerializer> GetSerializers(string editorAlias)
         => this.Where(x => x.Editors.InvariantContains(editorAlias));
+
+    /// <summary>
+    ///  find the first serializer that returns a non-null UI alias.
+    /// </summary>
+    public string? GetEditorUIAlias(string editorAlias)
+    {
+        foreach (var serializer in GetSerializers(editorAlias))
+        {
+            var uiAlias = serializer.GetEditorUIAlias();
+            if (uiAlias.IsNullOrWhiteSpace() is false)
+            {
+                return uiAlias;
+            }
+        }
+        return null;
+    }
 }

--- a/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
@@ -1,14 +1,29 @@
-﻿using System.Collections.Immutable;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
 using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Extensions;
 
 using uSync.Core.Extensions;
 
 namespace uSync.Core.DataTypes.DataTypeSerializers;
 internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, IConfigurationSerializer
 {
+    private readonly TinyMceToTiptapMigrationSettings _options;
+
+    private readonly ILogger<RichTextEditorMigratingSerializer> _logger;
+
+    public RichTextEditorMigratingSerializer(IOptions<TinyMceToTiptapMigrationSettings> options, ILogger<RichTextEditorMigratingSerializer> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
     public string Name => nameof(RichTextEditorMigratingSerializer);
 
     public string[] Editors => [
@@ -23,11 +38,123 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
     public string? GetEditorAlias()
         => Constants.PropertyEditors.Aliases.RichText;
 
+    /// <summary>
+    ///  updates the editor UI alias to the new Tiptap one, if migration is enabled.
+    /// </summary>
+    public string? GetEditorUIAlias()
+    {
+        if (_options.DisableMigration is true) return null;
+        return "Umb.PropertyEditorUi.Tiptap";
+    }
+
     public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
     {
+        configuration = MigrateToTipTap(configuration);
         configuration = FixMediaParent(configuration);
         configuration = TopLevelEditor(configuration);
         return configuration.ToImmutableSortedDictionary();
+    }
+
+    private IDictionary<string, object> MigrateToTipTap(IDictionary<string, object> configuration)
+    {
+        if (_options.DisableMigration is true)
+            return configuration;
+
+        if (configuration.ContainsKey("mode") is false && configuration.ContainsKey("hideLabel") is false)
+        {
+            _logger.LogDebug("Skipping Tiptap migration as it does not contain 'mode' or 'hideLabel'.");   
+            // if both mode and hideLabel are not present, then this has probibly already been migrated
+            return configuration;
+        }
+
+        _logger.LogDebug("Migrating TinyMCE configuration to Tiptap format.");
+        // do the tip tap things. 
+
+        if (!configuration.TryGetValue("toolbar", out var toolbar) || toolbar is not List<string> toolBarList)
+        {
+            return configuration;
+        }
+
+        configuration.Remove("mode");
+        configuration.Remove("hideLabel");
+
+        var newToolbar = toolBarList.Select(MapToolbarItem).WhereNotNull().ToList();
+        configuration["toolbar"] = new List<List<List<string>>> { new() { newToolbar } };
+
+        var extensions = new List<string>
+        {
+            "Umb.Tiptap.RichTextEssentials",
+            "Umb.Tiptap.Embed",
+            "Umb.Tiptap.Figure",
+            "Umb.Tiptap.Image",
+            "Umb.Tiptap.Link",
+            "Umb.Tiptap.MediaUpload",
+            "Umb.Tiptap.Subscript",
+            "Umb.Tiptap.Superscript",
+            "Umb.Tiptap.Table",
+            "Umb.Tiptap.TextAlign",
+            "Umb.Tiptap.TextDirection",
+            "Umb.Tiptap.TextIndent",
+            "Umb.Tiptap.Underline"
+        };
+
+        if (configuration.TryGetValue("blocks", out var blocks) && blocks is not null)
+        {
+            // if there are blocks, we need to add the block extension
+            extensions.Add("Umb.Tiptap.Block");
+        }
+
+        configuration["extensions"] = extensions.ToArray();
+
+        return configuration;
+    }
+
+    private string? MapToolbarItem(string item)
+    {
+        return item switch
+        {
+            "undo" => "Umb.Tiptap.Toolbar.Undo",
+            "redo" => "Umb.Tiptap.Toolbar.Redo",
+            "cut" => null,
+            "copy" => null,
+            "paste" => null,
+            "styles" => "Umb.Tiptap.Toolbar.StyleSelect",
+            "fontname" => "Umb.Tiptap.Toolbar.FontFamily",
+            "fontfamily" => "Umb.Tiptap.Toolbar.FontFamily",
+            "fontsize" => "Umb.Tiptap.Toolbar.FontSize",
+            "forecolor" => "Umb.Tiptap.Toolbar.TextColorForeground",
+            "backcolor" => "Umb.Tiptap.Toolbar.TextColorBackground",
+            "blockquote" => "Umb.Tiptap.Toolbar.Blockquote",
+            "formatblock" => null,
+            "removeformat" => "Umb.Tiptap.Toolbar.ClearFormatting",
+            "bold" => "Umb.Tiptap.Toolbar.Bold",
+            "italic" => "Umb.Tiptap.Toolbar.Italic",
+            "underline" => "Umb.Tiptap.Toolbar.Underline",
+            "strikethrough" => "Umb.Tiptap.Toolbar.Strike",
+            "alignleft" => "Umb.Tiptap.Toolbar.TextAlignLeft",
+            "aligncenter" => "Umb.Tiptap.Toolbar.TextAlignCenter",
+            "alignright" => "Umb.Tiptap.Toolbar.TextAlignRight",
+            "alignjustify" => "Umb.Tiptap.Toolbar.TextAlignJustify",
+            "bullist" => "Umb.Tiptap.Toolbar.BulletList",
+            "numlist" => "Umb.Tiptap.Toolbar.OrderedList",
+            "outdent" => "Umb.Tiptap.Toolbar.TextOutdent",
+            "indent" => "Umb.Tiptap.Toolbar.TextIndent",
+            "anchor" => "Umb.Tiptap.Toolbar.Anchor",
+            "table" => "Umb.Tiptap.Toolbar.Table",
+            "hr" => "Umb.Tiptap.Toolbar.HorizontalRule",
+            "subscript" => "Umb.Tiptap.Toolbar.Subscript",
+            "superscript" => "Umb.Tiptap.Toolbar.Superscript",
+            "charmap" => "Umb.Tiptap.Toolbar.CharacterMap",
+            "rtl" => "Umb.Tiptap.Toolbar.TextDirectionRtl",
+            "ltr" => "Umb.Tiptap.Toolbar.TextDirectionLtr",
+            "link" => "Umb.Tiptap.Toolbar.Link",
+            "unlink" => "Umb.Tiptap.Toolbar.Unlink",
+            "sourcecode" => "Umb.Tiptap.Toolbar.SourceEditor",
+            "umbmediapicker" => "Umb.Tiptap.Toolbar.MediaPicker",
+            "umbembeddialog" => "Umb.Tiptap.Toolbar.EmbeddedMedia",
+            "umbblockpicker" => "Umb.Tiptap.Toolbar.BlockPicker",
+            _ => null
+        };
     }
 
     private static IDictionary<string, object> FixMediaParent(IDictionary<string, object> configuration)

--- a/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
@@ -15,7 +15,6 @@ namespace uSync.Core.DataTypes.DataTypeSerializers;
 internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, IConfigurationSerializer
 {
     private readonly TinyMceToTiptapMigrationSettings _options;
-
     private readonly ILogger<RichTextEditorMigratingSerializer> _logger;
 
     public RichTextEditorMigratingSerializer(IOptions<TinyMceToTiptapMigrationSettings> options, ILogger<RichTextEditorMigratingSerializer> logger)
@@ -49,20 +48,20 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
 
     public override IDictionary<string, object> GetConfigurationImport(IDictionary<string, object> configuration)
     {
-        configuration = MigrateToTipTap(configuration);
         configuration = FixMediaParent(configuration);
         configuration = TopLevelEditor(configuration);
+        configuration = MigrateToTipTap(configuration);
         return configuration.ToImmutableSortedDictionary();
     }
 
     private IDictionary<string, object> MigrateToTipTap(IDictionary<string, object> configuration)
     {
-        if (_options.DisableMigration is true)
+        if (_options?.DisableMigration is true)
             return configuration;
 
         if (configuration.ContainsKey("mode") is false && configuration.ContainsKey("hideLabel") is false)
         {
-            _logger.LogDebug("Skipping Tiptap migration as it does not contain 'mode' or 'hideLabel'.");   
+            _logger.LogDebug("Skipping Tiptap migration as it does not contain 'mode' or 'hideLabel'.");
             // if both mode and hideLabel are not present, then this has probibly already been migrated
             return configuration;
         }
@@ -70,10 +69,15 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         _logger.LogDebug("Migrating TinyMCE configuration to Tiptap format.");
         // do the tip tap things. 
 
-        if (!configuration.TryGetValue("toolbar", out var toolbar) || toolbar is not List<string> toolBarList)
-        {
-            return configuration;
+
+
+        if (!configuration.TryGetValue("toolbar", out var toolbar)
+            || (toolbar is not List<string> toolBarList && TryGetToolbarArray(toolbar, out toolBarList) is false)) 
+        { 
+                _logger.LogDebug("Skipping Tiptap migration as toolbar is not a list or string.");
+                return configuration;
         }
+    
 
         configuration.Remove("mode");
         configuration.Remove("hideLabel");
@@ -107,6 +111,16 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         configuration["extensions"] = extensions.ToArray();
 
         return configuration;
+    }
+
+    private bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
+    {
+        toolBarList = new List<string>();
+        if (toolbar is null || toolbar is not JsonElement jsonElement || jsonElement.ValueKind != JsonValueKind.Array)
+            return false; 
+        
+        toolBarList = jsonElement.EnumerateArray().Select(x => x.GetString() ?? string.Empty).ToList();
+        return true;
     }
 
     private string? MapToolbarItem(string item)

--- a/uSync.Core/Mapping/Mappers/RTEMappers/RTEBlockDataContentMigrator.cs
+++ b/uSync.Core/Mapping/Mappers/RTEMappers/RTEBlockDataContentMigrator.cs
@@ -1,0 +1,51 @@
+﻿using System.Text.RegularExpressions;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.Extensions;
+
+namespace uSync.Core.Mapping.Mappers.RTEMappers;
+
+public partial class RTEBlockHelper
+{
+    [GeneratedRegex("<umb-rte-block.*(?<attribute>data-content-udi)=\"(?<udi>.[^\"]*)\".*<\\/umb-rte-block")]
+    public static partial Regex BlockRegex();
+}
+
+/// <summary>
+///  updates inline block data-content-udi attributes to data-content-key
+/// </summary>
+public class RTEBlockDataContentMigrator : SyncValueMapperBase, ISyncMapper
+{
+    public RTEBlockDataContentMigrator(IEntityService entityService)
+        : base(entityService)
+    { }
+
+    public override string Name => "RTE Block Data Content Mapper";
+
+    public override string[] Editors => [
+        "Umbraco.TinyMCE",
+        Constants.PropertyEditors.Aliases.RichText,
+        $"{Constants.PropertyEditors.Aliases.Grid}.rte"
+    ];
+
+    public override Task<string?> GetImportValueAsync(string value, string editorAlias)
+    {
+        if (value.TryDeserialize<RichTextEditorValue>(out RichTextEditorValue? richTextEditorValue) is false || richTextEditorValue is null)
+            return base.GetImportValueAsync(value, editorAlias);
+
+        if (RTEBlockHelper.BlockRegex().IsMatch(richTextEditorValue.Markup) is false)
+            return base.GetImportValueAsync(value, editorAlias);
+
+        richTextEditorValue.Markup = RTEBlockHelper.BlockRegex().Replace(
+        richTextEditorValue.Markup,
+        match => UdiParser.TryParse(match.Groups["udi"].Value, out GuidUdi? guidUdi)
+            ? match.Value
+                .Replace(match.Groups["attribute"].Value, "data-content-key")
+                .Replace(match.Groups["udi"].Value, guidUdi.Guid.ToString("D"))
+            : string.Empty);
+
+        return Task.FromResult<string?>(richTextEditorValue.SerializeJsonString());
+    }
+}

--- a/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -129,9 +129,12 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
 
         var editorUiAlias = info?.Element("EditorUIAlias").ValueOrDefault(string.Empty) ?? string.Empty;
 
-        // migration thing if this is missing we guess it.
-        if (string.IsNullOrWhiteSpace(editorUiAlias))
-            editorUiAlias = ToPropertyEditorUiAlias(editorAlias) ?? string.Empty;
+        // EditorUIAlias is often not set on migrations, so we need to go get it.
+        // Also for updates (like RTE to TipTap) then this value needs to change.
+        // so if it's blank or if fetching it gets us a new value, we should update it.
+        var newEditorUiAlias = ToPropertyEditorUiAlias(editorAlias) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(editorUiAlias) || string.IsNullOrWhiteSpace(newEditorUiAlias) is false)
+            editorUiAlias = newEditorUiAlias;
 
         if (item.EditorUiAlias != editorUiAlias)
         {
@@ -326,7 +329,9 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
 
     public override async Task SaveItemAsync(IDataType item)
     {
-        if (item.IsDirty() is false) return;
+        // v16: dirty flag is not set if you change the EditorUIAlias, so we can't trust it. 
+        // see : https://github.com/umbraco/Umbraco-CMS/issues/19732
+        // if (item.IsDirty() is false) return;
 
         if (item.HasIdentity is true)
             await _dataTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
@@ -416,8 +421,8 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
             Constants.PropertyEditors.Aliases.Tags => "Umb.PropertyEditorUi.Tags",
             Constants.PropertyEditors.Aliases.TextBox => "Umb.PropertyEditorUi.TextBox",
             Constants.PropertyEditors.Aliases.TextArea => "Umb.PropertyEditorUi.TextArea",
-            Constants.PropertyEditors.Aliases.RichText => "Umb.PropertyEditorUi.TinyMCE",
-            "Umbraco.TinyMCE" => "Umb.PropertyEditorUi.TinyMCE",
+            //Constants.PropertyEditors.Aliases.RichText => "Umb.PropertyEditorUi.TinyMCE",
+            //"Umbraco.TinyMCE" => "Umb.PropertyEditorUi.TinyMCE",
             Constants.PropertyEditors.Aliases.Boolean => "Umb.PropertyEditorUi.Toggle",
             Constants.PropertyEditors.Aliases.MarkdownEditor => "Umb.PropertyEditorUi.MarkdownEditor",
             Constants.PropertyEditors.Aliases.UserPicker => "Umb.PropertyEditorUi.UserPicker",
@@ -434,5 +439,5 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
     /// <param name="editorAlias"></param>
     /// <returns></returns>
     private string? GetEditorUIAliasFromSerializer(string editorAlias)
-        => _configurationSerializers.GetSerializer(editorAlias)?.GetEditorUIAlias();
+        => _configurationSerializers.GetEditorUIAlias(editorAlias);
 }

--- a/uSync.Tests/Migrations/RichTextMigrationTests.cs
+++ b/uSync.Tests/Migrations/RichTextMigrationTests.cs
@@ -1,4 +1,14 @@
-﻿using NUnit.Framework;
+﻿using Castle.Core.Logging;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core.Configuration.Models;
 
 using uSync.Core.DataTypes.DataTypeSerializers;
 
@@ -7,7 +17,17 @@ namespace uSync.Tests.Migrations;
 [TestFixture]
 internal class RichTextMigrationTests : MigrationTestBase
 {
-    private RichTextEditorMigratingSerializer _serializer = new();
+    private RichTextEditorMigratingSerializer _serializer;
+
+    [SetUp]
+    public void Setup()
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        _serializer = new RichTextEditorMigratingSerializer(
+            Mock.Of<IOptions<TinyMceToTiptapMigrationSettings>>(),
+            loggerFactory.CreateLogger<RichTextEditorMigratingSerializer>());
+    }
 
     private static string Source = @"{
   ""Blocks"": [
@@ -109,12 +129,77 @@ internal class RichTextMigrationTests : MigrationTestBase
   ""useLiveEditing"": false
 }";
 
+    private static string TipTapTarget = @"{
+  ""blocks"": [
+    {
+      ""backgroundColor"": null,
+      ""contentElementTypeKey"": ""a0eec50c-54ce-47d3-97f1-c01843887567"",
+      ""displayInline"": false,
+      ""editorSize"": ""medium"",
+      ""forceHideContentEditorInOverlay"": false,
+      ""iconColor"": null,
+      ""label"": null,
+      ""settingsElementTypeKey"": null,
+      ""stylesheet"": null,
+      ""thumbnail"": null,
+      ""view"": null
+    }
+  ],
+  ""dimensions"": {
+    ""width"": 500,
+    ""height"": 500
+  },
+  ""extensions"": [
+    ""Umb.Tiptap.RichTextEssentials"",
+    ""Umb.Tiptap.Embed"",
+    ""Umb.Tiptap.Figure"",
+    ""Umb.Tiptap.Image"",
+    ""Umb.Tiptap.Link"",
+    ""Umb.Tiptap.MediaUpload"",
+    ""Umb.Tiptap.Subscript"",
+    ""Umb.Tiptap.Superscript"",
+    ""Umb.Tiptap.Table"",
+    ""Umb.Tiptap.TextAlign"",
+    ""Umb.Tiptap.TextDirection"",
+    ""Umb.Tiptap.TextIndent"",
+    ""Umb.Tiptap.Underline"",
+    ""Umb.Tiptap.Block""
+  ],
+  ""ignoreUserStartNodes"": false,
+  ""maxImageSize"": 500,
+  ""mediaParentId"": ""71332aa7-8bea-44f1-9aa6-00de961b66e8"",
+  ""overlaySize"": ""medium"",
+  ""stylesheets"": [
+    ""/Editor Styles.css""
+  ],
+  ""toolbar"": [
+    [
+      [
+        ""Umb.Tiptap.Toolbar.StyleSelect"",
+        ""Umb.Tiptap.Toolbar.Bold"",
+        ""Umb.Tiptap.Toolbar.Italic"",
+        ""Umb.Tiptap.Toolbar.TextAlignLeft"",
+        ""Umb.Tiptap.Toolbar.TextAlignCenter"",
+        ""Umb.Tiptap.Toolbar.TextAlignRight"",
+        ""Umb.Tiptap.Toolbar.BulletList"",
+        ""Umb.Tiptap.Toolbar.OrderedList"",
+        ""Umb.Tiptap.Toolbar.TextOutdent"",
+        ""Umb.Tiptap.Toolbar.TextIndent"",
+        ""Umb.Tiptap.Toolbar.Link"",
+        ""Umb.Tiptap.Toolbar.MediaPicker"",
+        ""Umb.Tiptap.Toolbar.EmbeddedMedia""
+      ]
+    ]
+  ],
+  ""useLiveEditing"": false
+}";
+
     [Test]
     public void RichTextMigrationValueTest()
-        => TestSerializerPropertyMigration(_serializer, Source, Target);
+        => TestSerializerPropertyMigration(_serializer, Source, TipTapTarget);
 
     [Test]
     public void RichTextMigratedValueTest()
-        => TestSerializerPropertyMigration(_serializer, Target, Target);
+        => TestSerializerPropertyMigration(_serializer, Target, TipTapTarget);
 
 }


### PR DESCRIPTION
Updates to how RTE values containing blocks are updated, this is to fix an issue where the `data-content-udi` attribute changes to be a `data-content-key` attribute between versions. 

 