### PR TITLE
V13/root merge fix

### DIFF
--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -10,35 +10,18 @@
   "definitions": {
     "USyncuSyncDefinition": {
       "type": "object",
-      "description": "Configuration of uSync settings",
       "properties": {
         "Settings": {
-          "description": "uSync settings",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/USyncBackOfficeConfigurationuSyncSettings"
-            }
-          ]
+          "$ref": "#/definitions/USyncBackOfficeConfigurationuSyncSettings"
         },
         "ForceFips": {
-          "type": "boolean",
-          "description": "Force uSync to use FIPS compliant hashing algorthims when comparing files"
+          "type": "boolean"
         },
         "Sets": {
-          "description": "Settings of Handler sets",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/USyncuSyncSetsDefinition"
-            }
-          ]
+          "$ref": "#/definitions/USyncuSyncSetsDefinition"
         },
         "AutoTemplates": {
-          "description": "Settings for the AutoTemplates package, (dynamic adding of templates based on files on disk)",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/USyncAutoTemplatesDefinition"
-            }
-          ]
+          "$ref": "#/definitions/USyncAutoTemplatesDefinition"
         }
       }
     },
@@ -53,7 +36,6 @@
         },
         "Folders": {
           "type": "array",
-          "description": "collection of folders uSync looks in when performing imports.\n            ",
           "default": "uSync/Root/, uSync/v9",
           "items": {
             "type": "string"
@@ -61,26 +43,21 @@
         },
         "IsRootSite": {
           "type": "boolean",
-          "description": "Sets this site to be the root site (so it will save into \"uSync/root/\")\n            ",
           "default": false
         },
         "LockRoot": {
-          "type": "boolean",
-          "description": "when locked you can't make changes to anything that is in the root"
+          "type": "boolean"
         },
         "StopFile": {
           "type": "string",
-          "description": "location of the stop file (relative to the uSync folder)\n            ",
           "default": "usync.stop"
         },
         "OnceFile": {
           "type": "string",
-          "description": "location of the once file (relative to the uSync folder)\n            ",
           "default": "usync.once"
         },
         "LockRootTypes": {
           "type": "array",
-          "description": "lock specific types at root so they can't be changed in child sites. \n            ",
           "items": {
             "type": "string"
           }
@@ -132,7 +109,6 @@
         },
         "FailOnDuplicates": {
           "type": "boolean",
-          "description": "fail if a duplicate file of same type and key is detected during the import process.\n            ",
           "default": false
         },
         "CacheFolderKeys": {
@@ -158,8 +134,7 @@
           "default": true
         },
         "HistoryFolder": {
-          "type": "string",
-          "description": "Location of the history folder."
+          "type": "string"
         },
         "DefaultExtension": {
           "type": "string",
@@ -203,7 +178,6 @@
         },
         "BackgroundNotifications": {
           "type": "boolean",
-          "description": "trigger all the notifications in a background thread, \n            ",
           "default": false
         }
       }
@@ -300,6 +274,9 @@
           "type": "boolean",
           "description": "create a corresponding _clean file for this export \n            "
         },
