### PR TITLE
V16/block converters two

### DIFF
--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -60,7 +60,7 @@ public class JsonBlockGridLayoutItemConverter : JsonConverter<BlockGridLayoutIte
             }
         }
 
-        throw new JsonException("Unexpected end of JSON");
+        throw new JsonException("Unexpected end of JSON block");
     }
 
     public override void Write(Utf8JsonWriter writer, BlockGridLayoutItem value, JsonSerializerOptions options)

--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -2,9 +2,6 @@
 using System.Text.Json.Serialization;
 
 using Umbraco.Cms.Core.Models.Blocks;
-using Umbraco.Extensions;
-
-using uSync.Core.Extensions;
 
 namespace uSync.Core.Json;
 

--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -30,33 +30,28 @@ public class JsonBlockGridLayoutItemConverter : JsonConverter<BlockGridLayoutIte
             switch (propertyName)
             {
                 case "areas":
-                case nameof(BlockGridLayoutItem.Areas):
                     var areas = JsonSerializer.Deserialize<List<BlockGridLayoutAreaItem>>(ref reader, options);
                     if (areas != null)
                         item.Areas = [.. areas];
                     break;
                 
                 case "columnSpan":
-                case nameof(BlockGridLayoutItem.ColumnSpan):
                     if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var colSpan))
                         ((BlockGridLayoutItem)item).ColumnSpan = colSpan;
                     break;
                 
                 case "rowSpan":
-                case nameof(BlockGridLayoutItem.RowSpan):
                     if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var rowSpan))
                         ((BlockGridLayoutItem)item).RowSpan = rowSpan;
                     break;
                 
                 case "contentKey":
-                case nameof(BlockGridLayoutItem.ContentKey):
                     var contentKey = reader.GetString();
                     if (contentKey != null && Guid.TryParse(contentKey, out var contentGuid))
                         item.ContentKey = contentGuid;
                     break;
                 
                 case "settingsKey":
-                case nameof(BlockGridLayoutItem.SettingsKey):
                     var settingsKey = reader.GetString();
                     if (settingsKey != null && Guid.TryParse(settingsKey, out var settingsGuid))
                         item.SettingsKey = settingsGuid;

--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -1,0 +1,101 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Extensions;
+
+using uSync.Core.Extensions;
+
+namespace uSync.Core.Json;
+
+public class JsonBlockGridLayoutItemConverter : JsonConverter<BlockGridLayoutItem>
+{
+    public override BlockGridLayoutItem? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Invalid JSON expecting start object");
+
+        var item = new BlockGridLayoutItem();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                return item;
+            
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Invalid JSON expecting property name");
+
+            var propertyName = reader.GetString();
+            reader.Read();
+            switch (propertyName)
+            {
+                case "areas":
+                case nameof(BlockGridLayoutItem.Areas):
+                    var areas = JsonSerializer.Deserialize<List<BlockGridLayoutAreaItem>>(ref reader, options);
+                    if (areas != null)
+                        item.Areas = [.. areas];
+                    break;
+                
+                case "columnSpan":
+                case nameof(BlockGridLayoutItem.ColumnSpan):
+                    if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var colSpan))
+                        ((BlockGridLayoutItem)item).ColumnSpan = colSpan;
+                    break;
+                
+                case "rowSpan":
+                case nameof(BlockGridLayoutItem.RowSpan):
+                    if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var rowSpan))
+                        ((BlockGridLayoutItem)item).RowSpan = rowSpan;
+                    break;
+                
+                case "contentKey":
+                case nameof(BlockGridLayoutItem.ContentKey):
+                    var contentKey = reader.GetString();
+                    if (contentKey != null && Guid.TryParse(contentKey, out var contentGuid))
+                        item.ContentKey = contentGuid;
+                    break;
+                
+                case "settingsKey":
+                case nameof(BlockGridLayoutItem.SettingsKey):
+                    var settingsKey = reader.GetString();
+                    if (settingsKey != null && Guid.TryParse(settingsKey, out var settingsGuid))
+                        item.SettingsKey = settingsGuid;
+                    break;
+                
+                default:
+                    // we don't care about the obsolete properties here...
+                    break;
+            }
+        }
+
+        throw new JsonException("Unexpected end of JSON");
+    }
+
+    public override void Write(Utf8JsonWriter writer, BlockGridLayoutItem value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WritePropertyName("areas");
+        JsonSerializer.Serialize(writer, value.Areas, options);
+
+        if (value.ColumnSpan != null)
+        {
+            writer.WritePropertyName("columnSpan");
+            writer.WriteNumberValue(value.ColumnSpan.Value);
+        }
+
+        if (value.RowSpan != null)
+        {
+            writer.WritePropertyName("rowSpan");
+            writer.WriteNumberValue(value.RowSpan.Value);
+        }
+
+        writer.WriteString("contentKey", value.ContentKey.ToString());
+        writer.WriteNull("contentUdi");
+        if (value.SettingsKey.HasValue && value.SettingsKey != Guid.Empty)
+            writer.WriteString("settingsKey", value.SettingsKey.ToString());
+        else
+            writer.WriteNull("settingsKey");
+        writer.WriteEndObject();
+    }
+}

