### PR TITLE
Add cleanup in DocumentUrl tables when the content key changes.

### DIFF
--- a/uSync.Core/Documents/ISyncDocumentUrlCleaner.cs
+++ b/uSync.Core/Documents/ISyncDocumentUrlCleaner.cs
@@ -1,0 +1,7 @@
+﻿
+namespace uSync.Core.Documents;
+
+public interface ISyncDocumentUrlCleaner
+{
+    void CleanUrlsForDocument(Guid key);
+}

--- a/uSync.Core/Documents/SyncDocumentUrlCleaner.cs
+++ b/uSync.Core/Documents/SyncDocumentUrlCleaner.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+
+namespace uSync.Core.Documents;
+
+internal class SyncDocumentUrlCleaner : ISyncDocumentUrlCleaner
+{
+    private readonly ICoreScopeProvider _scopeProvider;
+    private readonly IDocumentUrlRepository _documentUrlRepository;
+    private readonly ILogger<SyncDocumentUrlCleaner> _logger;
+
+    public SyncDocumentUrlCleaner(IDocumentUrlRepository documentUrlRepository, ILogger<SyncDocumentUrlCleaner> logger, ICoreScopeProvider scopeProvider)
+    {
+        _documentUrlRepository = documentUrlRepository;
+        _logger = logger;
+        _scopeProvider = scopeProvider;
+    }
+
+    public void CleanUrlsForDocument(Guid key)
+    {
+        try
+        {
+            using (_scopeProvider.CreateCoreScope(autoComplete: true))
+            {
+                _logger.LogDebug("Cleaning urls for document {DocumentKey}", key);
+                _documentUrlRepository.DeleteByDocumentKey([key]);
+            }
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError(ex, "Error cleaning urls for document {DocumentKey}", key);
+        }  
+    }
+}

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
+using uSync.Core.Documents;
 using uSync.Core.Extensions;
 using uSync.Core.Mapping;
 using uSync.Core.Models;
@@ -23,6 +24,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
     protected readonly IUserService userService;
 
     protected readonly ITemplateService _templateService;
+    protected readonly ISyncDocumentUrlCleaner _urlCleaner;
 
     public ContentSerializer(
         IEntityService entityService,
@@ -33,7 +35,8 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         IContentService contentService,
         SyncValueMapperCollection syncMappers,
         IUserService userService,
-        ITemplateService templateService)
+        ITemplateService templateService,
+        ISyncDocumentUrlCleaner urlCleaner)
         : base(entityService, languageService, relationService, shortStringHelper, logger, UmbracoObjectTypes.Document, syncMappers)
     {
         this.contentService = contentService;
@@ -41,6 +44,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         this.relationAlias = Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias;
         this.userService = userService;
         _templateService = templateService;
+        _urlCleaner = urlCleaner;
     }
 
     #region Serialization
@@ -298,7 +302,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         var changes = await DeserializeSchedulesAsync(item, node, options);
         if (changes.Count != 0)
             return SyncAttempt<IContent>.Succeed(item.Name ?? item.Id.ToString(), item, ChangeType.Import, "" ?? string.Empty, true,
-                [..details, ..changes]);
+                [.. details, .. changes]);
 
         // if we have changed the sort order, then we return a change, else it was no change.        
         return SyncAttempt<IContent>.Succeed(item.Name ?? item.Id.ToString(), item,
@@ -794,4 +798,12 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
             }
         });
     }
+
+    protected override Task OnKeyChange(IContent item, Guid oldKey, Guid newKey)
+    {
+        // key changes need to clean the DocumentUrl cache.
+        _urlCleaner.CleanUrlsForDocument(oldKey);
+        return Task.CompletedTask;
+    }
 }
+

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -410,6 +410,10 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         {
             changes.AddUpdate(uSyncConstants.Xml.Key, item.Key, key);
             logger.LogTrace("{Id} Setting Key {Key}", item.Id, key);
+
+            if (item.Id > 0)
+                await OnKeyChange(item, item.Key, key);
+
             item.Key = key;
         }
 
@@ -424,6 +428,13 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         changes.AddRange(DeserializeName(item, node, options));
 
         return changes;
+    }
+
+    protected virtual Task OnKeyChange(TObject item, Guid oldKey, Guid newKey)
+    {
+        // nothing to do here, but subclasses might need to act on key changes.
+        logger.LogDebug("{id} Key changed from {oldKey} to {newKey}", item.Id, oldKey, newKey);
+        return Task.CompletedTask;
     }
 
     protected IEnumerable<uSyncChange> DeserializeName(TObject item, XElement node, SyncSerializerOptions options)

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
 
+using uSync.Core.Documents;
 using uSync.Core.Extensions;
 using uSync.Core.Mapping;
 using uSync.Core.Models;
@@ -29,8 +30,9 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
         IContentTypeService contentTypeService,
         SyncValueMapperCollection syncMappers,
         IUserService userService,
-        ITemplateService templateService)
-        : base(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, templateService)
+        ITemplateService templateService,
+        ISyncDocumentUrlCleaner urlCleaner)
+        : base(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, templateService, urlCleaner)
     {
         _contentTypeService = contentTypeService;
         this.umbracoObjectType = UmbracoObjectTypes.DocumentBlueprint;

--- a/uSync.Core/uSyncCoreBuilderExtensions.cs
+++ b/uSync.Core/uSyncCoreBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using uSync.Core.Cache;
 using uSync.Core.DataTypes;
 using uSync.Core.Dependency;
+using uSync.Core.Documents;
 using uSync.Core.Mapping;
 using uSync.Core.Roots.Configs;
 using uSync.Core.Serialization;
@@ -32,6 +33,9 @@ public static class uSyncCoreBuilderExtensions
             return builder;
 
         builder.Services.AddSingleton<uSyncCapabilityChecker>();
+
+        // document url cleaner, for key changes
+        builder.Services.AddSingleton<ISyncDocumentUrlCleaner ,SyncDocumentUrlCleaner>();
 
         // cache for entity items, we use it to speed up lookups.
         builder.Services.AddSingleton<SyncEntityCache>();


### PR DESCRIPTION
Workaround for https://github.com/umbraco/Umbraco-CMS/issues/21131. 

When a content item's Key changes during an import - Umbraco throws an ForeignKey exception because of the bindings to the `umbracoDocumentUrl` table.

This PR checks on key changes, and removes entries from that table (via the repository). - so the conflict doesn't happen. 

On Save Umbraco puts new entries in the table with the new Key so this "should" be ok. 