### PR TITLE
Fix #800 Add blockItemConverters 

### DIFF
--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -31,6 +31,8 @@ public static class JsonTextExtensions
             new JsonUdiRangeConverter(),
             new JsonBooleanConverter(),
             new JsonXElementConverter(),
+            new JsonBlockListLayoutItemConverter(),
+            new JsonBlockGridLayoutItemConverter()
         }
     };
 

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -61,10 +61,15 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
         // we could just not write out the obsolete properties, but they will appear as null it 
         // lots of people's existing exports , so we can write them out as null to keep things consistent.
         writer.WriteStartObject();
-        writer.WriteString("contentKey", value.ContentKey.ToString() ?? "null");
-        writer.WriteString("contentUdi", "null");
-        writer.WriteString("settingsKey", value.SettingsKey.ToString() ?? "null");
-        writer.WriteString("settingsUdi", "null");
+        writer.WriteString("contentKey", value.SettingsKey.ToString());
+        writer.WriteNull("contentUdi");
+
+        if (value.SettingsKey.HasValue && value.SettingsKey != Guid.Empty)
+            writer.WriteString("settingsKey", value.SettingsKey.ToString());
+        else
+            writer.WriteNull("settingsKey");
+
+        writer.WriteNull("settingsUdi");
         writer.WriteEndObject();
     }
 }

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -60,7 +60,7 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
         // we could just not write out the obsolete properties, but they will appear as null it 
         // lots of people's existing exports , so we can write them out as null to keep things consistent.
         writer.WriteStartObject();
-        writer.WriteString("contentKey", value.SettingsKey.ToString());
+        writer.WriteString("contentKey", value.ContentKey.ToString());
         writer.WriteNull("contentUdi");
 
         if (value.SettingsKey.HasValue && value.SettingsKey != Guid.Empty)

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -2,7 +2,6 @@
 using System.Text.Json.Serialization;
 
 using Umbraco.Cms.Core.Models.Blocks;
-using Umbraco.Extensions;
 
 namespace uSync.Core.Json;
 

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -1,0 +1,74 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Extensions;
+
+namespace uSync.Core.Json;
+
+/// <summary>
+/// in v16 the BlockLayoutItem(s) have obsolete properties that are sometimes set and sometimes not
+/// this leads to false positive's when looking for changes. 
+/// 
+///  these two custom converters write those properties out as null, so they never change. causing
+///  the serialized json to be consistent. 
+/// </summary>
+
+public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
+    where T : BlockLayoutItemBase, new()
+{
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Invalid JSON expecting start object");
+
+        var item = new T();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return item;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expecting property name");
+
+            var propertyName = reader.GetString();
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case "contentKey":
+                    var contentKey = reader.GetString();
+                    if (contentKey != null && Guid.TryParse(contentKey, out var contentGuid))
+                        item.ContentKey = contentGuid;
+                    break;
+                case "settingsKey":
+                    var settingsKey = reader.GetString();
+                    if (settingsKey != null && Guid.TryParse(settingsKey, out var settingsGuid))
+                        item.SettingsKey = settingsGuid;
+                    break;
+                default:
+                    // we don't care about the obsolete properties here...
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of JSON");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        // we could just not write out the obsolete properties, but they will appear as null it 
+        // lots of people's existing exports , so we can write them out as null to keep things consistent.
+        writer.WriteStartObject();
+        writer.WriteString("contentKey", value.ContentKey.ToString() ?? "null");
+        writer.WriteString("contentUdi", "null");
+        writer.WriteString("settingsKey", value.SettingsKey.ToString() ?? "null");
+        writer.WriteString("settingsUdi", "null");
+        writer.WriteEndObject();
+    }
+}
+
+public class JsonBlockListLayoutItemConverter : JsonBlockItemConverterBase<BlockListLayoutItem> { }
+
+public class JsonBlockGridLayoutItemConverter : JsonBlockItemConverterBase<BlockGridLayoutItem> { }

--- a/uSync.Core/Json/XElementJsonConverter.cs
+++ b/uSync.Core/Json/XElementJsonConverter.cs
@@ -2,8 +2,6 @@
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 
-using Umbraco.Cms.Core.Models.Blocks;
-
 namespace uSync.Core.Json;
 
 public class JsonXElementConverter : JsonConverter<XElement>

--- a/uSync.Core/Json/XElementJsonConverter.cs
+++ b/uSync.Core/Json/XElementJsonConverter.cs
@@ -2,6 +2,8 @@
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 
+using Umbraco.Cms.Core.Models.Blocks;
+
 namespace uSync.Core.Json;
 
 public class JsonXElementConverter : JsonConverter<XElement>
@@ -16,3 +18,4 @@ public class JsonXElementConverter : JsonConverter<XElement>
         writer.WriteStringValue(value.ToString());
     }
 }
+


### PR DESCRIPTION
In v16 the `BlockLayoutItem` classes have two obsolete properties (ContentUdi, SettingsUdi) these are often null, but sometimes not, depending on how you have asked for the content item. 

these being set sometimes can cause us to think the content property has changed, when it hasn't so we get false positives, and things import when they don't need to import. 

adding our own custom JsonConverters for `BlockListLayoutItem` and `BlockGridLayoutItem`, means we can control exactly how these elements are handled in the json. 

these converters always write the old values out as null, (as they are not used). and this way they are consitant, and also appear as they are most likely to appear in existing imports. 

for v18 we will remove them so only the keys get written out. 