### PR TITLE
add targets to not copy uSync folder into build outputs, (but to still copy in publish)

### DIFF
--- a/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.targets
+++ b/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<Content Update="uSync\**" >
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
+</Project>

--- a/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.targets
+++ b/uSync.BackOffice.Targets/buildTransitive/uSync.BackOffice.Targets.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<ItemGroup>
-		<Content Update="uSync\**" >
+		<Content Update="uSync/**" >
 			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
 			<CopyToPublishDirectory>Always</CopyToPublishDirectory>
 		</Content>


### PR DESCRIPTION
Adds an item group to the target files. that will be default exclude the 'uSync' folder from output folders (when you dotnet build), but will still include it in published folder (when you dotnet publish).

there is a small chance that there are some people taking the build output and using it to publish there site (but they shouldn't be!). and this will effect them because the usync folder will no longer be included. 

but it will be included if you do a `dotnet publish` which is the way to go (even in visual studio if you 'publish' it's doing a dotnet publish in the background. 

Addresses #833 