### PR TITLE
V16/multiple nodes per file

### DIFF
--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -236,7 +236,7 @@
     },
     "USyncBackOfficeConfigurationSyncFolderMode": {
       "type": "string",
-      "description": "",
+      "description": "uSync's folder mode - normal, root or production\n            ",
       "x-enumNames": [
         "Normal",
         "Root",

--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -205,7 +205,7 @@
         },
         "DisableNotificationSuppression": {
           "type": "boolean",
-          "description": "turns of use of the Notifications.Suppress method, so notifications\nfire after every item is imported.\n            ",
+          "description": "turns off use of the Notifications.Suppress method, so notifications\nfire after every item is imported.\n            ",
           "default": "true"
         },
         "BackgroundNotifications": {

--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -205,7 +205,7 @@
         },
         "DisableNotificationSuppression": {
           "type": "boolean",
-          "description": "turns of use of the Notifications.Supress method, so notifications\nfire after every item is imported.\n            ",
+          "description": "turns of use of the Notifications.Suppress method, so notifications\nfire after every item is imported.\n            ",
           "default": "true"
         },
         "BackgroundNotifications": {
@@ -217,8 +217,36 @@
           "type": "boolean",
           "description": "Move the uSync tree to it's own section in the back office. \n(requires a restart to take effect).\n            ",
           "default": false
+        },
+        "FolderMode": {
+          "description": "What type of mode the folder should work in (default, root, or production)\n            ",
+          "default": "Normal",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/USyncBackOfficeConfigurationSyncFolderMode"
+            }
+          ]
+        },
+        "ProductionFolder": {
+          "type": "string",
+          "description": "location of the 'production' folder to use when in production mode, \nor when creating the production mode files.\n            ",
+          "default": "uSync/production"
         }
       }
+    },
+    "USyncBackOfficeConfigurationSyncFolderMode": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Normal",
+        "Root",
+        "Production"
+      ],
+      "enum": [
+        "Normal",
+        "Root",
+        "Production"
+      ]
     },
     "USyncuSyncSetsDefinition": {
       "type": "object",

--- a/uSync.BackOffice/Configuration/SyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/SyncConfigService.cs
@@ -66,11 +66,8 @@ internal class SyncConfigService : ISyncConfigService
     /// <inheritdoc/>
     public string GetWorkingFolder()
     {
-        var folders = FetchFolders();
-
-        return Settings.IsRootSite
-            ? folders[0].TrimStart('/')
-            : folders.Last().TrimStart('/');
+        var folders = GetFolders();
+        return folders.Last().TrimStart('/');
     }
 
     /// <inheritdoc/>
@@ -78,9 +75,15 @@ internal class SyncConfigService : ISyncConfigService
     {
         var folders = FetchFolders();
 
-        return Settings.IsRootSite
-            ? [folders[0].TrimStart('/')]
-            : [.. folders.Select(x => x.TrimStart('/'))];
+        switch(Settings.FolderMode)
+        {
+            case SyncFolderMode.Root:
+                return [folders[0].TrimStart('/')];
+            case SyncFolderMode.Production:
+                return [Settings.ProductionFolder];
+            default:
+                return [.. folders.Select(x => x.TrimStart('/'))];
+        }
     }
 
     /// <inheritdoc/>

--- a/uSync.BackOffice/Configuration/SyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/SyncConfigService.cs
@@ -80,7 +80,7 @@ internal class SyncConfigService : ISyncConfigService
             case SyncFolderMode.Root:
                 return [folders[0].TrimStart('/')];
             case SyncFolderMode.Production:
-                return [Settings.ProductionFolder];
+                return [Settings.ProductionFolder.TrimStart('/')];
             default:
                 return [.. folders.Select(x => x.TrimStart('/'))];
         }

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -197,26 +197,22 @@ public class uSyncSettings
     public string HideAddOns { get; set; } = "licence";
 
     /// <summary>
-    ///  turns of use of the Notifications.Supress method, so notifications
+    ///  turns of use of the Notifications.Suppress method, so notifications
     ///  fire after every item is imported.
     /// </summary>
     /// <remarks>
-    ///  I am not sure this does what i think it does, it doesn't suppress
-    ///  then fire at the end , it just suppresses them all. 
+    ///  this disables the internal uSync scope provider that delays all 
+    ///  non cancellable notifications until after the import is complete.
     ///  
-    ///  until we have had time to look at this , we will leave this as 
-    ///  disabled by default so all notification messages fire.
+    ///  on v13 this is false, the import happens and then the notifications fire.
     ///  
-    ///  for v13 thius is fine, but for v14, grouping the notifications
-    ///  can causes issues if something fails. 
-    ///   
-    ///  So if a single content import fails then the whole batch doesn't 
-    ///  get published properly (so no content for you :( ) .
+    ///  on v16 the default is true, because some of the notifications appear to 
+    ///  be closely coupled to the save/publish process, and if something goes 
+    ///  wrong in one item's import it can cause a cascade of failures across 
+    ///  everything that might have been imported along with it. 
     ///  
-    ///  there might be something downlever we can do, but it likey means
-    ///  lots of core investigation to find that, for now 'old' school
-    ///  non suppressed notifications should be fine (if a little slower).
-    /// 
+    ///  if the notifications are not suppressed, then if an item fails to import
+    ///  it doesn't stop other items from being imported. 
     /// </remarks>
     [DefaultValue("true")]
     public bool DisableNotificationSuppression { get; set; } = true;
@@ -238,4 +234,25 @@ public class uSyncSettings
     /// </summary>
     [DefaultValue(false)]
     public bool MoveToSection { get; set; } = false;
+
+    /// <summary>
+    ///  What type of mode the folder should work in (default, root, or production)
+    /// </summary>
+    [DefaultValue("Normal")]
+    public SyncFolderMode FolderMode { get; set; } = SyncFolderMode.Normal;
+
+    /// <summary>
+    ///  location of the 'production' folder to use when in production mode, 
+    ///  or when creating the production mode files.
+    /// </summary>
+    [DefaultValue("uSync/production")]
+    public string ProductionFolder { get; set; } = "uSync/production";
 }
+
+public enum SyncFolderMode
+{
+    Normal,
+    Root,
+    Production,
+};
+

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -197,7 +197,7 @@ public class uSyncSettings
     public string HideAddOns { get; set; } = "licence";
 
     /// <summary>
