### PR TITLE
V13/create only report fix

### DIFF
--- a/uSync.BackOffice/Hubs/SyncHub.cs
+++ b/uSync.BackOffice/Hubs/SyncHub.cs
@@ -1,14 +1,18 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 
-using Microsoft.AspNetCore.SignalR;
+using Umbraco.Cms.Web.Common.Authorization;
 
 namespace uSync.BackOffice.Hubs
 {
     /// <summary>
     ///  SignalR Hub
     /// </summary>
+    [Authorize(Policy = uSyncHubPolicy.AccessHub)]
     public class SyncHub : Hub<ISyncHub>
     {
         /// <summary>

--- a/uSync.BackOffice/Hubs/uSyncHubAuthorizationHandler.cs
+++ b/uSync.BackOffice/Hubs/uSyncHubAuthorizationHandler.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Web.BackOffice.Authorization;
+
+namespace uSync.BackOffice.Hubs;
+
+public class uSyncHubAuthorizationHandler : MustSatisfyRequirementAuthorizationHandler<uSyncHubRequirement>
+{
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public uSyncHubAuthorizationHandler(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    protected override Task<bool> IsAuthorized(AuthorizationHandlerContext context, uSyncHubRequirement requirement)
+    {
+        var current = _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser;
+        return Task.FromResult(current != null);
+    }
+}
+
+public class uSyncHubRequirement : IAuthorizationRequirement
+{ 
+}
+
+public static class uSyncHubPolicy
+{
+    public const string AccessHub = "uSyncHubPolicy";
+}

--- a/uSync.BackOffice/Hubs/uSyncHubMiddleware.cs
+++ b/uSync.BackOffice/Hubs/uSyncHubMiddleware.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Extensions;
+
+namespace uSync.BackOffice.Hubs;
+
+public class uSyncHubMiddleware : IMiddleware
+{
+    private readonly IBackOfficeSecurityAccessor _backOfficeSecurityAccessor;
+
+    public uSyncHubMiddleware(IBackOfficeSecurityAccessor backOfficeSecurityAccessor)
+    {
+        _backOfficeSecurityAccessor = backOfficeSecurityAccessor;
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        CookieAuthenticationOptions cookieOptions = context.RequestServices
+                    .GetRequiredService<IOptionsSnapshot<CookieAuthenticationOptions>>()
+                    .Get(Constants.Security.BackOfficeAuthenticationType);
+
+        if (cookieOptions.Cookie.Name is null)
+        {
+            await next(context);
+            return;
+        }
+        var chunkingCookieManager = new ChunkingCookieManager();
+        var cookie = chunkingCookieManager.GetRequestCookie(context, cookieOptions.Cookie.Name);
+
+        if (!string.IsNullOrEmpty(cookie))
+        {
+            AuthenticationTicket unprotected = cookieOptions.TicketDataFormat.Unprotect(cookie);
+            ClaimsIdentity backOfficeIdentity = unprotected?.Principal.GetUmbracoIdentity();
+
+            if (backOfficeIdentity != null)
+            {
+                // Ok, we've got a real ticket, now we can add this ticket's identity to the current
+                // Principal, this means we'll have 2 identities assigned to the principal which we can
+                // use to authorize the preview and allow for a back office User.
+                context.User = new ClaimsPrincipal(backOfficeIdentity);
+                EnsureBackOfficeUser();
+            }
+        }
+
+        await next(context);
+    }
+
+    private void EnsureBackOfficeUser()
+        => _ = _backOfficeSecurityAccessor.BackOfficeSecurity.CurrentUser;
+}

--- a/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
@@ -56,84 +56,7 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         {
             this.localizationService = localizationService;
         }
-
-        /// <inheritdoc/>
-        public override IEnumerable<uSyncAction> Import(string filePath, HandlerSettings config, SerializerFlags flags)
-        {
-            if (IsOneWay(config))
-            {
-                // only sync dictionary items if they are new
-                // so if it already exists we don't do the sync
-
-                //
-                // <Handler Alias="dictionaryHandler" Enabled="true">
-                //    <Add Key="OneWay" Value="true" />
-                // </Handler>
-                //
-                var item = GetExistingItem(filePath);
-                if (item != null)
-                {
-                    return uSyncAction.SetAction(true, item.ItemKey, change: ChangeType.NoChange).AsEnumerableOfOne();
-                }
-            }
-
-            return base.Import(filePath, config, flags);
-
-        }
-
-        private IDictionaryItem GetExistingItem(string filePath)
-        {
-            syncFileService.EnsureFileExists(filePath);
-
-            using (var stream = syncFileService.OpenRead(filePath))
-            {
-                var node = XElement.Load(stream);
-                return serializer.FindItem(node);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override IEnumerable<uSyncAction> ExportAll(string folder, HandlerSettings config, SyncUpdateCallback callback)
-        {
-            syncFileService.CleanFolder(folder);
-            return ExportAll(Guid.Empty, folder, config, callback);
-        }
-
-        /// <summary>
-        ///  Export all Dictionary items based on a parent GUID value
-        /// </summary>
-        /// <remarks>
-        ///  You can't fetch dictionary items via the entity service so they require their own 
-        ///  export method. 
-        /// </remarks>
-        public IEnumerable<uSyncAction> ExportAll(Guid parent, string folder, HandlerSettings config, SyncUpdateCallback callback)
-        {
-            var actions = new List<uSyncAction>();
-
-            var items = new List<IDictionaryItem>();
-
-            if (parent == Guid.Empty)
-            {
-                items = localizationService.GetRootDictionaryItems().ToList();
-            }
-            else
-            {
-                items = localizationService.GetDictionaryItemChildren(parent).ToList();
-            }
-
-            int count = 0;
-            foreach (var item in items)
-            {
-                count++;
-                callback?.Invoke(item.ItemKey, count, items.Count);
-
-                actions.AddRange(Export(item, folder, config));
-                actions.AddRange(ExportAll(item.Key, folder, config, callback));
-            }
-
-            return actions;
-        }
-
+       
         /// <inheritdoc/>
         protected override IEnumerable<IEntity> GetFolders(int parent)
             => GetChildItems(parent);
@@ -164,26 +87,5 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         /// <inheritdoc/>
         protected override string GetItemPath(IDictionaryItem item, bool useGuid, bool isFlat)
             => item.ItemKey.ToSafeFileName(shortStringHelper);
-
-        /// <inheritdoc/>
-        protected override IEnumerable<uSyncAction> ReportElement(XElement node, string filename, HandlerSettings config)
-        {
-            if (config != null && IsOneWay(config))
-            {
-                // if we find it then there is no change. 
-                var item = GetExistingItem(filename);
-                if (item != null)
-                {
-                    return uSyncActionHelper<IDictionaryItem>
-                        .ReportAction(ChangeType.NoChange, item.ItemKey, node.GetPath(), syncFileService.GetSiteRelativePath(filename), item.Key, this.Alias, "Existing Item will not be overwritten")
-                        .AsEnumerableOfOne<uSyncAction>();
-                }
-            }
-
-            return base.ReportElement(node, filename, config);
-        }
-
-        private bool IsOneWay(HandlerSettings config)
-            => config.GetSetting("OneWay", false);
     }
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1428,6 +1428,14 @@ namespace uSync.BackOffice.SyncHandlers
         {
             try
             {
+                if (!ShouldImport(node, settings))
+                {
+                    return uSyncActionHelper<TObject>.ReportAction(ChangeType.NoChange, node.GetAlias(), node.GetPath(), syncFileService.GetSiteRelativePath(filename), node.GetKey(),
+                        this.Alias, "Will not be imported (Based on configuration)")
+                        .AsEnumerableOfOne<uSyncAction>();
+                }
+
+
                 //  starting reporting notification
                 //  this lets us intercept a report and 
                 //  shortcut the checking (sometimes).

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -109,12 +109,26 @@ namespace uSync.BackOffice
         /// </summary>
         public static IServiceCollection AdduSyncSignalR(this IServiceCollection services)
         {
+            services.AddSingleton<IAuthorizationHandler, uSyncHubAuthorizationHandler>();
+            services.AddSingleton<uSyncHubMiddleware>();
+
+            services.AddAuthorization(o =>
+            {
+                o.AddPolicy(uSyncHubPolicy.AccessHub, policy =>
+                {
+                    policy.AuthenticationSchemes.Add(Constants.Security.BackOfficeAuthenticationType);
+                    policy.Requirements.Add(new uSyncHubRequirement());
+                });
+            });
 
             services.Configure<UmbracoPipelineOptions>(options =>
             {
                 options.AddFilter(new UmbracoPipelineFilter(
                     "uSync",
-                    applicationBuilder => { },
+                    applicationBuilder => {
+                        applicationBuilder.UseWhen(x => x.Request.Path.StartsWithSegments("/umbraco/SyncHub", StringComparison.OrdinalIgnoreCase),
+                            appBuilder => appBuilder.UseMiddleware<uSyncHubMiddleware>());
+                    },
                     applicationBuilder => { },
                     applicationBuilder =>
                     {


### PR DESCRIPTION
Update the base report method to make sure it checks the `ShouldImport` method before reporting, this means we will only report changes that might actualy be imported.

Remove a lot of redundant overrides from the DictionaryHandler because the base was already doing those checks on import and export, and now it also does them on report. 

will fix #815 