+        "LegacyRootMerge": {
+          "type": "boolean"
+        },
         "Settings": {
           "type": "object",
           "description": "Additional settings for the handler",
@@ -314,17 +291,14 @@
       "properties": {
         "Enabled": {
           "type": "boolean",
-          "description": "Enable AutoTemplates feature",
           "default": false
         },
         "Delete": {
           "type": "boolean",
-          "description": "Delete templates from Umbraco if the file is missing from disk",
           "default": false
         },
         "Delay": {
           "type": "integer",
-          "description": "Amount of time (milliseconds) to wait after file change event before applying changes",
           "format": "int32",
           "default": 1000
         }

--- a/uSync.BackOffice/Configuration/ISyncfolder.cs
+++ b/uSync.BackOffice/Configuration/ISyncfolder.cs
@@ -1,0 +1,26 @@
+﻿namespace uSync.BackOffice.Configuration;
+
+/// <summary>
+///  folder type to define a folder for the site. 
+/// </summary>
+public interface ISyncFolder
+{
+    /// <summary>
+    ///  path to the folder we want to use. 
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    ///  weight in the list. 
+    /// </summary>
+    int Weight { get; }
+}
+
+/*
+ * example 
+ */
+//public class TestSyncFolder: ISyncFolder
+//{
+//    public string Path => "uSync/TestFolder";
+//    public int Weight => 100;
+//}

--- a/uSync.BackOffice/Configuration/SyncFolderCollection.cs
+++ b/uSync.BackOffice/Configuration/SyncFolderCollection.cs
@@ -1,0 +1,40 @@
+﻿using J2N.Collections.Generic.Extensions;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core.Composing;
+
+namespace uSync.BackOffice.Configuration;
+
+/// <summary>
+///  collection of folders loaded from extensions, merged into the 
+///  folders from settings at runtime. 
+/// </summary>
+public class SyncFolderCollection : BuilderCollectionBase<ISyncFolder>
+{
+    /// <inheritdoc/>
+    public SyncFolderCollection(Func<IEnumerable<ISyncFolder>> items)
+        : base(items)
+    { }
+
+    /// <summary>
+    ///  returns an array of all the folders in the collection.
+    /// </summary>
+    /// <returns></returns>
+    public ISyncFolder[] GetFolders()
+        => this.ToArray();
+}
+
+/// <summary>
+///  collection builder to mange folders. 
+/// </summary>
+public class SyncFolderCollectionBuilder
+    : SetCollectionBuilderBase<SyncFolderCollectionBuilder, SyncFolderCollection, ISyncFolder>
+{
+
+    /// <inheritdoc/>
+    protected override SyncFolderCollectionBuilder This => this;
+}
+

--- a/uSync.BackOffice/Configuration/uSyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/uSyncConfigService.cs
@@ -1,8 +1,10 @@
 ﻿
+using Microsoft.Extensions.Options;
+
 using System;
 using System.Linq;
 
-using Microsoft.Extensions.Options;
+using Umbraco.Extensions;
 
 namespace uSync.BackOffice.Configuration
 {
@@ -12,37 +14,15 @@ namespace uSync.BackOffice.Configuration
     public class uSyncConfigService
     {
         private IOptionsMonitor<uSyncHandlerSetSettings> _setOptionsMonitor;
+        private readonly SyncFolderCollection _syncFolders;
 
-        /// <summary>
-        ///  uSync settings loaded from configuration
-        /// </summary>
-        public uSyncSettings Settings { get; set; }
-
-        /// <summary>
-        ///  The unmapped root folder for uSync.
-        /// </summary>
-        [Obsolete("we should be using the array of folders, will be removed in v15")]
-        public string GetRootFolder()
-            => Settings.IsRootSite 
-                ? Settings.Folders[0].TrimStart('/')
-                : Settings.RootFolder.TrimStart('/');
-
-        /// <summary>
-        ///  Get the root folders that uSync is using. 
-        /// </summary>
-        /// <returns></returns>
-        public string[] GetFolders()
-            => Settings.IsRootSite
-                ? [Settings.Folders[0].TrimStart('/')]
-                : Settings.Folders.Select(x => x.TrimStart('/')).ToArray();
-        
-        
         /// <summary>
         /// Constructor for config service
         /// </summary>
         public uSyncConfigService(
             IOptionsMonitor<uSyncSettings> settingsOptionsMonitor,
-            IOptionsMonitor<uSyncHandlerSetSettings> setOptionsMonitor)
+            IOptionsMonitor<uSyncHandlerSetSettings> setOptionsMonitor,
+            SyncFolderCollection syncFolders)
         {
             Settings = settingsOptionsMonitor.CurrentValue;
 
@@ -52,9 +32,74 @@ namespace uSync.BackOffice.Configuration
             });
 
             _setOptionsMonitor = setOptionsMonitor;
-
+            _syncFolders = syncFolders;
         }
 
+
+        /// <summary>
+        ///  uSync settings loaded from configuration
+        /// </summary>
+        public uSyncSettings Settings { get; set; }
+
+        private string[] FetchFolders()
+        {
+            var folders = Settings.Folders
+                .Select((x, index) => new SyncFolderItem
+                {
+                    Path = x.TrimStart('/').EnsureEndsWith('/'),
+                    Weight = index * 1000
+                })
+                .ToList();
+
+            folders.AddRange(
+                _syncFolders.Select(x => new SyncFolderItem
+                {
+                    Path = x.Path.TrimStart('/').EnsureEndsWith('/'),
+                    Weight = x.Weight
+                })
+                );
+
+            return folders.OrderBy(x => x.Weight)
+                .Select(x => x.Path)
+                .Distinct()
+                .ToArray();
+        }
+
+        private class SyncFolderItem
+        {
+            public required string Path { get; set; }
+            public int Weight { get; set; }
+        }
+
+
+        /// <summary>
+        ///  The unmapped root folder for uSync.
+        /// </summary>
+        [Obsolete("we should be using the array of folders, will be removed in v15")]
+        public string GetRootFolder()
+        {
+            var folders = FetchFolders();
+
+            return Settings.IsRootSite
+                ? folders[0].TrimStart('/')
+                : Settings.RootFolder.TrimStart('/');
+        }
+
+        /// <summary>
+        ///  Get the root folders that uSync is using. 
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetFolders()
+        {
+            var folders = FetchFolders();
+
+            return Settings.IsRootSite
+                ? [folders[0].TrimStart('/')]
+                : folders.Select(x => x.TrimStart('/')).ToArray();
+        }
+
+
+    
         /// <summary>
         ///  get the settings for a named handler set.
         /// </summary>

--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -56,7 +56,18 @@ namespace uSync.BackOffice.Configuration
         /// <remarks>
         ///  the clean file will only get created if the item in question has children.
         /// </remarks>
-        public bool CreateClean { get; set; } = false;  
+        public bool CreateClean { get; set; } = false;
+
+
+        /// <summary>
+        ///  when saving root items with differences, save all the items, (this is the legacy behavior)
+        /// </summary>
+        /// <remarks>
+        ///  pre v13.3 when a change is made the whole .config file is saved to the new ./usync folder
+        ///  but this is a bug, the intention was and it that only the changes are saved to the folder
+        ///  this turns the old behavior back on. 
+        /// </remarks>
+        public bool LegacyRootMerge { get; set; } = false;
 
         /// <summary>
         /// Additional settings for the handler
@@ -120,6 +131,8 @@ namespace uSync.BackOffice.Configuration
                 UseFlatStructure = settings.UseFlatStructure,
                 Group = settings.Group,
                 GuidNames = settings.GuidNames,
+                LegacyRootMerge = settings.LegacyRootMerge,
+                CreateClean = settings.CreateClean,
                 Settings = new Dictionary<string, string>(settings.Settings, StringComparer.InvariantCultureIgnoreCase)
             };
         }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1098,6 +1098,9 @@ namespace uSync.BackOffice.SyncHandlers
                 if (ShouldExport(attempt.Item, config))
                 {
                     var files = folders.Select(x => GetPath(x, item, config.GuidNames, config.UseFlatStructure)).ToArray();
+
+                    // load all the nodes from everything but the last folder, 
+                    // so if it returns anything, we have files in a root folder somewhere. 
                     var nodes = syncFileService.GetAllNodes(files[..^1]);
                     if (nodes.Count > 0)
                     {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1105,7 +1105,8 @@ namespace uSync.BackOffice.SyncHandlers
                         var differences = syncFileService.GetDifferences(nodes, trackers.FirstOrDefault());
                         if (differences is not null && differences.HasElements)
                         {
-							syncFileService.SaveXElement(attempt.Item, filename);
+                            // save the Diffrence file as the XElement, then on import we merge it with root.
+							syncFileService.SaveXElement(differences, filename);
 						}
                         else
                         {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1093,51 +1093,59 @@ namespace uSync.BackOffice.SyncHandlers
         protected virtual SyncAttempt<XElement> Export_DoExport(TObject item, string filename, string[] folders, HandlerSettings config)
         {
             var attempt = SerializeItem(item, new SyncSerializerOptions(config.Settings));
-            if (attempt.Success)
+            if (attempt.Success is false)
+                return attempt;
+
+            if (ShouldExport(attempt.Item, config) is false)
+                return SyncAttempt<XElement>.Succeed(Path.GetFileName(filename), ChangeType.NoChange, "Not Exported (Based on configuration)");
+
+            var files = folders.Select(x => GetPath(x, item, config.GuidNames, config.UseFlatStructure)).ToArray();
+
+            // load all the nodes from everything but the last folder, 
+            // so if it returns anything, we have files in a root folder somewhere. 
+            var nodes = syncFileService.GetAllNodes(files[..^1]);
+            if (nodes.Count > 0)
             {
-                if (ShouldExport(attempt.Item, config))
+                nodes.Add(attempt.Item);
+                var differences = syncFileService.GetDifferences(nodes, trackers.FirstOrDefault());
+                if (differences is not null && differences.HasElements)
                 {
-                    var files = folders.Select(x => GetPath(x, item, config.GuidNames, config.UseFlatStructure)).ToArray();
-
-                    // load all the nodes from everything but the last folder, 
-                    // so if it returns anything, we have files in a root folder somewhere. 
-                    var nodes = syncFileService.GetAllNodes(files[..^1]);
-                    if (nodes.Count > 0)
+                    // if we have differences, then we save them to the file.
+                    // the buggy way was to save the whole item, but people might now expect that, 
+                    // so we have a setting to turn it back on.
+                    if (config.LegacyRootMerge)
                     {
-                        nodes.Add(attempt.Item);
-                        var differences = syncFileService.GetDifferences(nodes, trackers.FirstOrDefault());
-                        if (differences is not null && differences.HasElements)
-                        {
-                            // save the Diffrence file as the XElement, then on import we merge it with root.
-							syncFileService.SaveXElement(differences, filename);
-						}
-                        else
-                        {
-
-                            if (syncFileService.FileExists(filename))
-							{
-								// we don't delete them - because in deployments they might then hang around
-                                // we mark them as reverted and then they don't get processed.
-								var emptyNode = XElementExtensions.MakeEmpty(attempt.Item.GetKey(), SyncActionType.None, "Reverted to root");
-                                syncFileService.SaveXElement(emptyNode, filename);
-                            }
-                        }
-					}
-                    else
-                    {
+                        logger.LogDebug("Exporting {alias} with legacy root merge", GetItemAlias(item));
                         syncFileService.SaveXElement(attempt.Item, filename);
                     }
-
-                    if (config.CreateClean && HasChildren(item))
+                    else
                     {
-                        CreateCleanFile(GetItemKey(item), filename);
+                        logger.LogDebug("Exporting {alias} with differences", GetItemAlias(item));
+                        syncFileService.SaveXElement(differences, filename);
                     }
                 }
                 else
                 {
-                    return SyncAttempt<XElement>.Succeed(Path.GetFileName(filename), ChangeType.NoChange, "Not Exported (Based on configuration)");
+
+                    if (syncFileService.FileExists(filename))
+                    {
+                        // we don't delete them - because in deployments they might then hang around
+                        // we mark them as reverted and then they don't get processed.
+                        var emptyNode = XElementExtensions.MakeEmpty(attempt.Item.GetKey(), SyncActionType.None, "Reverted to root");
+                        syncFileService.SaveXElement(emptyNode, filename);
+                    }
                 }
             }
+            else
+            {
+                syncFileService.SaveXElement(attempt.Item, filename);
+            }
+
+            if (config.CreateClean && HasChildren(item))
+            {
+                CreateCleanFile(GetItemKey(item), filename);
+            }
+
             return attempt;
         }
 

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -59,6 +59,9 @@ namespace uSync.BackOffice
             // Setup uSync core.
             builder.AdduSyncCore();
 
+            // folder collection, so you can inject folders into the sync process.
+            builder.WithCollectionBuilder<SyncFolderCollectionBuilder>()
+                .Add(builder.TypeLoader.GetTypes<ISyncFolder>());
 
             // Setup the back office.
             builder.Services.AddSingleton<uSyncEventService>();

--- a/uSync.Backoffice.Assets/Controllers/uSyncDashboardApiController.cs
+++ b/uSync.Backoffice.Assets/Controllers/uSyncDashboardApiController.cs
@@ -119,7 +119,11 @@ namespace uSync.BackOffice.Assets.Controllers
         /// </summary>
         [HttpGet]
         public uSyncSettings GetSettings()
-            => this._uSyncConfig.Settings;
+        {
+            var settings = this._uSyncConfig.Settings;
+            settings.Folders = _uSyncConfig.GetFolders();
+            return settings;
+        }
 
         /// <summary>
         /// Return the default set name based on configuration

--- a/uSync.Core/Mapping/Mappers/MemberGroupPickerMapper.cs
+++ b/uSync.Core/Mapping/Mappers/MemberGroupPickerMapper.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+using uSync.Core.Dependency;
+
+using static Umbraco.Cms.Core.Constants;
+
+namespace uSync.Core.Mapping.Mappers;
+
+public class MemberGroupPickerMapper : SyncValueMapperBase, ISyncMapper
+{
+    private readonly IMemberGroupService _memberGroupService;
+
+    public MemberGroupPickerMapper(IEntityService entityService, IMemberGroupService memberGroupService) : base(entityService)
+    {
+        _memberGroupService = memberGroupService;
+    }
+
+    public override string Name => "Member Group Picker Mapper";
+    public override string[] Editors => [
+        Umbraco.Cms.Core.Constants.PropertyEditors.Aliases.MemberGroupPicker
+    ];
+
+    /// <summary>
+    ///  Export: take the int value that is stored , but return the name of the group as the value.
+    /// </summary>
+    public override string GetExportValue(object value, string editorAlias)
+    {
+        var attempt = value.TryConvertTo<int>();
+        if (attempt.Success is false) return base.GetExportValue(value, editorAlias);
+
+        var group = _memberGroupService.GetById(attempt.Result);
+        return group?.Name ?? base.GetExportValue(value, editorAlias);
+    }
+
+    /// <summary>
+    ///  Import: take the name of the group, and return the id of the group.
+    /// </summary>
+    public override string GetImportValue(string value, string editorAlias)
+    {
+        if (string.IsNullOrEmpty(value)) return base.GetImportValue(value, editorAlias);
+
+        var group = _memberGroupService.GetByName(value);
+        return group?.Id.ToString() ?? base.GetImportValue(value, editorAlias);
+    }
+
+    /// <summary>
+    ///  Dependency check, if the group is picked then return a dependency for the group, so it can be synced.
+    /// </summary>
+    public override IEnumerable<uSyncDependency> GetDependencies(object value, string editorAlias, DependencyFlags flags)
+    {
+        // if we are not including dependencies, then return nothing
+        if (flags.HasFlag(DependencyFlags.IncludeDependencies) is false) 
+            return Enumerable.Empty<uSyncDependency>();
+
+        // get the int value and load the group
+        var attempt = value.TryConvertTo<int>();
+        if (attempt.Success is false) return base.GetDependencies(value, editorAlias, flags);
+
+        var group = _memberGroupService.GetById(attempt.Result);
+        if (group is null) return base.GetDependencies(value, editorAlias, flags);
+
+        return new uSyncDependency
+        {
+            Flags = DependencyFlags.None,
+            Name = group.Name,
+            Udi = new GuidUdi(UdiEntityType.MemberGroup, group.Key),
+            Level = 0,
+            Order = DependencyOrders.OrderFromEntityType(UdiEntityType.MemberGroup)
+        }.AsEnumerableOfOne();
+    }
+}

--- a/uSync.Core/Tracking/Impliment/ContentBaseTracker.cs
+++ b/uSync.Core/Tracking/Impliment/ContentBaseTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Xml.Linq;
 
 using Umbraco.Cms.Core.Models;
 
@@ -36,5 +37,16 @@ namespace uSync.Core.Tracking.Impliment
 
             TrackingItem.Many("GenericProperty", "/GenericProperties/GenericProperty", uSyncConstants.Xml.Key)
         };
+
+        /// <summary>
+        ///  we don't support content merging content in roots, so just return the target all the time. 
+        /// </summary>
+        /// <remarks>
+        ///  we can do it,(the code is there). but blocks mean if people do change content in a block
+        ///  we would mark the whole block as changed, and i suspect editors would expect only the block to change
+        ///  so the level of potential confusion is too high.
+        /// </remarks>
+        public override XElement MergeFiles(XElement source, XElement target) => target;
+        public override XElement GetDifferences(List<XElement> nodes) => nodes[^1];
     }
 }