-    ///  turns of use of the Notifications.Suppress method, so notifications
+    ///  turns off use of the Notifications.Suppress method, so notifications
     ///  fire after every item is imported.
     /// </summary>
     /// <remarks>

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -249,10 +249,24 @@ public class uSyncSettings
     public string ProductionFolder { get; set; } = "uSync/production";
 }
 
+/// <summary>
+///  uSync's folder mode - normal, root or production
+/// </summary>
 public enum SyncFolderMode
 {
+    /// <summary>
+    ///  normal - expects individual files in the uSync folder(s)
+    /// </summary>
     Normal,
+
+    /// <summary>
+    ///  root - will read and write things to the root folder, 
+    /// </summary>
     Root,
+
+    /// <summary>
+    ///  production - looks in a 'production' folder, expects a single file per handler.
+    /// </summary>
     Production,
 };
 

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -238,7 +238,7 @@ public class uSyncSettings
     /// <summary>
     ///  What type of mode the folder should work in (default, root, or production)
     /// </summary>
-    [DefaultValue("Normal")]
+    [DefaultValue(SyncFolderMode.Normal)]
     public SyncFolderMode FolderMode { get; set; } = SyncFolderMode.Normal;
 
     /// <summary>

--- a/uSync.BackOffice/Hubs/HubClientService.cs
+++ b/uSync.BackOffice/Hubs/HubClientService.cs
@@ -85,12 +85,18 @@ public class HubClientService
     private int _start = 0;
     private int _end = 0;
 
+    /// <summary>
+    ///  set a range (start to end) that we except the next set of updates to be bound within.
+    /// </summary>
     public void SetCountRange(int start, int end)
     {
         _start = start;
         _end = end;
     }
 
+    /// <summary>
+    ///  post an update and increment the counter by one.
+    /// </summary>
     public void PostIncrementalUpdate(string message)
     {
         _start++;

--- a/uSync.BackOffice/Hubs/HubClientService.cs
+++ b/uSync.BackOffice/Hubs/HubClientService.cs
@@ -80,5 +80,21 @@ public class HubClientService
     ///  get the uSync callbacks for this connection
     /// </summary>
     /// <returns></returns>
-    public uSyncCallbacks Callbacks() => new(this.PostSummary, this.PostUpdate);
+    public uSyncCallbacks Callbacks() => new(this.PostSummary, this.PostUpdate, this.SetCountRange, this.PostIncrementalUpdate);
+
+    private int _start = 0;
+    private int _end = 0;
+
+    public void SetCountRange(int start, int end)
+    {
+        _start = start;
+        _end = end;
+    }
+
+    public void PostIncrementalUpdate(string message)
+    {
+        _start++;
+        if (_start > _end) _end = _start;
+        this.PostUpdate(message, _start, _end);
+    }
 }

--- a/uSync.BackOffice/Hubs/HubClientService.cs
+++ b/uSync.BackOffice/Hubs/HubClientService.cs
@@ -86,7 +86,7 @@ public class HubClientService
     private int _end = 0;
 
     /// <summary>
-    ///  set a range (start to end) that we except the next set of updates to be bound within.
+    ///  set a range (start to end) that we expect the next set of updates to be bound within.
     /// </summary>
     public void SetCountRange(int start, int end)
     {

--- a/uSync.BackOffice/Hubs/uSyncCallbacks.cs
+++ b/uSync.BackOffice/Hubs/uSyncCallbacks.cs
@@ -16,7 +16,7 @@ public delegate void SyncEventCallback(SyncProgressSummary summary);
 public delegate void SyncUpdateCallback(string message, int count, int total);
 
 /// <summary>
-///  callback delegate to set the start and end rage for the update counters.
+///  callback delegate to set the start and end range for the update counters.
 /// </summary>
 public delegate void SyncSetUpdateRange(int start, int end);
 

--- a/uSync.BackOffice/Hubs/uSyncCallbacks.cs
+++ b/uSync.BackOffice/Hubs/uSyncCallbacks.cs
@@ -1,5 +1,3 @@
-﻿using Org.BouncyCastle.Bcpg.OpenPgp;
-
 using uSync.BackOffice.Models;
 using uSync.BackOffice.SyncHandlers.Interfaces;
 

--- a/uSync.BackOffice/Hubs/uSyncCallbacks.cs
+++ b/uSync.BackOffice/Hubs/uSyncCallbacks.cs
@@ -15,7 +15,15 @@ public delegate void SyncEventCallback(SyncProgressSummary summary);
 /// </summary>
 public delegate void SyncUpdateCallback(string message, int count, int total);
 
+/// <summary>
+///  callback delegate to set the start and end rage for the update counters.
+/// </summary>
 public delegate void SyncSetUpdateRange(int start, int end);
+
+/// <summary>
+///  callback to send a update message and increment the counter by one so moving the progress bar.
+/// </summary>
+/// <param name="message"></param>
 public delegate void SyncIncrementalUpdateCallback(string message);
 
 
@@ -34,8 +42,14 @@ public class uSyncCallbacks
     /// </summary>
     public SyncUpdateCallback? Update { get; private set; }
 
+    /// <summary>
+    ///  set a start and end range for the counter.
+    /// </summary>
     public SyncSetUpdateRange? SetRange { get; private set; }
 
+    /// <summary>
+    ///  update and increment callback.
+    /// </summary>
     public SyncIncrementalUpdateCallback? IncrementalUpdate { get; private set; }
 
     /// <summary>
@@ -47,6 +61,9 @@ public class uSyncCallbacks
         this.Update = update;
     }
 
