### PR TITLE
V16/firstboot onstartup conflict fix

### DIFF
--- a/uSync.BackOffice/Boot/FirstBootMigration.cs
+++ b/uSync.BackOffice/Boot/FirstBootMigration.cs
@@ -58,19 +58,16 @@ public class FirstBootMigration : UnscopedAsyncMigrationBase
     /// <inheritdoc/>
     protected override async Task MigrateAsync()
     {
-        if (_serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
-        {
-            _logger.LogInformation("This is a Subscriber server in a load balanced setup - uSync only runs on single or schedulingPublisher (main) servers");
-            Context.Complete();
-            return;
-        }
 
         // first boot migration. 
         try
         {
             if (!_uSyncConfig.Settings.ImportOnFirstBoot)
+                return;
+
+            if (_serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
             {
-                Context.Complete();
+                _logger.LogInformation("This is a Subscriber server in a load balanced setup - uSync only runs on single or schedulingPublisher (main) servers");
                 return;
             }
 
@@ -105,7 +102,11 @@ public class FirstBootMigration : UnscopedAsyncMigrationBase
         {
             _logger.LogError(ex, "uSync First boot failed {message}", ex.Message);
         }
-
-        Context.Complete();
+        finally
+        {
+            // we always complete the context - even if we fail.
+            // we don't want to keep trying this migration every time.
+            Context.Complete();
+        }        
     }
 }

--- a/uSync.BackOffice/Boot/FirstBootMigration.cs
+++ b/uSync.BackOffice/Boot/FirstBootMigration.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
+using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Infrastructure.Migrations;
 
@@ -30,9 +31,10 @@ public class FirstBootMigrationPlan : MigrationPlan
 /// <summary>
 /// First boot Feature migration
 /// </summary>
-public class FirstBootMigration : AsyncMigrationBase
+public class FirstBootMigration : UnscopedAsyncMigrationBase
 {
     private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly IServerRoleAccessor _serverRoleAccessor;
     private readonly ISyncConfigService _uSyncConfig;
     private readonly ISyncService _uSyncService;
     private readonly ILogger<FirstBootMigration> _logger;
@@ -43,25 +45,34 @@ public class FirstBootMigration : AsyncMigrationBase
         IUmbracoContextFactory umbracoContextFactory,
         ISyncConfigService uSyncConfig,
         ISyncService uSyncService,
-        ILogger<FirstBootMigration> logger) : base(context)
+        ILogger<FirstBootMigration> logger,
+        IServerRoleAccessor serverRoleAccessor) : base(context)
     {
         _umbracoContextFactory = umbracoContextFactory;
         _uSyncConfig = uSyncConfig;
         _uSyncService = uSyncService;
         _logger = logger;
+        _serverRoleAccessor = serverRoleAccessor;
     }
 
     /// <inheritdoc/>
     protected override async Task MigrateAsync()
     {
-        // TODO: doesn't work in the betas. might need a new migration to add it.
-        // return;
+        if (_serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
+        {
+            _logger.LogInformation("This is a Subscriber server in a load balanced setup - uSync only runs on single or schedulingPublisher (main) servers");
+            Context.Complete();
+            return;
+        }
 
         // first boot migration. 
         try
         {
             if (!_uSyncConfig.Settings.ImportOnFirstBoot)
+            {
+                Context.Complete();
                 return;
+            }
 
             var sw = Stopwatch.StartNew();
             var changes = 0;
@@ -72,8 +83,9 @@ public class FirstBootMigration : AsyncMigrationBase
             // if config service is set to import on first boot then this 
             // will let uSync do a first boot import 
 
-            // not sure about context on migrations so will need to test
-            // or maybe we fire something into a notification (or use a static)
+            // this runs as a 'un-scoped' migration, so we need to manage the context here.
+            // as we are in the context and not just a scope all the publish stuff works 
+            // first time, just like it does in ImportOnStartup 
 
             using (var reference = _umbracoContextFactory.EnsureUmbracoContext())
             {
@@ -92,7 +104,8 @@ public class FirstBootMigration : AsyncMigrationBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "uSync First boot failed {message}", ex.Message);
-            throw;
         }
+
+        Context.Complete();
     }
 }

--- a/uSync.BackOffice/Notifications/uSyncApplicationStartingHandler.cs
+++ b/uSync.BackOffice/Notifications/uSyncApplicationStartingHandler.cs
@@ -120,8 +120,8 @@ internal class uSyncApplicationStartingHandler : INotificationAsyncHandler<Umbra
                     };
 
                     _logger.LogInformation("uSync: Running export at startup");