--- a/uSync.Core/Tracking/Impliment/ContentTypeBaseTracker.cs
+++ b/uSync.Core/Tracking/Impliment/ContentTypeBaseTracker.cs
@@ -29,12 +29,12 @@ namespace uSync.Core.Tracking.Impliment
            
             TrackingItem.Single("History", "/Info/HistoryCleanup"),
 
-            TrackingItem.Many("Compositions", "/Info/Compositions/Composition", "@Key"),
-            TrackingItem.Many("AllowedTemplates", "/Info/AllowedTemplates/Template", "@Key"),
+            TrackingItem.Many("Compositions", "/Info/Compositions/Composition", "@Key", "", "#"),
+            TrackingItem.Many("AllowedTemplates", "/Info/AllowedTemplates/Template", "@Key", "", "#"),
 
-            TrackingItem.Many("Allowed child node types", "/Structure/ContentType", "@Key"),
-            TrackingItem.Many("Allowed child node types", "/Structure/MediaType", "@Key"),
-            TrackingItem.Many("Allowed child node types", "/Structure/MemberType", "@Key"),
+            TrackingItem.Many("Allowed child node types", "/Structure/ContentType", "@Key", "", "SortOrder"),
+            TrackingItem.Many("Allowed child node types", "/Structure/MediaType", "@Key", "", "SortOrder"),
+            TrackingItem.Many("Allowed child node types", "/Structure/MemberType", "@Key", "", "SortOrder"),
 
 
             TrackingItem.Many("Property", "/GenericProperties/GenericProperty", uSyncConstants.Xml.Key, "Name", "Alias"),

