### PR TITLE
Fix: Compiled Views Content

### DIFF
--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -144,6 +144,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             }
         }
 
+        if (ViewsAreCompiled(options) && string.IsNullOrWhiteSpace(item.Content))
+        {
+            if (contentAttempt.Result != item.Content)
+            { 
+                details.AddUpdate("Content", item.Content ?? string.Empty, contentAttempt.Result ?? string.Empty);
+                item.Content = contentAttempt.Result;
+            }
+        }
+
         return SyncAttempt<ITemplate>.Succeed(item.Name, item, ChangeType.Import, details);
     }
 


### PR DESCRIPTION
Ensure compiled templates get the uSync:Id comment added so we know they are safe to delete.

- We where missing the code to add the <!-- uSync:id --> comment to empty templates that Umbraco creates when we create content, that we actually want to delete.

without the uSync:id then these values don't get removed and they just linger as empty files in the views folder.

