### PR TITLE
Add operation security filter so swagger auth is allowed.

### DIFF
--- a/uSync.Backoffice.Management.Api/Configuration/ConfigSyncApiSwaggerGenOptions.cs
+++ b/uSync.Backoffice.Management.Api/Configuration/ConfigSyncApiSwaggerGenOptions.cs
@@ -4,6 +4,8 @@ using Microsoft.OpenApi.Models;
 
 using Swashbuckle.AspNetCore.SwaggerGen;
 
+using Umbraco.Cms.Api.Management.OpenApi;
+
 namespace uSync.Backoffice.Management.Api.Configuration;
 public class ConfigSyncApiSwaggerGenOptions : IConfigureOptions<SwaggerGenOptions>
 {
@@ -18,5 +20,12 @@ public class ConfigSyncApiSwaggerGenOptions : IConfigureOptions<SwaggerGenOption
               Description = "Api access uSync operations"
           });
 
+        options.OperationFilter<uSyncClientOperationSecurityFilter>();
+
     }
+}
+
+public class uSyncClientOperationSecurityFilter : BackOfficeSecurityRequirementsOperationFilterBase
+{
+    protected override string ApiName => "uSync";
 }


### PR DESCRIPTION
Adds an OperationFilter using BackOfficeSecurityRequirementsOperationFilterBase which just allows the swagger UI to call the methods (all other methods still work)