--- a/uSync.Core/Tracking/SyncRootMergerHelper.cs
+++ b/uSync.Core/Tracking/SyncRootMergerHelper.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
-using Serilog.Core;
 
 namespace uSync.Core.Tracking;
 
@@ -75,7 +73,7 @@ public class SyncRootMergerHelper
             if (node.MakePlatformSafeHash() == differences.MakePlatformSafeHash())
                 return (combined, BlankNode(differences));
 
-            // workout any merged diffrences, 
+            // workout any merged differences, 
             (combined, differences) = GetTrackedNodeDifferences(node, combined, trackedNodes);
         }
         return (combined, differences);
@@ -99,7 +97,9 @@ public class SyncRootMergerHelper
 
             if (item.SingleItem is false)
             {
-                var path = item.Path.Substring(0, item.Path.LastIndexOf('/'));
+                var path = item.Path.Contains('*')
+                    ? item.Path.Substring(0, item.Path.IndexOf('*')).TrimEnd('/')
+                    : item.Path.Substring(0, item.Path.LastIndexOf('/'));
 
                 var (combined, difference) = GetMultipleChanges(item, source, target);
                 if (difference != null)
@@ -113,14 +113,11 @@ public class SyncRootMergerHelper
                     replacementNode?.Remove();
                 }
 