+    /// <summary>
+    ///  generate a callback object with range and incremental update
+    /// </summary>
     public uSyncCallbacks(SyncEventCallback? callback, SyncUpdateCallback? update, SyncSetUpdateRange? updateRange, SyncIncrementalUpdateCallback incrementalUpdate)
         : this(callback, update)
     {

--- a/uSync.BackOffice/Hubs/uSyncCallbacks.cs
+++ b/uSync.BackOffice/Hubs/uSyncCallbacks.cs
@@ -1,6 +1,23 @@
-﻿using uSync.BackOffice.SyncHandlers.Interfaces;
+﻿using Org.BouncyCastle.Bcpg.OpenPgp;
+
+using uSync.BackOffice.Models;
+using uSync.BackOffice.SyncHandlers.Interfaces;
 
 namespace uSync.BackOffice;
+
+/// <summary>
+///  Callback event for SignalR hub
+/// </summary>
+public delegate void SyncEventCallback(SyncProgressSummary summary);
+
+/// <summary>
+///  callback delegate for SignalR messaging 
+/// </summary>
+public delegate void SyncUpdateCallback(string message, int count, int total);
+
+public delegate void SyncSetUpdateRange(int start, int end);
+public delegate void SyncIncrementalUpdateCallback(string message);
+
 
 /// <summary>
 ///  Callback objects used to communicate via SignalR
@@ -17,6 +34,10 @@ public class uSyncCallbacks
     /// </summary>
     public SyncUpdateCallback? Update { get; private set; }
 
+    public SyncSetUpdateRange? SetRange { get; private set; }
+
+    public SyncIncrementalUpdateCallback? IncrementalUpdate { get; private set; }
+
     /// <summary>
     ///  generate a new callback object 
     /// </summary>
@@ -24,5 +45,12 @@ public class uSyncCallbacks
     {
         this.Callback = callback;
         this.Update = update;
+    }
+
+    public uSyncCallbacks(SyncEventCallback? callback, SyncUpdateCallback? update, SyncSetUpdateRange? updateRange, SyncIncrementalUpdateCallback incrementalUpdate)
+        : this(callback, update)
+    {
+        this.SetRange = updateRange;
+        this.IncrementalUpdate = incrementalUpdate;
     }
 }

--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -138,7 +138,7 @@ public interface ISyncFileService
     /// <summary>
     ///  merge all the files in the give folders into a single xml node, that can be bulk imported
     /// </summary>
-    Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string targetFolder, string fileName);
+    Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string fileName, string extension);
 
     /// <summary>
     ///  merge a list of files into a single XElement

--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -136,7 +136,7 @@ public interface ISyncFileService
     Task<XElement> LoadXElementAsync(string file);
 
     /// <summary>
-    ///  merge all the files in the give folders into a single xml node, that can be bulk imported
+    ///  merge all the files in the given folders into a single xml node, that can be bulk imported
     /// </summary>
     Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string fileName, string extension);
 

--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -136,6 +136,11 @@ public interface ISyncFileService
     Task<XElement> LoadXElementAsync(string file);
 
     /// <summary>
+    ///  merge all the files in the give folders into a single xml node, that can be bulk imported
+    /// </summary>
+    Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string targetFolder, string fileName);
+
+    /// <summary>
     ///  merge a list of files into a single XElement
     /// </summary>
     /// <remarks>

--- a/uSync.BackOffice/Services/ISyncService.cs
+++ b/uSync.BackOffice/Services/ISyncService.cs
@@ -160,6 +160,6 @@ public interface ISyncService
     /// <summary>
     ///  merge the given folders in single 'production' files for each handler.
     /// </summary>
-    Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers, bool clean);
+    Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers);
 
 }

--- a/uSync.BackOffice/Services/ISyncService.cs
+++ b/uSync.BackOffice/Services/ISyncService.cs
@@ -156,4 +156,10 @@ public interface ISyncService
     ///  trigger the end of the bulk process
     /// </summary>
     Task FinishBulkProcessAsync(HandlerActions action, IEnumerable<uSyncAction> actions);
+
+    /// <summary>
+    ///  merge the given folders in single 'production' files for each handler.
+    /// </summary>
+    Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers, bool clean);
+
 }

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -324,9 +324,9 @@ internal class SyncFileService : ISyncFileService
         }
     }
 
-    public async Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string targetFolder, string filename)
+    public async Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string filename, string extension)
     {
-        var merged = await MergeFoldersAsync(folders, "config", trackerBase);
+        var merged = await MergeFoldersAsync(folders, extension, trackerBase);
 
         var megaNode = new XElement(itemType + "s");
         int count = 0;
@@ -336,11 +336,10 @@ internal class SyncFileService : ISyncFileService
             megaNode.Add(new XElement(item.Node));
         }
 
-        var resolvedTargetFolder = GetAbsPath(targetFolder);
-        CreateFolder(resolvedTargetFolder);
+        var resolvedTargetFile = GetAbsPath(filename);
+        CreateFoldersForFile(resolvedTargetFile);
 
-        var singleFileName = Path.Combine(resolvedTargetFolder, $"{filename}.config");
-        await SaveXElementAsync(megaNode, singleFileName);
+        await SaveXElementAsync(megaNode, filename);
 
         return count;
     }

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -242,6 +242,7 @@ internal class SyncFileService : ISyncFileService
     {
         CheckCharacters = false,
         Async = true,
+        IgnoreWhitespace = true,
     };
 
     private static XmlWriterSettings _writerSettings = new XmlWriterSettings
@@ -251,8 +252,6 @@ internal class SyncFileService : ISyncFileService
         Async = true,
         CloseOutput= false,
         Indent = true,
-        
-
     };
 
     /// <inheritdoc/>
@@ -323,7 +322,27 @@ internal class SyncFileService : ISyncFileService
         {
             File.Copy(file, file.Replace(resolvedSource, resolvedTarget), true);
         }
+    }
 
+    public async Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string targetFolder, string filename)
+    {
+        var merged = await MergeFoldersAsync(folders, "config", trackerBase);
+
+        var megaNode = new XElement(itemType + "s");
+        int count = 0;
+        foreach(var item in merged)
+        {
+            count++;
+            megaNode.Add(new XElement(item.Node));
+        }
+
+        var resolvedTargetFolder = GetAbsPath(targetFolder);
+        CreateFolder(resolvedTargetFolder);
+
+        var singleFileName = Path.Combine(resolvedTargetFolder, $"{filename}.config");
+        await SaveXElementAsync(megaNode, singleFileName);
+
+        return count;
     }
 
     /// <inheritdoc/>

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -339,7 +339,7 @@ internal class SyncFileService : ISyncFileService
         var resolvedTargetFile = GetAbsPath(filename);
         CreateFoldersForFile(resolvedTargetFile);
 
-        await SaveXElementAsync(megaNode, filename);
+        await SaveXElementAsync(megaNode, resolvedTargetFile);
 
         return count;
     }

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -27,12 +27,6 @@ using uSync.Core.Serialization;
 
 namespace uSync.BackOffice;
 
-
-/// <summary>
-///  Callback event for SignalR hub
-/// </summary>
-public delegate void SyncEventCallback(SyncProgressSummary summary);
-
 /// <summary>
 ///  the service that does all the processing,
 ///  this forms the entry point as an API to 

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -112,7 +112,7 @@ public partial class SyncService
             .TrimEnd(Path.DirectorySeparatorChar);
 
     /// <inheritdoc />
