### PR TITLE
check "ShouldImport" on all report steps.

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/DictionaryHandler.cs
@@ -56,84 +56,6 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         {
             this.localizationService = localizationService;
         }
-
-        /// <inheritdoc/>
-        public override IEnumerable<uSyncAction> Import(string filePath, HandlerSettings config, SerializerFlags flags)
-        {
-            if (IsOneWay(config))
-            {
-                // only sync dictionary items if they are new
-                // so if it already exists we don't do the sync
-
-                //
-                // <Handler Alias="dictionaryHandler" Enabled="true">
-                //    <Add Key="OneWay" Value="true" />
-                // </Handler>
-                //
-                var item = GetExistingItem(filePath);
-                if (item != null)
-                {
-                    return uSyncAction.SetAction(true, item.ItemKey, change: ChangeType.NoChange).AsEnumerableOfOne();
-                }
-            }
-
-            return base.Import(filePath, config, flags);
-
-        }
-
-        private IDictionaryItem GetExistingItem(string filePath)
-        {
-            syncFileService.EnsureFileExists(filePath);
-
-            using (var stream = syncFileService.OpenRead(filePath))
-            {
-                var node = XElement.Load(stream);
-                return serializer.FindItem(node);
-            }
-        }
-
-        /// <inheritdoc/>
-        public override IEnumerable<uSyncAction> ExportAll(string folder, HandlerSettings config, SyncUpdateCallback callback)
-        {
-            syncFileService.CleanFolder(folder);
-            return ExportAll(Guid.Empty, folder, config, callback);
-        }
-
-        /// <summary>
-        ///  Export all Dictionary items based on a parent GUID value
-        /// </summary>
-        /// <remarks>
-        ///  You can't fetch dictionary items via the entity service so they require their own 
-        ///  export method. 
-        /// </remarks>
-        public IEnumerable<uSyncAction> ExportAll(Guid parent, string folder, HandlerSettings config, SyncUpdateCallback callback)
-        {
-            var actions = new List<uSyncAction>();
-
-            var items = new List<IDictionaryItem>();
-
-            if (parent == Guid.Empty)
-            {
-                items = localizationService.GetRootDictionaryItems().ToList();
-            }
-            else
-            {
-                items = localizationService.GetDictionaryItemChildren(parent).ToList();
-            }
-
-            int count = 0;
-            foreach (var item in items)
-            {
-                count++;
-                callback?.Invoke(item.ItemKey, count, items.Count);
-
-                actions.AddRange(Export(item, folder, config));
-                actions.AddRange(ExportAll(item.Key, folder, config, callback));
-            }
-
-            return actions;
-        }
-
         /// <inheritdoc/>
         protected override IEnumerable<IEntity> GetFolders(int parent)
             => GetChildItems(parent);
@@ -164,26 +86,5 @@ namespace uSync.BackOffice.SyncHandlers.Handlers
         /// <inheritdoc/>
         protected override string GetItemPath(IDictionaryItem item, bool useGuid, bool isFlat)
             => item.ItemKey.ToSafeFileName(shortStringHelper);
-
-        /// <inheritdoc/>
-        protected override IEnumerable<uSyncAction> ReportElement(XElement node, string filename, HandlerSettings config)
-        {
-            if (config != null && IsOneWay(config))
-            {
-                // if we find it then there is no change. 
-                var item = GetExistingItem(filename);
-                if (item != null)
-                {
-                    return uSyncActionHelper<IDictionaryItem>
-                        .ReportAction(ChangeType.NoChange, item.ItemKey, node.GetPath(), syncFileService.GetSiteRelativePath(filename), item.Key, this.Alias, "Existing Item will not be overwritten")
-                        .AsEnumerableOfOne<uSyncAction>();
-                }
-            }
-
-            return base.ReportElement(node, filename, config);
-        }
-
-        private bool IsOneWay(HandlerSettings config)
-            => config.GetSetting("OneWay", false);
     }
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1428,6 +1428,13 @@ namespace uSync.BackOffice.SyncHandlers
         {
             try
             {
+                if (!ShouldImport(node, settings))
+                {
+                    return uSyncActionHelper<TObject>.ReportAction(ChangeType.NoChange, node.GetAlias(), node.GetPath(), syncFileService.GetSiteRelativePath(filename), node.GetKey(),
+                        this.Alias, "Will not be imported (Based on configuration)")
+                        .AsEnumerableOfOne<uSyncAction>();
+                }
+
                 //  starting reporting notification
                 //  this lets us intercept a report and 
                 //  shortcut the checking (sometimes).


### PR DESCRIPTION
Fixes #815 

- Makes sure ALL handlers (using the base) check `shouldImport` before reporting, so reports will only show changes that are about to happen.
- Removes a lot of redundant code from the dictionary handler that the base does (including now reporting checking).