-                if (combined != null)
+                if (combined != null && (combined.HasElements || combined.HasAttributes))
                 {
                     var replacementNode = source.XPathSelectElement(path);
-                    if (combined.HasElements)
-                    {
-                        replacementNode?.AddAfterSelf(combined);
-                        replacementNode?.Remove();
-                    }
+                    replacementNode?.AddAfterSelf(combined);
+                    replacementNode?.Remove();
                 }
             }
             else
@@ -163,8 +160,11 @@ public class SyncRootMergerHelper
 
     private static (XElement combined, XElement diffrence) GetMultipleChanges(TrackingItem item, XElement source, XElement target)
     {
+        if (item.Path.Contains('*')) 
+            return GetWildcardChanges(item, source, target);
+
         var path = item.Path.Substring(0, item.Path.LastIndexOf('/'));
-        var element = item.Path.Substring(item.Path.LastIndexOf("/")+1);
+        var element = item.Path.Substring(item.Path.LastIndexOf('/')+1);
 
         var sourceCollection = source.XPathSelectElement(path);
         var targetCollection = target.XPathSelectElement(path);
@@ -174,8 +174,6 @@ public class SyncRootMergerHelper
 
         var differenceCollection = XElement.Parse(targetCollection.ToString());
         var combinedCollection = XElement.Parse(sourceCollection.ToString());
-
-        
 
         foreach (var sourceElement in sourceCollection.Elements(element))
         {
@@ -198,12 +196,12 @@ public class SyncRootMergerHelper
             {
                 var replacement = FindByKey(combinedCollection, element, item.Keys, key);
 
-				// only add this if its not a delete
-				if (targetElement.Attribute("deleted").ValueOrDefault(false) is false)
+                // only add this if its not a delete
+                if (targetElement.Attribute("deleted").ValueOrDefault(false) is false)
                 {
-					replacement?.AddAfterSelf(targetElement);
-				}
-				replacement?.Remove();
+                    replacement?.AddAfterSelf(targetElement);
+                }
+                replacement?.Remove();
             }
         }
 