-    public async Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers, bool clean)
+    public async Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers)
     {
         var totalMerged = 0;
 

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading.Tasks;
+
+using uSync.BackOffice.SyncHandlers.Models;
 
 namespace uSync.BackOffice;
 
@@ -104,4 +108,21 @@ public partial class SyncService
         => Path.GetFullPath(
             path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar))
             .TrimEnd(Path.DirectorySeparatorChar);
+
+    /// <inheritdoc />
+    public async Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers, bool clean)
+    {
+        var totalMerged = 0;
+        var root = _uSyncConfig.GetWorkingFolder();
+
+        foreach (var handler in handlers)
+        {
+            var folders = paths.Select(x => Path.Combine(x, handler.Handler.DefaultFolder)).ToArray();
+            var target = _uSyncConfig.Settings.ProductionFolder;
+
+            totalMerged += await _syncFileService.MakeSingleExportFromFolders(folders, handler.Handler.SerializeType, handler.Handler.BaseTracker, target, handler.Handler.DefaultFolder);
+        }
+
+        return totalMerged;
+    }
 }

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -118,7 +118,7 @@ public partial class SyncService
 
         foreach (var handler in handlers)
         {
-            var serializerType = handler.Handler.GetSerializeType();
+            var serializerType = handler.Handler.GetSerializerType();
             var baseTracker = handler.Handler.GetBaseTracker();
             if (serializerType is null || baseTracker is null)
             {

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -119,17 +119,19 @@ public partial class SyncService
 
         foreach (var handler in handlers)
         {
-            var folders = paths.Select(x => Path.Combine(x, handler.Handler.DefaultFolder)).ToArray();
-            var target = _uSyncConfig.Settings.ProductionFolder;
-
             var serializerType = handler.Handler.GetSerializeType();
-            if (serializerType is null)
+            var baseTracker = handler.Handler.GetBaseTracker();
+            if (serializerType is null || baseTracker is null)
             {
-                _logger.LogWarning("Handler {Handler} does not support file export", handler.Handler.Alias);
+                _logger.LogWarning("Handler {Handler} does not support file merging", handler.Handler.Alias);
                 continue;
             }
 
-            totalMerged += await _syncFileService.MakeSingleExportFromFolders(folders, serializerType, handler.Handler.GetBaseTracker(), target, handler.Handler.DefaultFolder);
+            var folders = paths.Select(x => Path.Combine(x, handler.Handler.DefaultFolder)).ToArray();
+            var targetFileName = Path.Combine(_uSyncConfig.Settings.ProductionFolder,
+                handler.Handler.DefaultFolder + "." + _uSyncConfig.Settings.DefaultExtension);
+
+            totalMerged += await _syncFileService.MakeSingleExportFromFolders(folders, serializerType, baseTracker, targetFileName, _uSyncConfig.Settings.DefaultExtension);
         }
 
         return totalMerged;

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -120,7 +122,14 @@ public partial class SyncService
             var folders = paths.Select(x => Path.Combine(x, handler.Handler.DefaultFolder)).ToArray();
             var target = _uSyncConfig.Settings.ProductionFolder;
 
-            totalMerged += await _syncFileService.MakeSingleExportFromFolders(folders, handler.Handler.SerializeType, handler.Handler.BaseTracker, target, handler.Handler.DefaultFolder);
+            var serializerType = handler.Handler.GetSerializeType();
+            if (serializerType is null)
+            {
+                _logger.LogWarning("Handler {Handler} does not support file export", handler.Handler.Alias);
+                continue;
+            }
+
+            totalMerged += await _syncFileService.MakeSingleExportFromFolders(folders, serializerType, handler.Handler.GetBaseTracker(), target, handler.Handler.DefaultFolder);
         }
 
         return totalMerged;

--- a/uSync.BackOffice/Services/SyncService_Files.cs
+++ b/uSync.BackOffice/Services/SyncService_Files.cs
@@ -115,7 +115,6 @@ public partial class SyncService
     public async Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers, bool clean)
     {
         var totalMerged = 0;
-        var root = _uSyncConfig.GetWorkingFolder();
 
         foreach (var handler in handlers)
         {

--- a/uSync.BackOffice/Services/SyncService_Handlers.cs
+++ b/uSync.BackOffice/Services/SyncService_Handlers.cs
@@ -39,7 +39,7 @@ public partial class SyncService
         var folders = GetHandlerFolders(GetFolderFromOptions(options), handlerPair.Handler);
 
         var productionFile = $"{folders.Last()}.{_uSyncConfig.Settings.DefaultExtension}";
-        if (File.Exists(productionFile))
+        if (_syncFileService.FileExists(productionFile))
             return await ReportMergedFile(productionFile, handlerPair, options);
 
         return await handlerPair.Handler.ReportAsync(folders, handlerPair.Settings, options.Callbacks?.Update);
@@ -81,7 +81,7 @@ public partial class SyncService
                 List<uSyncAction> results;
 
                 var productionFile = $"{folders.Last()}.{_uSyncConfig.Settings.DefaultExtension}";
-                if (File.Exists(productionFile))
+                if (_syncFileService.FileExists(productionFile))
                     results = [.. await ImportMergedFile(productionFile, handlerPair, options)];
                 else
                     results = [.. await handlerPair.Handler.ImportAllAsync(folders, handlerPair.Settings, options)];

--- a/uSync.BackOffice/Services/SyncService_Handlers.cs
+++ b/uSync.BackOffice/Services/SyncService_Handlers.cs
@@ -38,16 +38,17 @@ public partial class SyncService
         if (handlerPair == null) return [];
         var folders = GetHandlerFolders(GetFolderFromOptions(options), handlerPair.Handler);
 
-        if (File.Exists(folders.Last() + ".config"))
-        {
-            var fileName = folders.Last() + ".config";
-            var node = await _syncFileService.LoadXElementAsync(fileName);
-            return await handlerPair.Handler.ReportElementAsync(node, fileName, handlerPair.Settings, options);
-        }
-        else
-        {
-            return await handlerPair.Handler.ReportAsync(folders, handlerPair.Settings, options.Callbacks?.Update);
-        }
+        var productionFile = $"{folders.Last()}.{_uSyncConfig.Settings.DefaultExtension}";
+        if (File.Exists(productionFile))
+            return await ReportMergedFile(productionFile, handlerPair, options);
+
+        return await handlerPair.Handler.ReportAsync(folders, handlerPair.Settings, options.Callbacks?.Update);
+    }
+
+    private async Task<IEnumerable<uSyncAction>> ReportMergedFile(string filename, HandlerConfigPair handlerPair, uSyncImportOptions options)
+    {
+        var node = await _syncFileService.LoadXElementAsync(filename);
+        return await handlerPair.Handler.ReportElementAsync(node, filename, handlerPair.Settings, options);
     }
 
     /// <inheritdoc/>>
@@ -79,21 +80,13 @@ public partial class SyncService
 
                 List<uSyncAction> results;
 
-                if (File.Exists(folders.Last() + ".config"))
-                {
-                    var fileName = folders.Last() + ".config";
-                    var node = await _syncFileService.LoadXElementAsync(fileName);
-                    results = [.. await handlerPair.Handler.ImportElementAsync(node, fileName, handlerPair.Settings, options)];
-                }
+                var productionFile = $"{folders.Last()}.{_uSyncConfig.Settings.DefaultExtension}";
+                if (File.Exists(productionFile))
+                    results = [.. await ImportMergedFile(productionFile, handlerPair, options)];
                 else
-                {
-                    results = [..await handlerPair.Handler.ImportAllAsync(folders, handlerPair.Settings, options)];
-                }
-
-                // _logger.LogDebug("< Import Handler {handler}", handlerAlias);
+                    results = [.. await handlerPair.Handler.ImportAllAsync(folders, handlerPair.Settings, options)];
 
                 scope?.Complete();
-
                 return results;
             }
         }