-
-
+                    
+                    
                     _uSyncService.StartupExportAsync(_uSyncConfig.GetWorkingFolder(), options).Wait();
                 }
 
@@ -131,10 +131,10 @@ internal class uSyncApplicationStartingHandler : INotificationAsyncHandler<Umbra
 
                     if (!HasStopFile(_uSyncConfig.GetWorkingFolder()))
                     {
-                        _uSyncService.StartupImportAsync(_uSyncConfig.GetFolders(), false, new SyncHandlerOptions
+                        await _uSyncService.StartupImportAsync(_uSyncConfig.GetFolders(), false, new SyncHandlerOptions
                         {
                             Group = _uSyncConfig.Settings.ImportAtStartup
-                        }).Wait();
+                        });
 
                         await ProcessOnceFileAsync(_uSyncConfig.GetWorkingFolder());
                     }

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -132,7 +132,7 @@ public partial class SyncService : ISyncService
 
         if (_lastStartupRun.HasValue && _lastStartupRun.Value == runHash)
         {
-            _logger.LogInformation("uSync Startup Import: Skipping duplicate import");
+            _logger.LogInformation("uSync: Skipping [duplicate] startup import has already ran with these parameters");
             return [];
         }
 

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -128,7 +128,7 @@ public partial class SyncService : ISyncService
     /// <inheritdoc/>>
     public async Task<IEnumerable<uSyncAction>> StartupImportAsync(string[] folders, bool force, SyncHandlerOptions handlerOptions, uSyncCallbacks? callbacks = null)
     {
-        var runHash = $"{string.Join(",", folders)}|{force}|{handlerOptions.SerializeJsonString(false)}".GetDeterministicHashCode();
+        var runHash = $"{string.Join(",", folders)}{force}{handlerOptions.SerializeJsonString(false)}".GetDeterministicHashCode();
 
         if (_lastStartupRun.HasValue && _lastStartupRun.Value == runHash)
         {

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -22,6 +22,7 @@ using uSync.BackOffice.Services;
 using uSync.BackOffice.SyncHandlers;
 using uSync.BackOffice.SyncHandlers.Models;
 using uSync.Core;
+using uSync.Core.Extensions;
 using uSync.Core.Serialization;
 
 namespace uSync.BackOffice;
@@ -113,9 +114,28 @@ public partial class SyncService : ISyncService
     #region Importing
     static readonly SemaphoreSlim _importSemaphoreLock = new SemaphoreSlim(1, 1);
 
+    /// <summary>
+    ///  hash of the options last used in a startup import
+    /// </summary>
+    /// <remarks>
+    ///  as both first boot and import at startup use this method,
+    ///  and both can be triggered at startup, we use a hash of the 
+    ///  options and folders to make sure we are not running them 
+    ///  both if they are asking the same thing. 
+    /// </remarks>
+    static int? _lastStartupRun;
+
     /// <inheritdoc/>>
     public async Task<IEnumerable<uSyncAction>> StartupImportAsync(string[] folders, bool force, SyncHandlerOptions handlerOptions, uSyncCallbacks? callbacks = null)
     {
+        var runHash = $"{string.Join(",", folders)}|{force}|{handlerOptions.SerializeJsonString(false)}".GetDeterministicHashCode();
+
+        if (_lastStartupRun.HasValue && _lastStartupRun.Value == runHash)
+        {
+            _logger.LogInformation("uSync Startup Import: Skipping duplicate import");
+            return [];
+        }
+
         handlerOptions ??= new SyncHandlerOptions();
         handlerOptions.Action = HandlerActions.Import;
         var handlers = _handlerFactory.GetValidHandlers(handlerOptions);
@@ -126,6 +146,8 @@ public partial class SyncService : ISyncService
         // just because it seems not to refresh as part of the boot. 
         if (changes.Any(x => x.Change > ChangeType.NoChange && x.ItemType == "IContent"))
             _distributedCache.RefreshAllPublishedSnapshot();
+
+        _lastStartupRun = runHash;
 
         return changes;
     }


### PR DESCRIPTION
Fixes an issue with FirstBoot, where content isn't published at the end (like it is with ImportAtStartup)

- FirstBoot runs in a migration and is now UnScoped so we can control the context like we do for the ImportAtstartup version, so they both work the same.
- Added a Check to the uSync `StartupImportAsync` method so it generats a hash of the passed in parameters and will only run that import once. This means if firstboot and importonStartup are importing the same things - it only runs once, but if they are different they will both run.
- the call in ImportOnStartup was `StartupImportAsync(...).Wait()` when its in an async method so it can be `async StartupImportAsync(...)`