### PR TITLE
Add a custom section with the uSync tree in it 

### DIFF
--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -212,6 +212,11 @@
           "type": "boolean",
           "description": "trigger all the notifications in a background thread, \n            ",
           "default": false
+        },
+        "MoveToSection": {
+          "type": "boolean",
+          "description": "Move the uSync tree to it's own section in the back office. \n(requires a restart to take effect).\n            ",
+          "default": false
         }
       }
     },

--- a/uSync.BackOffice/BackOfficeConstants.cs
+++ b/uSync.BackOffice/BackOfficeConstants.cs
@@ -13,7 +13,7 @@ public static partial class uSyncConstants
     public const string MergedFolderName = "Combined";
 
     /// <summary>
-    ///  alias for the custon 'usync' section that can be added in the backoffice.
+    ///  alias for the custom 'usync' section that can be added in the backoffice.
     /// </summary>
     public const string uSyncSection = "usync.section";
 

--- a/uSync.BackOffice/BackOfficeConstants.cs
+++ b/uSync.BackOffice/BackOfficeConstants.cs
@@ -11,6 +11,7 @@ public static partial class uSyncConstants
     ///  folder name used when we merge two or more items together.
     /// </summary>
     public const string MergedFolderName = "Combined";
+    public const string uSyncSection = "usync.section";
 
     /// <summary>
     /// Information about the package name/files

--- a/uSync.BackOffice/BackOfficeConstants.cs
+++ b/uSync.BackOffice/BackOfficeConstants.cs
@@ -11,6 +11,10 @@ public static partial class uSyncConstants
     ///  folder name used when we merge two or more items together.
     /// </summary>
     public const string MergedFolderName = "Combined";
+
+    /// <summary>
+    ///  alias for the custon 'usync' section that can be added in the backoffice.
+    /// </summary>
     public const string uSyncSection = "usync.section";
 
     /// <summary>

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -230,4 +230,12 @@ public class uSyncSettings
     /// </remarks>
     [DefaultValue(false)]
     public bool BackgroundNotifications { get; set; } = false;
+
+
+    /// <summary>
+    ///  Move the uSync tree to it's own section in the back office. 
+    ///  (requires a restart to take effect).
+    /// </summary>
+    [DefaultValue(false)]
+    public bool MoveToSection { get; set; } = false;
 }

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -258,7 +258,8 @@ public static class uSyncBackOfficeBuilderExtensions
         options.AddPolicy(SyncAuthorizationPolicies.TreeAccessuSync, policy =>
         {
             policy.AuthenticationSchemes.Add(OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme);
-            policy.Requirements.Add(new uSyncApplicationRequirement(Constants.Applications.Settings));                
+            policy.Requirements.Add(new uSyncApplicationRequirement(
+                Constants.Applications.Settings, uSyncConstants.uSyncSection));                
         });
     }
 }

--- a/uSync.Backoffice.Management.Client/uSyncManifestReader.cs
+++ b/uSync.Backoffice.Management.Client/uSyncManifestReader.cs
@@ -8,15 +8,55 @@ using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Infrastructure.Manifest;
 using Umbraco.Extensions;
 
+using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Extensions;
 
 namespace uSync.Backoffice.Management.Client;
 
+[ComposeAfter(typeof(BackOffice.uSyncBackOfficeComposer))]
 public class uSyncManifestComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
         builder.Services.AddSingleton<IPackageManifestReader, uSyncManifestReader>();