@@ -101,6 +94,12 @@ public partial class SyncService
         {
             _importSemaphoreLock.Release();
         }
+    }
+
+    private async Task<IEnumerable<uSyncAction>> ImportMergedFile(string filename, HandlerConfigPair handlerPair, uSyncImportOptions options)
+    {
+        var node = await _syncFileService.LoadXElementAsync(filename);
+        return await handlerPair.Handler.ImportElementAsync(node, filename, handlerPair.Settings, options);
     }
 
     /// <inheritdoc/>>

--- a/uSync.BackOffice/Services/SyncService_Handlers.cs
+++ b/uSync.BackOffice/Services/SyncService_Handlers.cs
@@ -38,7 +38,16 @@ public partial class SyncService
         if (handlerPair == null) return [];
         var folders = GetHandlerFolders(GetFolderFromOptions(options), handlerPair.Handler);
 
-        return await handlerPair.Handler.ReportAsync(folders, handlerPair.Settings, options.Callbacks?.Update);
+        if (File.Exists(folders.Last() + ".config"))
+        {
+            var fileName = folders.Last() + ".config";
+            var node = await _syncFileService.LoadXElementAsync(fileName);
+            return await handlerPair.Handler.ReportElementAsync(node, fileName, handlerPair.Settings, options);
+        }
+        else
+        {
+            return await handlerPair.Handler.ReportAsync(folders, handlerPair.Settings, options.Callbacks?.Update);
+        }
     }
 
     /// <inheritdoc/>>
@@ -68,7 +77,18 @@ public partial class SyncService
                     backgroundTaskQueue: _backgroundTaskQueue,
                     options.Callbacks?.Update);
 
-                var results = await handlerPair.Handler.ImportAllAsync(folders, handlerPair.Settings, options);
+                List<uSyncAction> results;
+
+                if (File.Exists(folders.Last() + ".config"))
+                {
+                    var fileName = folders.Last() + ".config";
+                    var node = await _syncFileService.LoadXElementAsync(fileName);
+                    results = [.. await handlerPair.Handler.ImportElementAsync(node, fileName, handlerPair.Settings, options)];
+                }
+                else
+                {
+                    results = [..await handlerPair.Handler.ImportAllAsync(folders, handlerPair.Settings, options)];
+                }
 
                 // _logger.LogDebug("< Import Handler {handler}", handlerAlias);
 

--- a/uSync.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/DataTypeHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.XPath;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -66,40 +67,7 @@ public class DataTypeHandler : SyncHandlerContainerBase<IDataType>, ISyncHandler
         _dataTypeContainerService = dataTypeContainerService;
     }
 
-    /// <summary>
-    /// Process all DataType actions at the end of the import process
-    /// </summary>
-    /// <remarks>
-    /// Datatypes have to exist early on so DocumentTypes can reference them, but
-    /// some doctypes reference content or document types, so we re-process them
-    /// at the end of the import process to ensure those settings can be made too.
-    /// 
-    /// HOWEVER: The above isn't a problem Umbraco 10+ - the references can be set
-    /// before the actual doctypes exist, so we can do that in one pass.
-    /// 
-    /// HOWEVER: If we move deletes to the end , we still need to process them. 
-    /// but deletes are always 'change' = 'Hidden', so we only process hidden changes
-    /// </remarks>
-    public override async Task<IEnumerable<uSyncAction>> ProcessPostImportAsync(IEnumerable<uSyncAction> actions, HandlerSettings config)
-    {
-        if (actions == null || !actions.Any()) return [];
-
-        var results = new List<uSyncAction>();
-        var options = new uSyncImportOptions { Flags = SerializerFlags.LastPass };
-
-        // we only do deletes here. 
-        foreach (var action in actions.Where(x => x.Change == ChangeType.Hidden))
-        {
-            if (action.FileName is null) continue;
-            results.AddRange(
-                await ImportAsync(action.FileName, config, options));
-        }
-
-        results.AddRange(await CleanFoldersAsync(Guid.Empty));
-
-        return results;
-    }
-
+    
     /// <summary>
     ///  Fetch a DataType Container from the DataTypeService
     /// </summary>

--- a/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
@@ -15,11 +15,6 @@ using uSync.Core.Tracking;
 namespace uSync.BackOffice.SyncHandlers.Interfaces;
 
 /// <summary>
-///  callback delegate for SignalR messaging 
-/// </summary>
-public delegate void SyncUpdateCallback(string message, int count, int total);
-
-/// <summary>
 ///  Handler interface for anything that wants to process elements via uSync
 /// </summary>
 public interface ISyncHandler

--- a/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
@@ -10,6 +10,7 @@ using uSync.BackOffice.Models;
 using uSync.Core;
 using uSync.Core.Dependency;
 using uSync.Core.Models;
+using uSync.Core.Tracking;
 
 namespace uSync.BackOffice.SyncHandlers.Interfaces;
 