@@ -224,15 +222,76 @@ public class SyncRootMergerHelper
         return (combinedCollection, differenceCollection);
     }
 
+    /// <summary>
+    ///  changes where the path contains a wildcard (e.g /item/*/value)
+    /// </summary>
+    private static (XElement combined, XElement diffrences) GetWildcardChanges(TrackingItem item, XElement source, XElement target)
+    {
+        var rootPath = item.Path.Substring(0, item.Path.IndexOf("/*"));
+
+        var path = item.Path.Substring(0, item.Path.LastIndexOf('/'));
+        var element = item.Path.Substring(item.Path.LastIndexOf('/') + 1);
+
+        var sourceCollection = source.XPathSelectElements(path);
+        var targetCollection = target.XPathSelectElements(path);
+
+        if (sourceCollection == null || targetCollection == null)
+            return (source, target);
+
+        var combined = XElement.Parse(source.ToString());
+        var differences = XElement.Parse(target.ToString());
+
+        foreach (var sourceElement in sourceCollection)
+        {
+            var elementPath = item.Path.Replace("*", sourceElement.Name.LocalName);
+
+            var sourceNode = combined.XPathSelectElement(elementPath);
+            var targetNode = differences.XPathSelectElement(elementPath);
+
+            if (sourceNode == null || targetNode == null) continue;
+
+            if (targetNode.Attribute("deleted")?.Value == "true")
+            {
+                // if the target node is deleted, we need to remove it from the source
+                combined.XPathSelectElement(elementPath)?.Remove();
+                continue;
+            }
+
+            // compare. 
+            var sourceValue = sourceNode.ValueOrDefault(string.Empty);
+            var targetValue = targetNode.ValueOrDefault(string.Empty);
+
+            if (sourceValue.Equals(targetValue) is true)
+            {
+                // the same, remove from differences
+                differences.XPathSelectElement(elementPath)?.Remove();
+            }
+            else
+            {
+                var replacement = combined.XPathSelectElement(elementPath);
+                replacement?.AddAfterSelf(targetNode);
+                replacement?.Remove();
+            }
+        }
+
+        return (
+            combined.XPathSelectElement(rootPath),
+            RemoveEmptyChildren(differences.XPathSelectElement(rootPath))
+        ); 
+    }
+
     private static XElement SortElement(XElement node, string elementName, string key)
     {
-        var sorted = node.Elements(elementName)
-            .OrderBy(x => (string)x.Element(key) ?? "")
-            .ToList();
+        var keyName = key.StartsWith('#') ? key.Substring(1) : key;
+
+        List<XElement> sorted = key.StartsWith('#')
+            ?  string.IsNullOrWhiteSpace(keyName) 
+                ? [.. node.Elements(elementName).OrderBy(e => e.Value ?? "")]
+                : [.. node.Elements(elementName).OrderBy(e => e.Element(keyName)?.Value ?? "")]
+            : [.. node.Elements(elementName).OrderBy(x => (string)x.Element(key) ?? "")];
 
         node.RemoveNodes();
         node.Add(sorted);
-
         return node;
     }
 
