### PR TITLE
Offer more granular updates to the ordering process

### DIFF
--- a/uSync.BackOffice/Models/SyncMergeOptions.cs
+++ b/uSync.BackOffice/Models/SyncMergeOptions.cs
@@ -11,5 +11,5 @@ public class SyncMergeOptions
         UpdateCallback = callback;
     }
 
-    public SyncUpdateCallback? UpdateCallback;
+    public SyncUpdateCallback? UpdateCallback { get; set; }
 }

--- a/uSync.BackOffice/Models/SyncMergeOptions.cs
+++ b/uSync.BackOffice/Models/SyncMergeOptions.cs
@@ -1,0 +1,15 @@
+﻿using uSync.BackOffice.SyncHandlers.Interfaces;
+
+namespace uSync.BackOffice.Models;
+
+public class SyncMergeOptions
+{
+    public SyncMergeOptions() { }
+
+    public SyncMergeOptions(SyncUpdateCallback? callback)
+    {
+        UpdateCallback = callback;
+    }
+
+    public SyncUpdateCallback? UpdateCallback;
+}

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -111,7 +111,7 @@ public partial class SyncService : ISyncService
 
 
     #region Importing
-    static SemaphoreSlim _importSemaphoreLock = new SemaphoreSlim(1, 1);
+    static readonly SemaphoreSlim _importSemaphoreLock = new SemaphoreSlim(1, 1);
 
     /// <inheritdoc/>>
     public async Task<IEnumerable<uSyncAction>> StartupImportAsync(string[] folders, bool force, SyncHandlerOptions handlerOptions, uSyncCallbacks? callbacks = null)

--- a/uSync.BackOffice/SyncHandlers/Handlers/LanguageHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/LanguageHandler.cs
@@ -19,6 +19,7 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Models;
 using uSync.BackOffice.Services;
 using uSync.BackOffice.SyncHandlers.Interfaces;
 using uSync.BackOffice.SyncHandlers.Models;
@@ -72,8 +73,8 @@ public class LanguageHandler : SyncHandlerBase<ILanguage>, ISyncHandler,
     /// <summary>
     ///  order the merged items, making sure the default language is first. 
     /// </summary>
-    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
-        => [.. (await base.GetMergedItemsAsync(folders)).OrderBy(x => x.Node.Element("IsDefault").ValueOrDefault(false) ? 0 : 1)];
+    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders, SyncMergeOptions options)
+        => [.. (await base.GetMergedItemsAsync(folders, options)).OrderBy(x => x.Node.Element("IsDefault").ValueOrDefault(false) ? 0 : 1)];
 
     /// <summary>
     ///  ensure we import the 'default' language first, so we don't get errors doing it. 
@@ -162,7 +163,7 @@ public class LanguageHandler : SyncHandlerBase<ILanguage>, ISyncHandler,
         }
     }
 
-    private static ConcurrentDictionary<string, string> _newLanguages = new();
+    private readonly static ConcurrentDictionary<string, string> _newLanguages = new();
 
     /// <inheritdoc/>
     public override async Task HandleAsync(SavingNotification<ILanguage> notification, CancellationToken cancellationToken)

--- a/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
@@ -68,9 +68,9 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
     }
 
     /// <inheritdoc/>
