### PR TITLE
Fix - when descriptions are blank, they get filled with 'null'

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -263,7 +263,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
             item.Thumbnail = thumbnail;
         }
 
-        var description = info.Element("Description").ValueOrDefault<string?>(null);
+        var description = info.Element("Description").ValueOrDefault<string?>(string.Empty);
         if (item.Description != description)
         {
             changes.AddUpdate("Description", item.Description, description, "");


### PR DESCRIPTION
quick fix, when a description is blank for a content type, we are putting in the word 'null' and we shouldn't 