### PR TITLE
share second pass actions across comon IContentBase objects

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -291,20 +291,8 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
     public override async Task<SyncAttempt<IContent>> DeserializeSecondPassAsync(IContent item, XElement node, SyncSerializerOptions options)
     {
         var details = new List<uSyncChange>();
-        // move trashed state to second pass, as the item needs an Id for the relation to work. 
-        details.AddNotNull(await DeserializeTrashed(node, item, Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias));
 
-        // move sort to second pass, as if we attempt to set this 
-        // on a brand new item, it doesn't get set. 
-        // doing it on second pass ensures it gets set on the item
-        // after it has been saved by umbraco. 
-        if (!options.GetSetting<bool>(
-            uSyncConstants.DefaultSettings.IgnoreSortOrder,
-            uSyncConstants.DefaultSettings.IgnoreSortOrder_Default))
-        {
-            var sortOrder = node.Element(uSyncConstants.Xml.Info)?.Element(uSyncConstants.Xml.SortOrder).ValueOrDefault(-1) ?? -1;
-            details.AddNotNull(HandleSortOrder(item, sortOrder));
-        }
+        details.AddRange(await this.DeserializeSecondPassSharedAsync(item, node, options));
 
         var changes = await DeserializeSchedulesAsync(item, node, options);
         if (changes.Count != 0)

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -433,7 +433,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
             logger.LogDebug("Performing Save: {id} {name}", item.Id, item.Name);
             var result = contentService.Save(item, options.UserId, scheduleCollection);
             if (result.Success)
-                item = contentService.GetById(item.Id)!;
+                item = contentService.GetById(item.Id) ?? item;
             else
             {
                 // something went wrong saving. ???

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -292,7 +292,8 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
     {
         var details = new List<uSyncChange>();
 
-        details.AddRange(await this.DeserializeSecondPassSharedAsync(item, node, options));
+        details.AddRange(await this.DeserializeSecondPassSharedAsync(item, node, options,
+             Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias));
 
         var changes = await DeserializeSchedulesAsync(item, node, options);
         if (changes.Count != 0)

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -607,7 +607,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     }
 
     /// <summary>
-    ///  things most 'IContentBase' serializers need (ones that have trash anyway).
+    ///  Things most 'IContentBase' serializers need (ones that have trash anyway).
     /// </summary>
     protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options)
     {

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -607,6 +607,32 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     }
 
     /// <summary>
+    ///  things most 'IContentBase' serializers need (ones that have trash anyway).
+    /// </summary>
+    protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options)
+    {
+        var details = new List<uSyncChange>();
+
+        // move trashed state to second pass, as the item needs an Id for the relation to work. 
+        details.AddNotNull(await DeserializeTrashed(node, item, Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias));
+
+        // move sort to second pass, as if we attempt to set this 
+        // on a brand new item, it doesn't get set. 
+        // doing it on second pass ensures it gets set on the item
+        // after it has been saved by umbraco. 
+        if (!options.GetSetting<bool>(
+            uSyncConstants.DefaultSettings.IgnoreSortOrder,
+            uSyncConstants.DefaultSettings.IgnoreSortOrder_Default))
+        {
+            var sortOrder = node.Element(uSyncConstants.Xml.Info)?.Element(uSyncConstants.Xml.SortOrder).ValueOrDefault(-1) ?? -1;
+            details.AddNotNull(HandleSortOrder(item, sortOrder));
+        }
+
+        return details;
+    }
+
+
+    /// <summary>
     ///  compares to object values to see if they are the same. 
     /// </summary>
     /// <remarks>

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -609,7 +609,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     /// <summary>
     ///  Things most 'IContentBase' serializers need (ones that have trash anyway).
     /// </summary>
-    protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options
+    protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options,
         string trashedRelationAlias)
     {
         var details = new List<uSyncChange>();

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -609,12 +609,13 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     /// <summary>
     ///  things most 'IContentBase' serializers need (ones that have trash anyway).
     /// </summary>
-    protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options)
+    protected async Task<List<uSyncChange>> DeserializeSecondPassSharedAsync(TObject item, XElement node, SyncSerializerOptions options
+        string trashedRelationAlias)
     {
         var details = new List<uSyncChange>();
 
         // move trashed state to second pass, as the item needs an Id for the relation to work. 
-        details.AddNotNull(await DeserializeTrashed(node, item, Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias));
+        details.AddNotNull(await DeserializeTrashed(node, item, trashedRelationAlias));
 
         // move sort to second pass, as if we attempt to set this 
         // on a brand new item, it doesn't get set. 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -185,14 +185,19 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         var allowedTypeOrdered = item.AllowedContentTypes?.OrderBy(x => x.SortOrder);
         if (allowedTypeOrdered is null) return node;
 
+        int defaultSortOrder = 0;
         foreach (var allowedType in allowedTypeOrdered)
         {
             var allowedItem = await FindItemAsync(allowedType.Key);
             if (allowedItem != null)
             {
+                var sortOrder = allowedType.SortOrder > 0 ? allowedType.SortOrder : defaultSortOrder;
+
                 node.Add(new XElement(ItemType,
                     new XAttribute(uSyncConstants.Xml.Key, allowedItem.Key),
-                    new XAttribute(uSyncConstants.Xml.SortOrder, allowedType.SortOrder), allowedItem.Alias));
+                    new XAttribute(uSyncConstants.Xml.SortOrder, sortOrder), allowedItem.Alias));
+
+                defaultSortOrder = sortOrder + 1;
             }
         }
         return node;
