### PR TITLE
Ensure we don't build the extend unless we are in debug.

### DIFF
--- a/uSync.slnx
+++ b/uSync.slnx
@@ -27,7 +27,9 @@
   <Project Path="uSync.BackOffice.Targets/uSync.BackOffice.Targets.csproj" />
   <Project Path="uSync.BackOffice/uSync.BackOffice.csproj" />
   <Project Path="uSync.Core/uSync.Core.csproj" />
-  <Project Path="uSync.Extend/uSync.Extend.csproj" Id="7004bc54-4d76-45d4-aa26-3f1a415c5b8c" />
+  <Project Path="uSync.Extend/uSync.Extend.csproj" Id="7004bc54-4d76-45d4-aa26-3f1a415c5b8c">
+    <Build Solution="Debug|*" Project="false" />
+  </Project>
   <Project Path="uSync.History/uSync.History.csproj" />
   <Project Path="uSync.Tests/uSync.Tests.csproj" />
   <Project Path="uSync/uSync.csproj" />


### PR DESCRIPTION
changes the solution config, so extend isn't built as part of a release