### PR TITLE
Fix: Don't group notifications if they are being fired in a background

### DIFF
--- a/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
+++ b/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
@@ -82,7 +82,7 @@ internal class SyncScopedNotificationPublisher
         else
         {
             // when not in the background we group them
-            // Umbraco doesn't currenlty fire them as groups, but it might in the future so we should. 
+            // Umbraco doesn't currently fire them as groups, but it might in the future so we should. 
             var groupedNotifications = notifications
                 .Where(x => x != null)
                 .GroupBy(x => x.GetType().Name);

--- a/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
+++ b/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
@@ -65,33 +65,35 @@ internal class SyncScopedNotificationPublisher
 
         SetNotificationStates(notifications);
 
-        var groupedNotifications = notifications
-            .Where(x => x != null)
-            .GroupBy(x => x.GetType().Name);
-
-        foreach (var items in groupedNotifications)
+        if (_uSyncConfig.Settings.BackgroundNotifications is true && _backgroundTaskQueue != null)
         {
-            if (_uSyncConfig.Settings.BackgroundNotifications is true && _backgroundTaskQueue != null)
-            {
-                _logger.LogDebug("Pushed {count} notifications into background queue", items.Count());
-                _backgroundTaskQueue.QueueBackgroundWorkItem(
-                    cancellationToken =>
+            _logger.LogDebug("Processing notifications in background queue");
+            _backgroundTaskQueue.QueueBackgroundWorkItem(
+                cancellationToken =>
+                {
+                    using (ExecutionContext.SuppressFlow())
                     {
-                        using (ExecutionContext.SuppressFlow())
-                        {
-                            Task.Run(() => _eventAggregator.Publish(items), cancellationToken);
-                            _logger.LogDebug("Background Events Processed");
-                            return Task.CompletedTask;
-                        }
-                    });
-            }
-            else
+                        Task.Run(() => base.PublishScopedNotifications(notifications), cancellationToken);
+                        _logger.LogDebug("Background Events Processed");
+                        return Task.CompletedTask;
+                    }
+                });
+        }
+        else
+        {
+            // when not in the background we group them
+            // Umbraco doesn't currenlty fire them as groups, but it might in the future so we should. 
+            var groupedNotifications = notifications
+                .Where(x => x != null)
+                .GroupBy(x => x.GetType().Name);
+
+            foreach (var items in groupedNotifications)
             {
                 _updateCallback?.Invoke($"Processing {items.Key}s ({items.Count()})", 90, 100);
                 _eventAggregator.Publish(items);
             }
-        }
 
+        }
         sw.Stop();
         _logger.LogDebug("<< Notifications processed - {elapsed}ms", sw.ElapsedMilliseconds);
 


### PR DESCRIPTION
If we group the notifications and then fire them. we end up with multiple background threads processing all sorts of notifications and even with the Suppress Flow line it trips up and locks the db. 

so when we are throwing notifications into the background we don't group them, we just put all of them in a background thread.

this makes the sync look super quick as all the slow stuff happens afterwards. its like when they change d the Processing of the GINA component in windows XP from synchronous to asynchronous, it made it look like Windows XP was turning on way faster, when it was just doing stuff in the background behind the login prompt. which is fine if you are not doing anything major during the start-up process but if you install extra software via the GINA then it might not be there right away when the user logs in, which again is a thing you don't really care about. In this context it means the sync might complete but the examine indexes or published caches might not be up to date right away, if you are adding sub 1000 content items you probably won't notice as this will happen within the first 60-90 seconds, but if you added say 10,000 content items on a slow site, it might be 20 minutes in which everything is 'synced' but you site doesn't quite have all the content. 

so - do we make this on by default (and everyone thinks "isn't this fast" ) or do we have it off by default and have everything ready at the end of the sync every time ?