@@ -277,5 +336,31 @@ public class SyncRootMergerHelper
         var blank = XElement.Parse(source.ToString());
         blank.RemoveNodes();
         return blank;
+    }
+
+    /// <summary>
+    /// Removes all empty child elements from the given XElement node recursively.
+    /// An element is considered empty if it has no child elements, no attributes, and no value.
+    /// </summary>
+    public static XElement RemoveEmptyChildren(XElement node)
+    {
+        if (node == null) return node;
+
+        // Recursively process child nodes to check they don't have any empty children
+        foreach (var child in node.Elements().Where(e => e.HasElements || e.HasAttributes))
+        {
+            RemoveEmptyChildren(child);
+        }
+
+        // Make a list to avoid modifying the collection while iterating
+        var emptyChildren = node.Elements()
+            .Where(e => !e.HasElements && string.IsNullOrWhiteSpace(e.Value) && !e.HasAttributes)
+            .ToList();
+        foreach (var empty in emptyChildren)
+        {
+            empty.Remove();
+        }
+
+        return node;
     }
 }

--- a/uSync.Core/Tracking/SyncRootMergerHelper.cs
+++ b/uSync.Core/Tracking/SyncRootMergerHelper.cs
@@ -225,7 +225,7 @@ public class SyncRootMergerHelper
     /// <summary>
     ///  changes where the path contains a wildcard (e.g /item/*/value)
     /// </summary>