+        builder.Services.AddSingleton<IPackageManifestReader, SyncSectionManifestReader>();
+    }
+}
+
+internal sealed class SyncSectionManifestReader : IPackageManifestReader
+{
+    private readonly ISyncConfigService _configService;
+
+    public SyncSectionManifestReader(ISyncConfigService configService)
+    {
+        _configService = configService;
+    }
+
+    public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()
+    {
+        if (_configService.Settings.MoveToSection is false) 
+            return Task.FromResult(Enumerable.Empty<PackageManifest>());
+
+        List<PackageManifest> manifest = [
+            new PackageManifest
+            {
+                Id = "uSync.Section",
+                Name = "uSync Section",
+                AllowTelemetry = false,
+                Version = typeof(SyncSectionManifestReader).Assembly.GetName()?.Version?.ToString(3) ?? "15.0.0",
+                Extensions = [ new JsonObject {
+                    ["type"] = "section",
+                    ["name"] = "uSync Section",
+                    ["alias"] = "usync.section",
+                    ["weight"] = 350,
+                    ["meta"] = new JsonObject {
+                        ["label"] = "#uSync_section",
+                        ["pathname"] = "sync"
+                    }
+                }]
+            }
+        ];
+        return Task.FromResult(manifest.AsEnumerable());
     }
 }
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/conditions/constants.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/conditions/constants.ts
@@ -1,0 +1,1 @@
+export const USYNC_CONDITION_NEW_SECTION = 'usync.condition.new-section';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/conditions/index.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/conditions/index.ts
@@ -1,1 +1,2 @@
 export * from './legacy-files.condition.js';
+export * from './new-section.condition.js';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/conditions/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/conditions/manifest.ts
@@ -1,5 +1,7 @@
 import { SyncLegacyFilesCondition } from '@jumoo/uSync';
 import { uSyncConstants } from '@jumoo/uSync';