--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -34,12 +34,12 @@ public class JsonBlockGridLayoutItemConverter : JsonConverter<BlockGridLayoutIte
                 
                 case "columnSpan":
                     if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var colSpan))
-                        ((BlockGridLayoutItem)item).ColumnSpan = colSpan;
+                        item.ColumnSpan = colSpan;
                     break;
                 
                 case "rowSpan":
                     if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var rowSpan))
-                        ((BlockGridLayoutItem)item).RowSpan = rowSpan;
+                        item.RowSpan = rowSpan;
                     break;
                 
                 case "contentKey":

--- a/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockGridLayoutItemConverter.cs
@@ -60,7 +60,7 @@ public class JsonBlockGridLayoutItemConverter : JsonConverter<BlockGridLayoutIte
             }
         }
 
-        throw new JsonException("Unexpected end of JSON block");
+        throw new JsonException("Unexpected end of JSON");
     }
 
     public override void Write(Utf8JsonWriter writer, BlockGridLayoutItem value, JsonSerializerOptions options)

--- a/uSync.Core/Json/JsonBlockListLayoutItemConverter.cs
+++ b/uSync.Core/Json/JsonBlockListLayoutItemConverter.cs
@@ -5,23 +5,14 @@ using Umbraco.Cms.Core.Models.Blocks;
 
 namespace uSync.Core.Json;
 
-/// <summary>
-/// in v16 the BlockLayoutItem(s) have obsolete properties that are sometimes set and sometimes not
-/// this leads to false positive's when looking for changes. 
-/// 
-///  these two custom converters write those properties out as null, so they never change. causing
-///  the serialized json to be consistent. 
-/// </summary>
-
-public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
-    where T : BlockLayoutItemBase, new()
+public class JsonBlockListLayoutItemConverter : JsonConverter<BlockListLayoutItem>
 {
-    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override BlockListLayoutItem? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.StartObject)
             throw new JsonException("Invalid JSON expecting start object");
 
-        var item = new T();
+        var item = new BlockListLayoutItem();
 
         while (reader.Read())
         {
@@ -29,7 +20,7 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
                 return item;
 
             if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expecting property name");
+                throw new JsonException("Invalid JSON expecting property name");
 
             var propertyName = reader.GetString();
             reader.Read();
@@ -55,7 +46,7 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
         throw new JsonException("Unexpected end of JSON");
     }
 
-    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, BlockListLayoutItem value, JsonSerializerOptions options)
     {
         // we could just not write out the obsolete properties, but they will appear as null it 
         // lots of people's existing exports , so we can write them out as null to keep things consistent.
@@ -72,7 +63,3 @@ public abstract class JsonBlockItemConverterBase<T> : JsonConverter<T>
         writer.WriteEndObject();
     }
 }
-
-public class JsonBlockListLayoutItemConverter : JsonBlockItemConverterBase<BlockListLayoutItem> { }
-
-public class JsonBlockGridLayoutItemConverter : JsonBlockItemConverterBase<BlockGridLayoutItem> { }


### PR DESCRIPTION
splits the jsonConverts for the blocks into two one for `BlockListLayoutItems` and one for `BlockGridLayoutItems`. its probably possible to have these share a converter but it would likely need a bit of reflection etc, and i want to keep it simple.