-    private static (XElement combined, XElement diffrences) GetWildcardChanges(TrackingItem item, XElement source, XElement target)
+    private static (XElement combined, XElement differences) GetWildcardChanges(TrackingItem item, XElement source, XElement target)
     {
         var rootPath = item.Path.Substring(0, item.Path.IndexOf("/*"));
 

--- a/uSync.SchemaGenerator/Options.cs
+++ b/uSync.SchemaGenerator/Options.cs
@@ -8,5 +8,10 @@ namespace uSync
             HelpText = "",
             Default = "..\\uSync.Backoffice.Targets\\appsettings-schema.usync.json")]
         public string OutputFile { get; set; }
+
+        [Option('s', "site", Required = false,
+            HelpText = "The test site to also copy the file to.",
+            Default = "uSync.Site")]
+        public string Site { get; set; } 
     }
 }

--- a/uSync.SchemaGenerator/Program.cs
+++ b/uSync.SchemaGenerator/Program.cs
@@ -43,6 +43,15 @@ namespace uSync
             await File.WriteAllTextAsync(path, schema);
 
             Console.WriteLine("File written at {0}", path);
+
+            if (string.IsNullOrWhiteSpace(options.Site) is false)
+            {
+                var sitePath = Path.Combine("..", options.Site, "appsettings-schema.usync.json");
+                Console.WriteLine("Writing to site path {0}", sitePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(sitePath));
+                await File.WriteAllTextAsync(sitePath, schema);
+                Console.WriteLine("File written at {0}", sitePath);
+            }
         }
     }
 }


### PR DESCRIPTION
fixes and updates for the root functionality: 

 - fix the merging of block elements in datatypes 
 - fixes for content type property merging orders (Compositions, tabs and templates).
 - Addition of the ISyncFolder collection (which lets you add folders to uSync's list programatically).