@@ -23,6 +24,9 @@ public delegate void SyncUpdateCallback(string message, int count, int total);
 /// </summary>
 public interface ISyncHandler
 {
+    string SerializeType { get; }
+    ISyncTrackerBase? BaseTracker { get; }
+
     /// <summary>
     ///  alias for handler, used when finding a handler 
     /// </summary>

--- a/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
@@ -24,8 +24,15 @@ public delegate void SyncUpdateCallback(string message, int count, int total);
 /// </summary>
 public interface ISyncHandler
 {
-    string SerializeType { get; }
-    ISyncTrackerBase? BaseTracker { get; }
+    /// <summary>
+    ///  get the serializer type for the handler (e.g the name used in the xml)
+    /// </summary>
+    string? GetSerializeType() => null;
+
+    /// <summary>
+    ///  gets the base tracker from the serializer (used to track changes, merge items).
+    /// </summary>
+    ISyncTrackerBase? GetBaseTracker() => null;
 
     /// <summary>
     ///  alias for handler, used when finding a handler 

--- a/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Interfaces/ISyncHandler.cs
@@ -22,7 +22,7 @@ public interface ISyncHandler
     /// <summary>
     ///  get the serializer type for the handler (e.g the name used in the xml)
     /// </summary>
-    string? GetSerializeType() => null;
+    string? GetSerializerType() => null;
 
     /// <summary>
     ///  gets the base tracker from the serializer (used to track changes, merge items).

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -130,13 +130,13 @@ public abstract class SyncHandlerContainerBase<TObject>
 
             // single 
             if (_loadedFiles[action.FileName].Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
-                return await ImportElementAsync(_loadedFiles[action.FileName], action.FileName, config, options);
+                return await ImportSingleElementAsync(_loadedFiles[action.FileName], action.FileName, config, options);
 
             // multiple ? 
             var node = _loadedFiles[action.FileName].XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
             if (node is null) continue;
            
-            results.AddRange(await ImportElementAsync(node, action.FileName, config, options));
+            results.AddRange(await ImportSingleElementAsync(node, action.FileName, config, options));
         }
 
         _loadedFiles.Clear();

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -128,15 +128,19 @@ public abstract class SyncHandlerContainerBase<TObject>
             if (_loadedFiles.TryGetValue(action.FileName, out XElement? xml) is false)
                 _loadedFiles[action.FileName] = await syncFileService.LoadXElementAsync(action.FileName);
 
-            // single 
             if (_loadedFiles[action.FileName].Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
-                return await ImportSingleElementAsync(_loadedFiles[action.FileName], action.FileName, config, options);
+            {
+                // single 
+                results.AddRange(await ImportSingleElementAsync(_loadedFiles[action.FileName], action.FileName, config, options));
+            }
+            else
+            {
+                // multiple ? 
+                var node = _loadedFiles[action.FileName].XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
+                if (node is null) continue;
 
-            // multiple ? 
-            var node = _loadedFiles[action.FileName].XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
-            if (node is null) continue;
-           
-            results.AddRange(await ImportSingleElementAsync(node, action.FileName, config, options));
+                results.AddRange(await ImportSingleElementAsync(node, action.FileName, config, options));
+            }
         }
 
         _loadedFiles.Clear();

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using System.Xml.XPath;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Cache;
@@ -115,7 +116,19 @@ public abstract class SyncHandlerContainerBase<TObject>
         foreach (var action in actions.Where(x => x.Change == ChangeType.Hidden))
         {
             if (action.FileName is null) continue;
-            results.AddRange(await ImportAsync(action.FileName, config, options));
+
+            if (syncFileService.FileExists(action.FileName))
+            {
+                var xml = await syncFileService.LoadXElementAsync(action.FileName);
+                var node = xml.XPathSelectElement($"//Empty[@Key='{action.Key}']");
+                if (node is null) continue;
+                results.AddRange(
+                    await ImportElementAsync(node, action.FileName, config, options));
+            }
+            else
+            {
+                await ImportAsync(action.FileName, config, options);
+            }
         }
 
         results.AddRange(await CleanFoldersAsync(Guid.Empty));

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -116,19 +116,18 @@ public abstract class SyncHandlerContainerBase<TObject>
         foreach (var action in actions.Where(x => x.Change == ChangeType.Hidden))
         {
             if (action.FileName is null) continue;
+            if (syncFileService.FileExists(action.FileName) is false) continue;
 
-            if (syncFileService.FileExists(action.FileName))
-            {
-                var xml = await syncFileService.LoadXElementAsync(action.FileName);
-                var node = xml.XPathSelectElement($"//Empty[@Key='{action.Key}']");
-                if (node is null) continue;
-                results.AddRange(
-                    await ImportElementAsync(node, action.FileName, config, options));
-            }
-            else
-            {
-                await ImportAsync(action.FileName, config, options);
-            }
+            // single 
+            var xml = await syncFileService.LoadXElementAsync(action.FileName);
+            if (xml.Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
+                return await ImportElementAsync(xml, action.FileName, config, options);
+
+            // multiple ? 
+            var node = xml.XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
+            if (node is null) continue;
+            
+            results.AddRange(await ImportElementAsync(node, action.FileName, config, options));
         }
 
         results.AddRange(await CleanFoldersAsync(Guid.Empty));

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -112,23 +112,34 @@ public abstract class SyncHandlerContainerBase<TObject>
         var results = new List<uSyncAction>();
         var options = new uSyncImportOptions { Flags = SerializerFlags.LastPass };
 
+        // a cache of loaded files so we don't keep loading the same file multiple times
+        // in production mode the same file might contain multiple 'empty' nodes
+        // and they can be large, and require loading from disk multiple times would slow
+        // it all down.
+        Dictionary<string, XElement> _loadedFiles = [];
+
         // we only do deletes here. 
         foreach (var action in actions.Where(x => x.Change == ChangeType.Hidden))
         {
             if (action.FileName is null) continue;
             if (syncFileService.FileExists(action.FileName) is false) continue;
 
+            // load the file if we haven't already
+            if (_loadedFiles.TryGetValue(action.FileName, out XElement? xml) is false)
+                _loadedFiles[action.FileName] = await syncFileService.LoadXElementAsync(action.FileName);
+
             // single 
-            var xml = await syncFileService.LoadXElementAsync(action.FileName);
-            if (xml.Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
-                return await ImportElementAsync(xml, action.FileName, config, options);
+            if (_loadedFiles[action.FileName].Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
+                return await ImportElementAsync(_loadedFiles[action.FileName], action.FileName, config, options);
 
             // multiple ? 
-            var node = xml.XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
+            var node = _loadedFiles[action.FileName].XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
             if (node is null) continue;
-            
+           
             results.AddRange(await ImportElementAsync(node, action.FileName, config, options));
         }
+
+        _loadedFiles.Clear();
 
         results.AddRange(await CleanFoldersAsync(Guid.Empty));
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerContainerBase.cs
@@ -25,6 +25,8 @@ using uSync.Core;
 using uSync.Core.Dependency;
 using uSync.Core.Serialization;
 
+using CoreConstants = uSync.Core.uSyncConstants;
+
 namespace uSync.BackOffice.SyncHandlers;
 
 /// <summary>
@@ -128,15 +130,15 @@ public abstract class SyncHandlerContainerBase<TObject>
             if (_loadedFiles.TryGetValue(action.FileName, out XElement? xml) is false)
                 _loadedFiles[action.FileName] = await syncFileService.LoadXElementAsync(action.FileName);
 
-            if (_loadedFiles[action.FileName].Name.LocalName.Equals(Core.uSyncConstants.Serialization.Empty) is true)
+            if (_loadedFiles[action.FileName].Name.LocalName.Equals(CoreConstants.Serialization.Empty) is true)
             {
                 // single 
                 results.AddRange(await ImportSingleElementAsync(_loadedFiles[action.FileName], action.FileName, config, options));
             }
             else
             {
-                // multiple ? 
-                var node = _loadedFiles[action.FileName].XPathSelectElement($"//{Core.uSyncConstants.Serialization.Empty}[@Key='{action.Key}']");
+                // multiple ?
+                var node = _loadedFiles[action.FileName].XPathSelectElement($"//{CoreConstants.Serialization.Empty}[@Key='{action.Key}']");
                 if (node is null) continue;
 
                 results.AddRange(await ImportSingleElementAsync(node, action.FileName, config, options));

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -278,6 +278,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         int count = 0;
         int total = items.Count;
 
+        options.Callbacks?.SetRange?.Invoke(count, total);
+
         foreach (var item in items)
         {
             count++;
@@ -455,7 +457,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         if (node.Name.LocalName == this.serializer.ItemType + "s")
         {
             var actions = new List<uSyncAction>();
-            foreach (var item in node.Elements())
+            var elements = node.Elements().ToList();
+            options.Callbacks?.SetRange?.Invoke(0, elements.Count);
+            foreach (var item in elements)
             {
                 actions.AddRange(await ImportSingleElementAsync(new XElement(item), filename, settings, options));
             }
@@ -483,6 +487,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         try
         {
+            options.Callbacks?.IncrementalUpdate?.Invoke(node.GetAlias());
+
             // merge the options from the handler and any import options into our serializer options.
             var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings, options.UserId);
             serializerOptions.MergeSettings(options.Settings);

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -170,7 +170,17 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     protected readonly IShortStringHelper shortStringHelper;
 
     /// <summary>
-    ///  Constructor, base for all handlers
+    ///  The serializer's item type (this is what the xml-node name will be.
+    /// </summary>
+    public string SerializeType => serializer.ItemType;
+
+    /// <summary>
+    ///  tracker used by the seralizer.
+    /// </summary>
+    public ISyncTrackerBase? BaseTracker => trackers.FirstOrDefault() as ISyncTrackerBase;
+
+    /// <summary>
+    ///  Constructor, base for all handlers`
     /// </summary>
     public SyncHandlerRoot(
             ILogger<SyncHandlerRoot<TObject, TContainer>> logger,
@@ -272,7 +282,6 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         {
             count++;
 
-            options.Callbacks?.Update?.Invoke($"Importing {Path.GetFileNameWithoutExtension(item.Path)}", count, total);
 
             var result = await ImportElementAsync(item.Node, item.FileName, config, options);
             foreach (var attempt in result)
@@ -442,6 +451,21 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     ///  All Imports lead here
     /// </remarks>
     virtual public async Task<IEnumerable<uSyncAction>> ImportElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
+    {
+        if (node.Name.LocalName == this.serializer.ItemType + "s")
+        {
+            var actions = new List<uSyncAction>();
+            foreach (var item in node.Elements())
+            {
+                actions.AddRange(await ImportSingleElementAsync(new XElement(item), filename, settings, options));
+            }
+            return actions;
+        }
+
+        return await ImportSingleElementAsync(node, filename, settings, options);
+    }
+
+    virtual public async Task<IEnumerable<uSyncAction>> ImportSingleElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
     {
         if (!await ShouldImportAsync(node, settings))
         {
@@ -1191,9 +1215,28 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     }
 
     /// <summary>
-    /// Report on any changes for a single XML node.
+    /// Report on any changes for a single XML node. (may contain multiple items in a single node).
     /// </summary>
     public virtual async Task<IEnumerable<uSyncAction>> ReportElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
+    {
+        if (node.Name.LocalName == this.serializer.ItemType + "s")
+        {
+            var actions = new List<uSyncAction>();
+            foreach (var item in node.Elements())
+            {
+                var cleanItem = new XElement(item);
+                actions.AddRange(await ReportElementSingleAsync(cleanItem, filename, settings, options));
+            }
+            return actions;
+        }
+
+        return await ReportElementSingleAsync(node, filename, settings, options);
+    }
+
+    /// <summary>
+    /// Report on any changes for a single XML node.
+    /// </summary>
+    public virtual async Task<IEnumerable<uSyncAction>> ReportElementSingleAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
     {
         try
         {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -446,12 +446,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         return await ImportAsync(file, config, options);
     }
 
-    /// <summary>
-    /// Import a node, with settings and options 
-    /// </summary>
-    /// <remarks>
-    ///  All Imports lead here
-    /// </remarks>
+    /// <inheritdoc />
     virtual public async Task<IEnumerable<uSyncAction>> ImportElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
     {
         if (node.Name.LocalName == this.serializer.ItemType + "s")

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -170,7 +170,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     protected readonly IShortStringHelper shortStringHelper;
 
     /// <summary>
-    ///  The serializer's item type (this is what the xml-node name will be.
+    ///  The serializer's item type (this is what the xml-node name will be).
     /// </summary>
     public string? GetSerializerType() => serializer.ItemType;
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -180,7 +180,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     public ISyncTrackerBase? GetBaseTracker() => trackers.FirstOrDefault() as ISyncTrackerBase;
 
     /// <summary>
-    ///  Constructor, base for all handlers`
+    ///  Constructor, base for all handlers
     /// </summary>
     public SyncHandlerRoot(
             ILogger<SyncHandlerRoot<TObject, TContainer>> logger,

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -469,7 +469,14 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         return await ImportSingleElementAsync(node, filename, settings, options);
     }
 
-    virtual public async Task<IEnumerable<uSyncAction>> ImportSingleElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
+    /// <summary>
+    ///  import a single XElement into umbraco. 
+    /// </summary>
+    /// <remarks>
+    ///  if the XElement contains multiple entries, then this method will not import them, if there is a possibility of that
+    ///  then the ImportElementAsync method should be used - which splits them before loading this call. 
+    /// </remarks>
+    virtual protected async Task<IEnumerable<uSyncAction>> ImportSingleElementAsync(XElement node, string filename, HandlerSettings settings, uSyncImportOptions options)
     {
         if (!await ShouldImportAsync(node, settings))
         {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -172,12 +172,12 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// <summary>
     ///  The serializer's item type (this is what the xml-node name will be.
     /// </summary>
-    public string SerializeType => serializer.ItemType;
+    public string? GetSerializerType() => serializer.ItemType;
 
     /// <summary>
-    ///  tracker used by the seralizer.
+    ///  tracker used by the serializer.
     /// </summary>
-    public ISyncTrackerBase? BaseTracker => trackers.FirstOrDefault() as ISyncTrackerBase;
+    public ISyncTrackerBase? GetBaseTracker() => trackers.FirstOrDefault() as ISyncTrackerBase;
 
     /// <summary>
     ///  Constructor, base for all handlers`

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -103,6 +103,9 @@ public static class uSyncBackOfficeBuilderExtensions
             {
                 options.Folders = ["uSync/Root/", options.RootFolder];
             }
+
+            if (options.IsRootSite is true && options.FolderMode == SyncFolderMode.Normal)
+                options.FolderMode = SyncFolderMode.Root;
         });
 
         return builder;

--- a/uSync.Backoffice.Management.Api/Controllers/Actions/SyncFolderController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Actions/SyncFolderController.cs
@@ -31,7 +31,7 @@ public class SyncFolderController : uSyncControllerBase
     {
         var folders = _configService.GetFolders();
         var handlers = _handlerFactory.GetValidHandlers(new BackOffice.SyncHandlers.Models.SyncHandlerOptions { Set = _configService.Settings.DefaultSet });
-        var result = await _syncService.MergeExportFolder(folders, handlers, false);
+        var result = await _syncService.MergeExportFolder(folders, handlers);
         return Ok(result);
     }
 }

--- a/uSync.Backoffice.Management.Api/Controllers/Actions/SyncFolderController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Actions/SyncFolderController.cs
@@ -1,0 +1,37 @@
+﻿using Asp.Versioning;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using uSync.BackOffice;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.SyncHandlers;
+
+namespace uSync.Backoffice.Management.Api.Controllers.Actions;
+
+[ApiVersion("1.0")]
+[ApiExplorerSettings(GroupName = "Folders")]
+public class SyncFolderController : uSyncControllerBase
+{
+    private readonly ISyncService _syncService;
+    private readonly ISyncConfigService _configService;
+    private readonly ISyncHandlerFactory _handlerFactory;
+
+    public SyncFolderController(ISyncService syncService, ISyncConfigService configService, ISyncHandlerFactory handlerFactory)
+    {
+        _syncService = syncService;
+        _configService = configService;
+        _handlerFactory = handlerFactory;
+    }
+
+    [HttpPost("MergeExport")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType<int>(StatusCodes.Status200OK)]
+    public async Task<IActionResult> MergeExportFolder()
+    {
+        var folders = _configService.GetFolders();
+        var handlers = _handlerFactory.GetValidHandlers(new BackOffice.SyncHandlers.Models.SyncHandlerOptions { Set = _configService.Settings.DefaultSet });
+        var result = await _syncService.MergeExportFolder(folders, handlers, false);
+        return Ok(result);
+    }
+}

--- a/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncActionsController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncActionsController.cs
@@ -33,7 +33,7 @@ public class uSyncActionsController : uSyncControllerBase
     public async Task<List<SyncActionGroup>> GetActionsBySet(string setName)
     {
         return await Task.FromResult(_syncManagementService.GetActions(setName));
-    }
+    }   
 
 
 }

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "16.1.0",
+	"version": "16.1.0-build.20251013.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "16.1.0",
+			"version": "16.1.0-build.20251013.4",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "16.1.0-build.20251013.4",
+	"version": "16.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "16.1.0-build.20251013.4",
+			"version": "16.1.0",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "16.1.0-build.20251013.4",
+	"version": "16.1.0",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "16.1.0",
+	"version": "16.1.0-build.20251013.4",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
@@ -60,7 +60,7 @@ export class USyncSettingsViewElement extends UmbElementMixin(LitElement) {
 								.value=${this.settings?.exportAtStartup}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_exportOnSaveup')}
+								.name=${this.localize.term('USyncSettings_exportOnSave')}
 								.description=${this.localize.term('USyncSettings_exportOnSaveDesc')}
 								.value=${this.settings?.exportOnSave}></usync-setting-item>
 

--- a/uSync.Core/Serialization/SyncSerializerRoot.cs
+++ b/uSync.Core/Serialization/SyncSerializerRoot.cs
@@ -281,7 +281,7 @@ public abstract class SyncSerializerRoot<TObject>
 
         var node = XElementExtensions.MakeEmpty(ItemKey(item), change, alias);
 
-        return Task.FromResult(SyncAttempt<XElement>.Succeed("Empty", node, ChangeType.Removed, []));
+        return Task.FromResult(SyncAttempt<XElement>.Succeed(uSyncConstants.Serialization.Empty, node, ChangeType.Removed, []));
     }
 
 

--- a/uSync.Core/uSyncConstants.cs
+++ b/uSync.Core/uSyncConstants.cs
@@ -49,6 +49,9 @@ public static partial class uSyncConstants
 
         public const string Domain = "Domain";
 
+        /// <summary>
+        ///  action files are 'empty' with an action to say what they do.
+        /// </summary>
         public const string Empty = "Empty";
 
         public const string RelationType = "RelationType";


### PR DESCRIPTION
Allows uSync to import files that contain multiple individual node items from a folder.

- this is quicker on something like azure, because it reduces the number of individual file reads. 
- it does require that the export be 'merged' into the single files for this to be true.
   - there is new api end point for creating these 'production' merge files of an on disk export
- there is a new 'mode' setting that you can put the site in to get it to read a 'production' folder where it expects these merged files to be. 

As of yet there is no ui to create the merged files, we will probably put it in the uSync command line. as really it needs to be part of CI/CD to be consistent and expected by the servers. 