### PR TITLE
move away from uui-table-row 

### DIFF
--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/index.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/index.ts
@@ -4,3 +4,4 @@ export * from './usync-progress-box.js';
 export * from './usync-results-view.js';
 export * from './usync-change-view.js';
 export * from './usync-results-group-view.js';
+export * from './usync-result-row.js';

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-result-row.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-result-row.ts
@@ -48,11 +48,13 @@ export class uSyncResultRow extends UmbLitElement {
 		const noChange =
 			result.change == ChangeType.NO_CHANGE || result.change == ChangeType.EXPORT;
 
-		return html`<div class="${classMap({ no_change: noChange })} row">
+		return html`<div
+			class="${classMap({ no_change: noChange })} row"
+			@click=${() => this.#showDetail(result)}>
 			<div class="icon-cell" .noPadding=${true}>
 				<umb-icon .name=${icon}></umb-icon>
 			</div>
-			<div class="row-content" @click=${() => this.#showDetail(result)} .clipText=${true}>
+			<div class="row-content" .clipText=${true}>
 				<div class="item-detail">
 					<div class="item-change">${result.change}</div>
 				</div>
@@ -119,4 +121,12 @@ export class uSyncResultRow extends UmbLitElement {
 			min-width: 60px;
 		}
 	`;
+}
+
+export default uSyncResultRow;
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'usync-result-row': uSyncResultRow;
+	}
 }

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-result-row.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-result-row.ts
@@ -1,0 +1,122 @@
+import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
+import { ChangeType, USyncActionView } from '../api';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap, css, html } from '@umbraco-cms/backoffice/external/lit';
+import { uSyncShowDetailEvent } from './events';
+import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
+import { USYNC_ERROR_MODAL } from '../dialogs';
+
+@customElement('usync-result-row')
+export class uSyncResultRow extends UmbLitElement {
+	@property({ type: Object })
+	result?: USyncActionView;
+
+	async #showDetail(action: USyncActionView) {
+		if (action.change == ChangeType.NO_CHANGE || action.change == ChangeType.EXPORT)
+			return;
+
+		this.dispatchEvent(new uSyncShowDetailEvent(action));
+	}
+
+	async #viewError(e: Event, result: USyncActionView) {
+		e.stopPropagation();
+		const modalContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
+		const modal = modalContext?.open(this, USYNC_ERROR_MODAL, {
+			data: {
+				action: result,
+			},
+		});
+
+		const data = await modal?.onSubmit().catch(() => {
+			return;
+		});
+
+		return data;
+	}
+
+	render() {
+		if (!this.result) return null;
+		const result = this.result;
+
+		const icon =
+			result.change == ChangeType.NO_CHANGE
+				? 'icon-trafic'
+				: result.success
+					? 'icon-check color-green'
+					: 'icon-wrong color-red';
+
+		const noChange =
+			result.change == ChangeType.NO_CHANGE || result.change == ChangeType.EXPORT;
+
+		return html`<div class="${classMap({ no_change: noChange })} row">
+			<div class="icon-cell" .noPadding=${true}>
+				<umb-icon .name=${icon}></umb-icon>
+			</div>
+			<div class="row-content" @click=${() => this.#showDetail(result)} .clipText=${true}>
+				<div class="item-detail">
+					<div class="item-change">${result.change}</div>
+				</div>
+				<div class="item-name">
+					<div>${result.name}</div>
+					<div>${this.renderMessage(result)}</div>
+				</div>
+			</div>
+		</div>`;
+	}
+
+	renderMessage(result: USyncActionView) {
+		return (result.change != ChangeType.FAIL &&
+			result.change != ChangeType.IMPORT_FAIL) ||
+			!result.message
+			? html`<em>${result.message}</em>`
+			: html` <uui-button
+					look="outline"
+					color="danger"
+					label="View error"
+					compact
+					@click=${(e: Event) => this.#viewError(e, result)}></uui-button>`;
+	}
+
+	static styles = css`
+		.row {
+			display: flex;
+			align-items: center;
+			gap: var(--uui-size-space-5);
+			padding: var(--uui-size-space-5);
+			border-bottom: 1px solid var(--uui-color-border);
+			cursor: pointer;
+		}
+
+		.row:hover {
+			background-color: var(--uui-color-surface-alt);
+		}
+
+		.no_change {
+			color: var(--uui-color-disabled-contrast);
+			cursor: default;
+		}
+
+		.row-content {
+			gap: 10px;
+			flex-grow: 1;
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+		}
+
+		.item-name {
+			display: flex;
+			font-weight: bold;
+			align-items: center;
+			flex-grow: 2;
+			justify-content: space-between;
+		}
+
+		.item-detail {
+			display: flex;
+			flex-direction: column;
+			font-size: smaller;
+			min-width: 60px;
+		}
+	`;
+}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
@@ -73,43 +73,10 @@ export class uSyncResultGroupView extends UmbLitElement {
 	renderGroupedRows(results?: USyncActionView[]) {
 		const rowsHtml = results?.map((result) => {
 			if (!this.showAll && result.change == ChangeType.NO_CHANGE) return nothing;
-
-			const icon =
-				result.change == ChangeType.NO_CHANGE
-					? 'icon-trafic'
-					: result.success
-						? 'icon-check color-green'
-						: 'icon-wrong color-red';
-
-			const isChange =
-				result.change != ChangeType.NO_CHANGE && result.change != ChangeType.EXPORT;
-
-			const changeCount = result.details.length;
-
-			return html`
-				<uui-table-row
-					class=${classMap({ changerow: isChange, no_change: changeCount == 0 })}>
-					<uui-table-cell class="icon-cell" .noPadding=${true}>
-						<umb-icon .name=${icon}></umb-icon>
-					</uui-table-cell>
-					<uui-table-cell
-						@click=${() => this.#showDetail(result)}
-						.clipText=${true}
-						style="--uui-table-cell-padding: var(--uui-size-space-2);">
-						<div class="item-name">
-							<div>${result.name}</div>
-							<div>${this.renderMessage(result)}</div>
-						</div>
-						<div class="item-detail">
-							<div>${result.itemType}</div>
-							<div>${result.change}</div>
-						</div>
-					</uui-table-cell>
-				</uui-table-row>
-			`;
+			return html`<usync-result-row .result=${result}></usync-result-row>`;
 		});
 
-		return html`${rowsHtml}`;
+		return rowsHtml;
 	}
 
 	renderMessage(result: USyncActionView) {

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
@@ -10,9 +10,6 @@ import {
 } from '@umbraco-cms/backoffice/external/lit';
 import { UmbLitElement } from '@umbraco-cms/backoffice/lit-element';
 import { ChangeType, USyncActionView } from '../api';
-import { UMB_MODAL_MANAGER_CONTEXT } from '@umbraco-cms/backoffice/modal';
-import { USYNC_ERROR_MODAL } from '../dialogs';
-import { uSyncShowDetailEvent } from './events';
 
 @customElement('usync-result-group')
 export class uSyncResultGroupView extends UmbLitElement {
@@ -27,13 +24,6 @@ export class uSyncResultGroupView extends UmbLitElement {
 
 	@property({ type: String })
 	groupName: string = '';
-
-	async #showDetail(action: USyncActionView) {
-		if (action.change == ChangeType.NO_CHANGE || action.change == ChangeType.EXPORT)
-			return;
-
-		this.dispatchEvent(new uSyncShowDetailEvent(action));
-	}
 
 	getChangeCount() {
 		return this.results?.filter((r) => r.change !== ChangeType.NO_CHANGE).length;
@@ -79,35 +69,6 @@ export class uSyncResultGroupView extends UmbLitElement {
 		return rowsHtml;
 	}
 
-	renderMessage(result: USyncActionView) {
-		return (result.change != ChangeType.FAIL &&
-			result.change != ChangeType.IMPORT_FAIL) ||
-			!result.message
-			? html`<em>${result.message}</em>`
-			: html` <uui-button
-					look="default"
-					color="danger"
-					label="View error"
-					compact
-					@click=${(e: Event) => this.#viewError(e, result)}></uui-button>`;
-	}
-
-	async #viewError(e: Event, result: USyncActionView) {
-		e.stopPropagation();
-		const modalContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
-		const modal = modalContext?.open(this, USYNC_ERROR_MODAL, {
-			data: {
-				action: result,
-			},
-		});
-
-		const data = await modal?.onSubmit().catch(() => {
-			return;
-		});
-
-		return data;
-	}
-
 	static styles = css`
 		uui-box {
 			cursor: pointer;
@@ -142,39 +103,8 @@ export class uSyncResultGroupView extends UmbLitElement {
 			border-bottom: none;
 		}
 
-		.has_changes .count {
+		.count {
 			color: var(--uui-text);
-		}
-
-		.changerow {
-			cursor: pointer;
-		}
-
-		.icon-cell {
-			padding-left: 20px;
-			width: var(--uui-size-8);
-		}
-
-		.item-name {
-			display: flex;
-			justify-content: space-between;
-			padding-right: 20px;
-		}
-
-		.item-detail {
-			display: flex;
-			justify-content: space-between;
-			font-size: smaller;
-			color: var(--uui-color-disabled-contrast);
-			padding-right: 20px;
-		}
-
-		uui-table-row:first-child uui-table-cell {
-			border-top-color: transparent;
-		}
-
-		uui-table-row:hover {
-			background-color: var(--uui-color-surface-emphasis);
 		}
 	`;
 }


### PR DESCRIPTION
changes the rendering of individual result rows to use styled `div` elements over uui-table-row, because uui-table-row is slow when we add hundreds of them to the lists. 

this makes the rendering of all changes much quicker in the dashboard.