### PR TITLE
Get Correct Content version on second pass events.

### DIFF
--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -535,7 +535,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             if (result.Success && result.Change > ChangeType.NoChange && result.Saved is false && result.Item is not null)
             {
                 logger.LogTrace("Second Pass Import for {alias} - Saving item {key}", this.Alias, node.GetKey());
-                await serializer.SaveAsync(result.Item.AsEnumerableOfOne());
+                await serializer.SaveItemAsync(result.Item);
             }
 
             return uSyncActionHelper<TObject>.SetAction(result, syncFileService.GetSiteRelativePath(fileName), node.GetKey(), this.Alias).AsEnumerableOfOne();

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -31,8 +31,8 @@ public static class JsonTextExtensions
             new JsonUdiRangeConverter(),
             new JsonBooleanConverter(),
             new JsonXElementConverter(),
-            new JsonBlockListLayoutItemConverter(),
-            new JsonBlockGridLayoutItemConverter()
+            // new JsonBlockListLayoutItemConverter(),
+            // new JsonBlockGridLayoutItemConverter()
         }
     };
 

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -29,7 +29,7 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
                 return item;
 
             if (reader.TokenType != JsonTokenType.PropertyName)
-                continue;
+                throw new JsonException("Invalid JSON expecting property name");
 
             var propertyName = reader.GetString();
             reader.Read();

--- a/uSync.Core/Json/JsonBlockItemConverters.cs
+++ b/uSync.Core/Json/JsonBlockItemConverters.cs
@@ -29,7 +29,7 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
                 return item;
 
             if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expecting property name");
+                continue;
 
             var propertyName = reader.GetString();
             reader.Read();

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -378,7 +378,8 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
                 if (changes.Count != 0)
                 {
                     logger.LogDebug("Saving Schedule changes: {item}", item.Name);
-                    contentService.PersistContentSchedule(item, currentSchedules);
+                    var latest = GetByKey(item.Key) ?? item;
+                    contentService.PersistContentSchedule(latest, currentSchedules);
                     return changes;
                 }
 

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -641,7 +641,9 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
 
             var currentSortOrder = item.SortOrder;
 
-            item.SortOrder = sortOrder;
+            var updatedItem = GetByKey(item.Key);
+            if (updatedItem is not null)
+                updatedItem.SortOrder = sortOrder; ;
 
             return uSyncChange.Update(uSyncConstants.Xml.SortOrder, uSyncConstants.Xml.SortOrder, currentSortOrder, sortOrder);
         }

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -674,11 +674,12 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     {
         if (!trashed && item.Trashed)
         {
+            var latestItem = GetByKey(item.Key) ?? item;
             // if the item is trashed, then the change of it's parent 
             // should restore it (as long as we do a move!)
 
-            var restoreParentId = GetRelationParentId(item, restoreParent, relationAlias);
-            MoveItem(item, restoreParentId);
+            var restoreParentId = GetRelationParentId(latestItem, restoreParent, relationAlias);
+            MoveItem(latestItem, restoreParentId);
 
             // clean out any relations for this item (some versions of Umbraco don't do this on a Move)
             CleanRelations(item, relationAlias);
@@ -688,20 +689,21 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         }
         else if (trashed && !item.Trashed)
         {
+            var latestItem = GetByKey(item.Key) ?? item;
             // not already in the recycle bin?
-            if (item.ParentId > Constants.System.RecycleBinContent)
+            if (latestItem.ParentId > Constants.System.RecycleBinContent)
             {
                 // clean any relations that may be there (stops an error)
-                CleanRelations(item, relationAlias);
+                CleanRelations(latestItem, relationAlias);
 
                 // move to the recycle bin    
-                MoveToRecycleBin(item);
+                MoveToRecycleBin(latestItem);
             }
             else
             {
                 // on first import the item might be in the recycle bin, but not marked as trash.
                 // but one does not simple set 'trashed' on a content item.
-                SetTrashed(item);
+                SetTrashed(latestItem);
 
                 AddRelation(relationAlias, restoreParent, item.Id);
             }

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -704,7 +704,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
                 // but one does not simple set 'trashed' on a content item.
                 SetTrashed(latestItem);
 
-                AddRelation(relationAlias, restoreParent, item.Id);
+                AddRelation(relationAlias, restoreParent, latestItem.Id);
             }
 
             return Task.FromResult<uSyncChange?>(uSyncChange.Update("Moved to Bin", item.Name ?? item.Id.ToString(), "", "Recycle Bin"));

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -641,9 +641,8 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
 
             var currentSortOrder = item.SortOrder;
 
-            var updatedItem = GetByKey(item.Key);
-            if (updatedItem is not null)
-                updatedItem.SortOrder = sortOrder; ;
+            var updatedItem = GetByKey(item.Key) ?? item;
+            updatedItem.SortOrder = sortOrder;
 
             return uSyncChange.Update(uSyncConstants.Xml.SortOrder, uSyncConstants.Xml.SortOrder, currentSortOrder, sortOrder);
         }

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -681,7 +681,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
             MoveItem(latestItem, restoreParentId);
 
             // clean out any relations for this item (some versions of Umbraco don't do this on a Move)
-            CleanRelations(item, relationAlias);
+            CleanRelations(latestItem, relationAlias);
 
             return Task.FromResult<uSyncChange?>(uSyncChange.Update("Restored", item.Name ?? item.Id.ToString(), "Recycle Bin", restoreParent.ToString()));
 


### PR DESCRIPTION
This is a little be of a sticking plaster on how the ContentService is updating it's version of the content as we progress (and save/publish it). We really need to return the new version of the item in the result of a couple of functions so it can make it back into the in memory array of items we then use in the second pass. 

at the moment we are reloading the version if the second pass needs to then save it, in theory if something is trashed, with a schedule and not in the right order, that means we load it three times, but that is preferable to loading ever single content item on a second pass that we might not then need. 

the longer term fix is to capture the new version at the place we save/publish it in the first pass, and then we won't have to reload things all the time. .