-    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
+    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders, SyncMergeOptions options)
     {
-        var items = await base.GetMergedItemsAsync(folders);
+        var items = await base.GetMergedItemsAsync(folders, options);
         try
         {
             var results = new List<OrderedNodeInfo>();

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -263,7 +263,7 @@ public abstract class SyncHandlerContainerBase<TObject>
 
         var results = new List<OrderedNodeInfo>(sortedList.Count);
 
-        options?.UpdateCallback?.Invoke("Order: Building sorted list", 4, 5);
+        options.UpdateCallback?.Invoke("Order: Building sorted list", 4, 5);
 
         foreach (var key in sortedList)
         {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -234,11 +234,16 @@ public abstract class SyncHandlerContainerBase<TObject>
     /// <summary>
     ///  Get merged items from a collection of folders. 
     /// </summary>
-    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
+    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders, SyncMergeOptions options)
     {
-        var items = await base.GetMergedItemsAsync(folders);
+        options.UpdateCallback?.Invoke("Order: Loading files from disk", 1, 5);
 
+        var items = await base.GetMergedItemsAsync(folders, options);
+
+        options.UpdateCallback?.Invoke("Order: Checking for duplicates", 2, 5);
         CheckForDuplicates(items);
+
+        options.UpdateCallback?.Invoke("Order: Sorting items", 3, 5);
 
         var nodes = items.DistinctBy(x => x.Key).ToDictionary(k => k.Key);
         var renames = nodes.Where(x => x.Value.Node.IsEmptyItem()).Select(x => x.Value);
@@ -258,11 +263,15 @@ public abstract class SyncHandlerContainerBase<TObject>
 
         var results = new List<OrderedNodeInfo>(sortedList.Count);
 
+        options?.UpdateCallback?.Invoke("Order: Building sorted list", 4, 5);
+
         foreach (var key in sortedList)
         {
             if (nodes.TryGetValue(key, out OrderedNodeInfo? value) && value is not null)
                 results.Add(value);
         }
+
+        options?.UpdateCallback?.Invoke("Order: Adding actions", 5, 5);
 
         if (renames.Any())
         {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerLevelBase.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Models;
 using uSync.BackOffice.Services;
 using uSync.Core;
 
@@ -48,8 +49,8 @@ public abstract class SyncHandlerLevelBase<TObject>
     ///  as we are already loading everything to merge, it doesn't
     ///  then cost us much to sort them when we have to.
     /// </remarks>
-    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
-        => [.. (await base.GetMergedItemsAsync(folders)).OrderBy(x => x.Level)];
+    protected override async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders, SyncMergeOptions options)
+        => [.. (await base.GetMergedItemsAsync(folders, options)).OrderBy(x => x.Level)];
 
     /// <inheritdoc/>
     override protected string GetItemPath(TObject item, bool useGuid, bool isFlat)

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -256,7 +256,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
 
-        var items = await GetMergedItemsAsync(folders);
+        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
 
         options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
 
@@ -327,16 +327,21 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// <param name="folders"></param>
     /// <returns></returns>
     public async Task<IReadOnlyList<OrderedNodeInfo>> FetchAllNodesAsync(string[] folders)
-        => await GetMergedItemsAsync(folders);
+        => await GetMergedItemsAsync(folders, new SyncMergeOptions());
 
-    /// <summary>
-    ///  method to get the merged folders, handlers that care about orders should override this. 
-    /// </summary>
-    protected virtual async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
+
+    protected virtual async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders, SyncMergeOptions options)
     {
         var baseTracker = trackers.FirstOrDefault() as ISyncTrackerBase;
         return [.. (await syncFileService.MergeFoldersAsync(folders, uSyncConfig.Settings.DefaultExtension, baseTracker))];
     }
+
+    /// <summary>
+    ///  method to get the merged folders, handlers that care about orders should override this. 
+    /// </summary>
+    [Obsolete("Use GetMergedItemsAsync with SyncMergeOptions will be removed in v18")]
+    protected virtual async Task<IReadOnlyList<OrderedNodeInfo>> GetMergedItemsAsync(string[] folders)
+        => await GetMergedItemsAsync(folders, new SyncMergeOptions());
 
     /// <summary>
     ///  given a file path, will give you the merged values across all folders. 
@@ -1006,9 +1011,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         var cacheKey = PrepCaches();
 
-        callback?.Invoke("Organizing import structure", 1, 3);
+        callback?.Invoke("Calculating order", 1, 3);
 
-        var items = await GetMergedItemsAsync(folders);
+        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(callback));
         var options = new uSyncImportOptions();
 
         int count = 0;
@@ -2008,7 +2013,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     public async Task<XElement?> TryFindItemNodeAsync(Guid key)
     {
         var folders = GetDefaultHandlerFolders();
-        var items = await GetMergedItemsAsync(folders);
+        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions());
 
         foreach (var item in items)
         {


### PR DESCRIPTION
pass in the callback methods to the `GetMergedItemsAsync` method, so we can split up the update a bit (in reality it will still probably fly past, so only the initial file load will seem slow).