+import { USYNC_CONDITION_NEW_SECTION } from './constants';
+import { SyncNewSectionCondition } from './new-section.condition';
 
 export const manifests: UmbExtensionManifest[] = [
 	{
@@ -7,5 +9,11 @@ export const manifests: UmbExtensionManifest[] = [
 		alias: uSyncConstants.conditions.legacy,
 		name: 'uSync Legacy Files Condition',
 		api: SyncLegacyFilesCondition,
+	},
+	{
+		type: 'condition',
+		alias: USYNC_CONDITION_NEW_SECTION,
+		name: 'uSync New Section Condition',
+		api: SyncNewSectionCondition,
 	},
 ];

--- a/uSync.Backoffice.Management.Client/usync-assets/src/conditions/new-section.condition.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/conditions/new-section.condition.ts
@@ -1,0 +1,59 @@
+import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import {
+	UmbConditionConfigBase,
+	UmbConditionControllerArguments,
+	UmbExtensionsManifestInitializer,
+} from '@umbraco-cms/backoffice/extension-api';
+import {
+	UmbConditionBase,
+	umbExtensionsRegistry,
+} from '@umbraco-cms/backoffice/extension-registry';
+import { UMB_SECTION_CONTEXT } from '@umbraco-cms/backoffice/section';
+import { USYNC_SECTION_ALIAS } from '../tree/constants';
+
+export type SyncNewSectionConditionConfig = UmbConditionConfigBase & {};
+
+export class SyncNewSectionCondition extends UmbConditionBase<SyncNewSectionConditionConfig> {
+	#currentSection: string | undefined;
+	#allSections: string[] | undefined;
+
+	constructor(
+		host: UmbControllerHost,
+		args: UmbConditionControllerArguments<SyncNewSectionConditionConfig>,
+	) {
+		super(host, args);
+
+		new UmbExtensionsManifestInitializer(
+			this,
+			umbExtensionsRegistry,
+			'section',
+			() => true,
+			async (sections) => {
+				this.#allSections = sections.map((section) => section.alias);
+				this.permitted = this.#checkPermission();
+			},
+			'uSyncAllSectionsManifestFilter',
+		);
+
+		this.consumeContext(UMB_SECTION_CONTEXT, (_context) => {
+			if (!_context) return;
+
+			this.observe(_context.alias, (_alias) => {
+				this.#currentSection = _alias;
+				this.permitted = this.#checkPermission();
+			});
+		});
+	}
+
+	#checkPermission() {
+		if (!this.#currentSection) return false;
+		if (!this.#allSections) return false;
+
+		// if the new section isn't defined, this will still show in settings.
+		if (!this.#allSections.includes(USYNC_SECTION_ALIAS)) return true;
+
+		if (this.#currentSection === USYNC_SECTION_ALIAS) return true;
+
+		return false;
+	}
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
@@ -1,5 +1,6 @@
 export default {
 	uSync: {
+		section: 'Syncronisation',
 		name: 'uSync',
 		banner: 'uSync all the things',
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
@@ -1,6 +1,6 @@
 export default {
 	uSync: {
-		section: 'Syncronisation',
+		section: 'Synchronisation',
 		name: 'uSync',
 		banner: 'uSync all the things',
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/tree/constants.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/tree/constants.ts
@@ -1,0 +1,1 @@
+export const USYNC_SECTION_ALIAS = 'usync.section';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
@@ -1,10 +1,22 @@
 import { uSyncConstants, uSyncMenuElement } from '@jumoo/uSync';
+import { USYNC_CONDITION_NEW_SECTION } from '../conditions/constants';
+import { USYNC_SECTION_ALIAS } from './constants';
 
 const sectionAlias = 'Umb.Section.Settings';
 
+/*
+ * config slight of hand: This manifest is added in c#
+ * via a manaifestreader, that only adds it if a setting
+ * is true in the appsettings.json file.
+ *
+ * we can then use conditional code that will only allow
+ * the tree to show in settings when this section doesn't
+ * exist globally.
+ */
+/*
 const uSyncSection: UmbExtensionManifest = {
 	type: 'section',
-	alias: 'usync.section',
+	alias: USYNC_SECTION_ALIAS,
 	name: 'uSync',
 	weight: 350,
 	meta: {
@@ -12,6 +24,7 @@ const uSyncSection: UmbExtensionManifest = {
 		pathname: 'sync',
 	},
 };
+*/
 
 const menuConstants = {
 	alias: 'usync.menu',
@@ -57,7 +70,10 @@ const menuSidebarApp: UmbExtensionManifest = {
 	conditions: [
 		{
 			alias: 'Umb.Condition.SectionAlias',
-			oneOf: [sectionAlias, uSyncSection.alias],
+			oneOf: [sectionAlias, USYNC_SECTION_ALIAS],
+		},
+		{
+			alias: USYNC_CONDITION_NEW_SECTION,
 		},
 	],
 };
@@ -77,7 +93,7 @@ const menuSidebarApp: UmbExtensionManifest = {
 // }
 
 export const manifests = [
-	uSyncSection,
+	// uSyncSection,
 	menu,
 	menuSidebarApp,
 	menuItem,

--- a/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
@@ -2,6 +2,17 @@ import { uSyncConstants, uSyncMenuElement } from '@jumoo/uSync';
 
 const sectionAlias = 'Umb.Section.Settings';
 
+const uSyncSection: UmbExtensionManifest = {
+	type: 'section',
+	alias: 'usync.section',
+	name: 'uSync',
+	weight: 350,
+	meta: {
+		label: '#uSync_section',
+		pathname: 'sync',
+	},
+};
+
 const menuConstants = {
 	alias: 'usync.menu',
 	name: 'uSync',
@@ -46,7 +57,7 @@ const menuSidebarApp: UmbExtensionManifest = {
 	conditions: [
 		{
 			alias: 'Umb.Condition.SectionAlias',
-			match: sectionAlias,
+			oneOf: [sectionAlias, uSyncSection.alias],
 		},
 	],
 };
@@ -66,6 +77,7 @@ const menuSidebarApp: UmbExtensionManifest = {
 // }
 
 export const manifests = [
+	uSyncSection,
 	menu,
 	menuSidebarApp,
 	menuItem,


### PR DESCRIPTION
Adds a custom section, that when enabled will show the uSync tree.

This section isn't required as the tree also appears in Settings. so for most people it will be fine. but if you want to 'move' things to a new section this would do it. 

~Ideally we would also have something that removes it from the settings tree, A condition might do this, but it needs to be section aware (e.g know that we are currently rendering the 'settings' section). I think this might be possible, not yet sure.~

**Update:**
This PR now has a custom condition which mean the uSync menu tree will not show in the settings menu if the `usync.section` has been defined (at all). 

the usync.section is then defined in a custom manifest reader in c# which will only register it if the `MoveToSection` setting is set to true. 

it's a bit sneaky but it means our custom condition doesn't have to call back to the server to get a setting or anything, it can read the registered section manifests from Umbraco to know if the section exists and act accordingly 

so now. 

```json
"uSync": {
  "Settings": {
     "MoveToSection": true
  }
}
```

will make uSync use the 'syncronisation' section for it's tree,
- the section will need to be added to user groups for them to see it. 