### PR TITLE
only check for legacy when the default folder hasn't been changed.

### DIFF
--- a/uSync.BackOffice/Legacy/SyncLegacyService.cs
+++ b/uSync.BackOffice/Legacy/SyncLegacyService.cs
@@ -42,7 +42,7 @@ internal class SyncLegacyService : ISyncLegacyService
     {
         folder = null;
 
-        // if the default folder is not point to latest, then we don't check for legacy. 
+        // if the default folder does not point to latest, then we don't check for legacy. 
         var latest = _configService.GetFolders().Last();
         if (latest.Contains($"uSync/v{_majorVersion}/", StringComparison.OrdinalIgnoreCase) is false)
             return false;

--- a/uSync.BackOffice/Legacy/SyncLegacyService.cs
+++ b/uSync.BackOffice/Legacy/SyncLegacyService.cs
@@ -43,9 +43,7 @@ internal class SyncLegacyService : ISyncLegacyService
         folder = null;
 
         // if the default folder is not point to latest, then we don't check for legacy. 
-        var latest = _configService.GetFolders().Last();
-        if (latest.Contains($"uSync/v{_majorVersion}/", StringComparison.OrdinalIgnoreCase) is false)
-            return false;
+        if (HasDefaultConfigFolder() is false) return false;
 
         for (int n = _majorVersion - 1; n > 8; n--)
         {
@@ -61,6 +59,18 @@ internal class SyncLegacyService : ISyncLegacyService
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///  Check to see if the last folder in the current config, is the default one for this version.
+    /// </summary>
+    private bool HasDefaultConfigFolder()
+    {
+        var folders = _configService.GetFolders();
+        if (folders is null || folders.Length == 0)
+            return false;
+
+        return folders.Last().Contains($"uSync/v{_majorVersion}/", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc/>

--- a/uSync.BackOffice/Legacy/SyncLegacyService.cs
+++ b/uSync.BackOffice/Legacy/SyncLegacyService.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
+using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Services;
 using uSync.Core;
 
@@ -27,16 +29,23 @@ internal class SyncLegacyService : ISyncLegacyService
     };
 
     private readonly ISyncFileService _syncFileService;
+    private readonly ISyncConfigService _configService;
 
-    public SyncLegacyService(ISyncFileService syncFileService)
+    public SyncLegacyService(ISyncFileService syncFileService, ISyncConfigService configService)
     {
         _syncFileService = syncFileService;
+        _configService = configService;
     }
 
     /// <inheritdoc/>
     public bool TryGetLatestLegacyFolder([MaybeNullWhen(false)] out string? folder)
     {
         folder = null;
+
+        // if the default folder is not point to latest, then we don't check for legacy. 
+        var latest = _configService.GetFolders().Last();
+        if (latest.Contains($"uSync/v{_majorVersion}/", StringComparison.OrdinalIgnoreCase) is false)
+            return false;
 
         for (int n = _majorVersion - 1; n > 8; n--)
         {

--- a/uSync.BackOffice/Models/SyncFinalActionRequest.cs
+++ b/uSync.BackOffice/Models/SyncFinalActionRequest.cs
@@ -41,3 +41,15 @@ public class SyncFinalActionRequest
     public uSyncCallbacks? Callbacks { get; set; }
 }
 
+public class SyncStartActionRequest
+{
+    /// <summary>
+    ///  current handler action (e.g import, export)
+    /// </summary>
+    public HandlerActions HandlerAction { get; set; } = HandlerActions.None;
+
+    /// <summary>
+    ///  user of the person who triggered the process
+    /// </summary>
+    public string? Username { get; set; }
+}

--- a/uSync.BackOffice/Services/ISyncActionService.cs
+++ b/uSync.BackOffice/Services/ISyncActionService.cs
@@ -46,7 +46,13 @@ public interface ISyncActionService
     /// <summary>
     ///  run an export based on the options provided
     /// </summary>
+    [Obsolete("Use StartProcessAsync(SyncStartActionRequest request) will be removed in v18")]
     Task StartProcessAsync(HandlerActions action);
+
+    /// <summary>
+    ///  run an export based on the options provided
+    /// </summary>
+    Task StartProcessAsync(SyncStartActionRequest request);
 
     /// <summary>
     ///  finish the bulk process

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Resources;
 using System.Threading.Tasks;
 
 using uSync.BackOffice.Configuration;
@@ -183,12 +184,17 @@ internal class SyncActionService : ISyncActionService
     private static Stopwatch? _timer;
 
     /// <inheritdoc/>
-    public async Task StartProcessAsync(HandlerActions action)
+    public async Task StartProcessAsync(SyncStartActionRequest request)
     {
-        _logger.LogInformation("Starting {action} process", action);
+        _logger.LogInformation("[uSync {version}] {user} Starting {action} process",
+                uSync.Version.ToString(3), request.Username, request.HandlerAction);
         _timer = Stopwatch.StartNew();
-        await _uSyncService.StartBulkProcessAsync(action);
+        await _uSyncService.StartBulkProcessAsync(request.HandlerAction);
     }
+
+    /// <inheritdoc/>
+    public async Task StartProcessAsync(HandlerActions action)
+        => await StartProcessAsync(new SyncStartActionRequest { HandlerAction = action, Username = "" });
 
     /// <inheritdoc/>
     public async Task<SyncActionResult> FinishProcessAsync(SyncFinalActionRequest request)
@@ -198,10 +204,11 @@ internal class SyncActionService : ISyncActionService
         _timer?.Stop();
         var elapsed = _timer?.ElapsedMilliseconds ?? 0;
 
-        _logger.LogInformation("{user} finished {action} process ({changes} changes {time})",
-            request.Username, request.HandlerAction, request.Actions.Count(), elapsed);
+        _logger.LogInformation("[uSync {version}] {user} finished {action} process ({changes}/{count} changes) in ({time:#,#}ms)",
+            uSync.Version.ToString(3), request.Username, request.HandlerAction,
+            request.Actions.CountChanges(), request.Actions.Count(), elapsed);
 
-        request.Callbacks?.Update?.Invoke("Process completed", 1, 1);
+        request.Callbacks?.Update?.Invoke($"{request.HandlerAction} completed ({elapsed:#,#}ms)", 1, 1);
 
         // for speed we return an empty list. the merge will just take 
         // what we where passed in, and we avoid a whole copy and compare step

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -179,17 +180,26 @@ internal class SyncActionService : ISyncActionService
         return string.Empty;
     }
 
+    private static Stopwatch? _timer;
+
     /// <inheritdoc/>
     public async Task StartProcessAsync(HandlerActions action)
-        => await _uSyncService.StartBulkProcessAsync(action);
+    {
+        _logger.LogInformation("Starting {action} process", action);
+        _timer = Stopwatch.StartNew();
+        await _uSyncService.StartBulkProcessAsync(action);
+    }
 
     /// <inheritdoc/>
     public async Task<SyncActionResult> FinishProcessAsync(SyncFinalActionRequest request)
     {
         await _uSyncService.FinishBulkProcessAsync(request.HandlerAction, request.Actions);
 
-        _logger.LogInformation("{user} finished {action} process ({changes} changes)",
-            request.Username, request.HandlerAction, request.Actions.Count());
+        _timer?.Stop();
+        var elapsed = _timer?.ElapsedMilliseconds ?? 0;
+
+        _logger.LogInformation("{user} finished {action} process ({changes} changes {time})",
+            request.Username, request.HandlerAction, request.Actions.Count(), elapsed);
 
         request.Callbacks?.Update?.Invoke("Process completed", 1, 1);
 

--- a/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
@@ -171,12 +171,11 @@ internal class uSyncManagementService : ISyncManagementService
         var handlers = _syncActionService.GetActionHandlers(action, actionRequest.Options)
             .ToList();
 
-        if (action == HandlerActions.Export && string.IsNullOrWhiteSpace(actionRequest.RequestId))
+        if (string.IsNullOrWhiteSpace(actionRequest.RequestId) is true)
         {
             await _syncActionService.StartProcessAsync(action);
 
-            // first step in an export.
-            if (actionRequest.Options?.Clean is true)
+            if (action == HandlerActions.Export && actionRequest.Options?.Clean is true)
             {
                 // clean the export folder.  
                 _syncActionService.CleanExportFolder();

--- a/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
@@ -173,7 +173,11 @@ internal class uSyncManagementService : ISyncManagementService
 
         if (string.IsNullOrWhiteSpace(actionRequest.RequestId) is true)
         {
-            await _syncActionService.StartProcessAsync(action);
+            await _syncActionService.StartProcessAsync(new SyncStartActionRequest
+            {
+                Username = user?.Username,
+                HandlerAction = action
+            });
 
             if (action == HandlerActions.Export && actionRequest.Options?.Clean is true)
             {
@@ -259,7 +263,6 @@ internal class uSyncManagementService : ISyncManagementService
         // when complete we clean out our action cache.
         _syncManagementCache.Clear(requestId);
 
-        callbacks?.Update?.Invoke("Finished", 1, 1);
         return [.. actionResults.Where(x => x.Change != Core.ChangeType.Hidden)];
     }
 

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "16.0.7-build.20251002.2",
+	"version": "16.0.7-build.20251002.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "16.0.7-build.20251002.2",
+			"version": "16.0.7-build.20251002.6",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -2,7 +2,7 @@
 	"name": "@jumoo/usync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "16.0.7-build.20251002.2",
+	"version": "16.0.7-build.20251002.6",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",


### PR DESCRIPTION
We run a legacy check on the dashboard that looks for older versions of uSync from v8 up (e.g /uSync/v10, /uSync/v13) .

If any of them exist below the current version the legacy tab appears. 

This change checks the config first, and if you have changed the default folders setting so you are not pointing at /uSync/{latest} then the legacy check doesn't run, because you clearly know what you want. 

*legacy checks exists so we can do migrations or at least alert people when they have some potentially unmigratable data in their uSync folder. over-riding the legacy check would mean you don't see this*