@@ -346,7 +351,11 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
 
         int sortOrder = 0;
 
-        foreach (var baseNode in structure.Elements(ItemType))
+        // do it in the sort order (if there is one). 
+        // makes it more likely to 'work' first time.
+        var nodes = structure.Elements(ItemType).OrderBy(x => x.Attribute(uSyncConstants.Xml.SortOrder).ValueOrDefault(int.MinValue));
+
+        foreach (var baseNode in nodes)
         {
             logger.LogDebug("baseNode {base}", baseNode.ToString());
             var alias = baseNode.Value;
@@ -375,34 +384,30 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
 
             if (baseItem != null)
             {
-                logger.LogDebug("Structure Found {alias}", baseItem.Alias);
                 allowed.Add(new ContentTypeSort(baseItem.Key, itemSortOrder, baseItem.Alias));
                 sortOrder = itemSortOrder + 1;
             }
         }
 
-        logger.LogDebug("Structure: {count} items", allowed.Count);
-
-
         if (item.AllowedContentTypes is not null)
         {
             // compare the two lists (the equality compare fails because the id value is lazy)
-            var currentHash = string.Join(":", item.AllowedContentTypes.Select(x => $"{x.Key}-{x.SortOrder}").OrderBy(x => x));
-            var newHash = string.Join(":", allowed.Select(x => $"{x.Key}-{x.SortOrder}").OrderBy(x => x));
+            var currentHash = string.Join(":", item.AllowedContentTypes.Select(x => $"{x.Key}-{x.SortOrder}").OrderBy(x => x)).GetDeterministicHashCode();
+            var newHash = string.Join(":", allowed.Select(x => $"{x.Key}-{x.SortOrder}").OrderBy(x => x)).GetDeterministicHashCode();
 
-            if (!currentHash.Equals(newHash))
+            if (currentHash.Equals(newHash) is false)
             {
                 changes.AddUpdate("Allowed",
-                    string.Join(",", item.AllowedContentTypes.Select(x => x.Alias) ?? []),
-                    string.Join(",", allowed.Select(x => x.Alias) ?? []), "/Structure");
+                    string.Join("::", item.AllowedContentTypes.Select(x => x.Alias)?? []),
+                    string.Join("::", allowed.Select(x => x.Alias) ?? []), "/Structure");
 
-                logger.LogDebug("Updating allowed content types {old}, {new}", currentHash, newHash);
-                item.AllowedContentTypes = allowed;
+                item.AllowedContentTypes = allowed.OrderBy(x => x.SortOrder);
             }
         }
         else
         {
-            item.AllowedContentTypes = allowed;
+            changes.AddNew("Allowed", string.Join("::", allowed.Select(x => x.Alias) ?? []), "/Structure");
+            item.AllowedContentTypes = allowed.OrderBy(x => x.SortOrder);
         }
 
         return changes;
@@ -1348,7 +1353,12 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
 
     public override async Task SaveItemAsync(TObject item)
     {
-        if (item.IsDirty() is false) return;
+        logger.LogDebug("Save Item {name} ({alias})", item.Name, item.Alias);
+        if (item.IsDirty() is false)
+        {
+            logger.LogDebug("Item not dirty, skipping save");
+            return;
+        }
 
         if (item.Id <= 0)
         {

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -99,8 +99,7 @@ public class MediaSerializer : ContentSerializerBase<IMedia>, ISyncSerializer<IM
 
     public override async Task<SyncAttempt<IMedia>> DeserializeSecondPassAsync(IMedia item, XElement node, SyncSerializerOptions options)
     {
-        var details = new List<uSyncChange>();
-        details.AddNotNull(await DeserializeTrashed(node, item, Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias));
+        var details = await DeserializeSecondPassSharedAsync(item, node, options);
 
         return SyncAttempt<IMedia>.Succeed(item.Name ?? item.Id.ToString(), item,
             details.Count == 0 ? ChangeType.NoChange : ChangeType.Import, details);

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -99,7 +99,8 @@ public class MediaSerializer : ContentSerializerBase<IMedia>, ISyncSerializer<IM
 
     public override async Task<SyncAttempt<IMedia>> DeserializeSecondPassAsync(IMedia item, XElement node, SyncSerializerOptions options)
     {
-        var details = await DeserializeSecondPassSharedAsync(item, node, options);
+        var details = await DeserializeSecondPassSharedAsync(item, node, options,
+             Constants.Conventions.RelationTypes.RelateParentMediaFolderOnDeleteAlias);
 
         return SyncAttempt<IMedia>.Succeed(item.Name ?? item.Id.ToString(), item,
             details.Count == 0 ? ChangeType.NoChange : ChangeType.Import, details);


### PR DESCRIPTION
moves some of the DeserializeSecondPass actions in content and media into shared method in the base class, so they both do the same and use the same code. 