### PR TITLE
refresh the trees in settings when uSync finishes an import 

### DIFF
--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.0.1",
+	"version": "17.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.0.1",
+			"version": "17.0.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/client-fetch": "^0.10.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.0.1",
+	"version": "17.0.3",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
@@ -19,6 +19,16 @@ import {
 	USYNC_SIGNALR_CONTEXT_TOKEN,
 } from '@jumoo/uSync';
 import { uSyncActionPerformEvent } from '../../components/events';
+import { UmbRequestReloadChildrenOfEntityEvent } from '@umbraco-cms/backoffice/entity-action';
+import { UMB_ACTION_EVENT_CONTEXT } from '@umbraco-cms/backoffice/action';
+import { UMB_DOCUMENT_TYPE_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/document-type';
+import { UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/media-type';
+import { UMB_TEMPLATE_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/template';
+import { UMB_DATA_TYPE_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/data-type';
+import { UMB_MEMBER_TYPE_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/member-type';
+import { UMB_STYLESHEET_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/stylesheet';
+import { UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/partial-view';
+import { UMB_SCRIPT_ROOT_ENTITY_TYPE } from '@umbraco-cms/backoffice/script';
 
 @customElement('usync-default-view')
 export class uSyncDefaultViewElement extends UmbLitElement {
@@ -126,10 +136,12 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 				this._results = _results;
 			});
 
-			this.observe(_instance.completed, (_completed) => {
+			this.observe(_instance.completed, async (_completed) => {
 				this._completed = _completed;
 				if (this._completed) {
 					this._buttonState = 'success';
+
+					await this.#refreshTrees();
 				}
 			});
 
@@ -146,6 +158,28 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 					this._group = _workingGroup;
 				}
 			});
+		});
+	}
+
+	async #refreshTrees() {
+		const actionEventContext = await this.getContext(UMB_ACTION_EVENT_CONTEXT);
+		const refreshTypes = [
+			UMB_DOCUMENT_TYPE_ROOT_ENTITY_TYPE,
+			UMB_MEDIA_TYPE_ROOT_ENTITY_TYPE,
+			UMB_MEMBER_TYPE_ROOT_ENTITY_TYPE,
+			UMB_TEMPLATE_ROOT_ENTITY_TYPE,
+			UMB_DATA_TYPE_ROOT_ENTITY_TYPE,
+			UMB_STYLESHEET_ROOT_ENTITY_TYPE,
+			UMB_PARTIAL_VIEW_ROOT_ENTITY_TYPE,
+			UMB_SCRIPT_ROOT_ENTITY_TYPE,
+		];
+
+		refreshTypes.forEach((type) => {
+			const event = new UmbRequestReloadChildrenOfEntityEvent({
+				entityType: type,
+				unique: null,
+			});
+			actionEventContext?.dispatchEvent(event);
 		});
 	}
 

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.0.1",
+  "version": "17.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.0.1",
+      "version": "17.0.3",
       "dependencies": {
         "@jumoo/translate": "^17.0.0-rc1"
       },
@@ -508,6 +508,7 @@
       "integrity": "sha512-LSBHP2/wTF1BnaccHGX1t+0Ss+2VJQxotrLz/0+LK2z8ocuyVZXOYhfBSd7FP8sK78MDJVDBYrPCsBUvNSlH1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "^0.2.0",
         "@hey-api/json-schema-ref-parser": "1.2.0",
@@ -574,7 +575,6 @@
       "integrity": "sha512-DrhgzFWI9JE4RPTsHYRxh4yr+OhnwKz8bnJe7eIi7mLLjqhJpEb62CiUy/YbFvLqLzcGzlzz1QWgVAW0zyipMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",
@@ -589,7 +589,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -648,8 +647,7 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
@@ -1155,7 +1153,6 @@
       "integrity": "sha512-nPzraIx/f1cOUNqG1LSC0OTnEu3mudcN3jQVuyGh3dvdOnik7FUciJEVfHKnloAyeoijidEeiLpiGHInp2uREg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tiptap/core": "^3.6.2",
         "@tiptap/extension-blockquote": "^3.6.2",
@@ -1208,7 +1205,6 @@
       "integrity": "sha512-swBtOW1g6LMwA1LTZN2GBpdgwOD6pL/SX1GrfZJ46uQF8uBuErsUc+Iop7SX3pVPGLmQg40k0qW5k9QjEC8dGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1223,7 +1219,6 @@
       "integrity": "sha512-8TE9oFEonoAs0k3Vd1RGW1FiDBayJiBWyd+1eoH6EEmk1DD7quHcP1mBNZwPpjhONMITaSmizs2FjweWYibFwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1238,7 +1233,6 @@
       "integrity": "sha512-SzE8u9QrpzculNmtxKJZAvNG2hGLwishk4oUocK8aAYGUhesKd4pLHE1emA54TgWP0t1aXstg49QIhmHcUND0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1253,7 +1247,6 @@
       "integrity": "sha512-jeStJuFR5jpwHw/jdnqc1sVNe73dJcqDhcjmNV8cxy86BBadSGynUL1O1/vIyGbF1BFkU69UDBAOLptPH/M2Xg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1268,7 +1261,6 @@
       "integrity": "sha512-Yy7XREi27aUE3S1NMihq0j4vM9rNLa3AQVHWFx1Ze2Jec2MUK7ef8WUkMs28cX76M+yB4P63Q2z8meH6HUAzyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1284,7 +1276,6 @@
       "integrity": "sha512-HM9lmPGKX1s9NJYQh1BD6oLqwh0gWylNmgkT6hEI7lm7DANxaYyMZue9anCDae+K6tln22BauXGAfbRb6Bs0Lw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1299,7 +1290,6 @@
       "integrity": "sha512-fF3h2Oac8vr21uJh+tiUEz/XUoEzXqx5JpoyWj6BmrTulaMY5uw+SUbh1MxN2EeZ+dUvoc8wPATvn0TTq/3GpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1314,7 +1304,6 @@
       "integrity": "sha512-Tg43PHL21ZgVXiQZrXmMWCx8jZGEfxB7xxamEkl0CdRFGkcXRmARXuNKT72NtCI3t7/QSlKbpyD/2/9RFGvyeA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1329,7 +1318,6 @@
       "integrity": "sha512-kCz/ILEVr3jd4/adOfl9d62dEe9PQrHXAB5rBy1ZFoNC+C7Trq8cgpyqUYFAK7Z500nKmUgQh1GtqGN2vy338Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1344,7 +1332,6 @@
       "integrity": "sha512-udG4cG1pmumECEb6WDW/qYtuHcHscTMPCR6mG8hz0WpYk1S+LQWGPaQPdvHK6qYrMo/3YwQcYZv5vuQiB3dpjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1359,7 +1346,6 @@
       "integrity": "sha512-P9dJrVnVlYTESmXWMDmAMHw1TLHZwKQV8Yfz1f8mCuuIHTR++hoWVgjZ70MYZzdAMCug3FWsmDjo+sxGCWOTpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1375,7 +1361,6 @@
       "integrity": "sha512-/VbABhC20z/KWhKjcFUk7jJuOgD8Hp2V5lr6fOLFJaRpptoJhmbCRrPJzEZhs/Z55nv6aF7ZxVxtjzO0FpKneQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1390,7 +1375,6 @@
       "integrity": "sha512-87OBwlU/ylPCDNhNyKPQaM0KiT0FscyAqh8/oErmI7gKVdrUNfO4zcqIOKHql32lEu9KsmpSum/jSeeUJMR4pA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "linkifyjs": "^4.3.2"
       },
@@ -1425,7 +1409,6 @@
       "integrity": "sha512-YCK2N2RJGnvMTolwMD3kutnN4x1duBhUH14SdigJuPQLhDi02ck6jjTCNTjQRgDfpL9qfSLpPdn0ou7+NbFu3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1440,7 +1423,6 @@
       "integrity": "sha512-EPFZtv4yzuCRXqyIQ6v7xvDFGb9L4O+r6NpQ/Aim6fgQmElxHKs75iDet0dFWGQ/Re/o1Q7zgW3mhBcl1MLszw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1455,7 +1437,6 @@
       "integrity": "sha512-dpKNFFF8QqfwSuXYoTktb3Woeqqjc3pZ4Vx4F4JSyzIlgBPLim0Wkn18ClJFIC2But/FcLm6NQrlpnimExfFlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1470,7 +1451,6 @@
       "integrity": "sha512-ocxyg947q5yOSyripEingN7SnsJ/4cYuxOg8BdNlSao8HzUTw5298/81Almf2pT0FNAJHMp8R4Xsii2oMlJ/yQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1485,7 +1465,6 @@
       "integrity": "sha512-NYnQOQM/HRvOcCRdetZthMMOZFpxpJ2PBuYg6u6ysotFJPWVVaegtNfZ4se0UdxDNPYInTW3gAgF05Tq/XszRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1500,7 +1479,6 @@
       "integrity": "sha512-Af0WBQJvjiTnEArutOZENCVNGuK7Ln3BwUH3jXsk4OUHxOyt5JK9qsDePsO46Dj9OlXHbnBi5hAnhJGI8zGLzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1515,7 +1493,6 @@
       "integrity": "sha512-U56hHqCSjwP8wAq28n6A+l+aNW/DxJXiaNwXs7YlC4IjRDkbsl5q53UcOlRCoVnYVY2mxj1L6Zmu2u6dhjeuSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1599,8 +1576,7 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -1608,7 +1584,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1619,8 +1594,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -1773,7 +1747,6 @@
       "integrity": "sha512-WM08j2cGcJcbXWS6Pb9FdhaKDz3+EUSuoxrsZoGkJBJMriZLv4gq9EcE5RIstUbT8JmDPQ7uT3SDT2gZWl07MQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button-group": "1.16.0"
@@ -1785,7 +1758,6 @@
       "integrity": "sha512-1u6+hOLy5NrFh5/Z4Kp88y3Mhq+FYCZRwPb+5lSutm+aMy27dehRKkZqlbptWn/qocUCibDxQpruvu/UMtVQtg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1796,7 +1768,6 @@
       "integrity": "sha512-509UZzUSD/JhJEVLEpT5ltccHpEw8RxoZbG+hJeg23Oh3jNuRrKvuiyOut5c6JfjMdawHw6vPivVwjqCmbZG5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0"
@@ -1808,7 +1779,6 @@
       "integrity": "sha512-sHo71JOxxk0EufgYfCl9miuYgM1LDSnmtHedvDGs776htMFkLo3W/cFWgIXabAHZeSj4R5UWMGDNsugwv03R+w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1819,7 +1789,6 @@
       "integrity": "sha512-8i9bdcSrdR/4lWm0xetr3R3w3Rod3YVbIddHqbb3iVrr0TmPDTVA48tnOsJyQFAvTrh2LZjiETvEve7pBy4WQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
@@ -1830,7 +1799,6 @@
       "integrity": "sha512-IRU2z3GV+WzyjUvIMeErYeOE/0GyOpItsXxfmxsEENT/7qq4UMk28fIxY9IdDfI285WP0N3kezWkPBPlCKBcNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1841,7 +1809,6 @@
       "integrity": "sha512-/Wgnv2jr6wKG436WNjBdGq6x+aExiZhZgLPnzrTcaevy85MM5pJZWgY1+aI+pJclgU6WtRMii2+C8MZL2Qmh0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -1853,7 +1820,6 @@
       "integrity": "sha512-PuLcxG+3ZeSXKH3M0Kkh3eVYOEJPwLfg+6+b4UXxV/O9p0tUFbNPc8ciggL/1ZBXYXjsQnFTaOQWV4zGpnCnFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1864,7 +1830,6 @@
       "integrity": "sha512-0nTAx/GVOdGvlekkIxZp1nJs2E1DRzbdUnARl6RN5Oc40HowW9oO5oJvDIpoZcsWqkqWzFTQqVgE1z1PafKHZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0"
@@ -1876,7 +1841,6 @@
       "integrity": "sha512-CXjJzLbedqHtlza2zspSWNZCw5XhHV5QkPFzRI5Zd8FwFZop1/UgM2GQeSrMaWdfpznbWvfUqnvSYt9wYEubVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0"
@@ -1888,7 +1852,6 @@
       "integrity": "sha512-ygici33P70SJqa2SSjdSVd8paSKqHwewKJMcyIF/IehDepnDP0ngSHWA23B/sEzJNJgq0Zngo9g3jlhZz6H6GA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1899,7 +1862,6 @@
       "integrity": "sha512-To9K/mYXLm4SGih3uA8/jbZd/ewWKVvYH6b26F5fvEDVT+X9fjJchKT7J/u0a4C7wghvVNT+os7H0rxS3yTXiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1910,7 +1872,6 @@
       "integrity": "sha512-o/8vDLT03WnQsJKyD8r7PzxvhD3loRI7pL3tZU1BeSDcFAOZPPWIudQ/OwYeJnMI1iHkd2eTu0h22B/sXOfIIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-checkbox": "1.16.0"
@@ -1922,7 +1883,6 @@
       "integrity": "sha512-Xpq/kB/ofSn067teaOyS4hEsEt/WUlrJ0opTFgkwHxsWg9rvMzUtg2nc2JGMoIqJ64/40Axcx0jmmchIDUcbsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0"
@@ -1934,7 +1894,6 @@
       "integrity": "sha512-VPRDFrZSPLDGE3kAarW78dZHIFBhwXakyj7PM278tcXGdfSM7M9HsLXME6DhlleOYfSV07wHXm0UXKieqO7vgw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -1947,7 +1906,6 @@
       "integrity": "sha512-IHFCnXr4Bdpj/aUn+jpmlYx9L0FzeWTwt+cb29b4oP0cjIiVaJIrkOCSIl3SF8ncrKfMlTjlgBe0t0sP4mjeug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-card": "1.16.0",
@@ -1961,7 +1919,6 @@
       "integrity": "sha512-Ne64+ssQrpP9zJvlJhH1Y5xlEDMW1lG17Orj6XH99iDtGdrnug9FjRE4vpNfAVRIb9P1pf7xNJtq2XqCJHvqOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -1974,7 +1931,6 @@
       "integrity": "sha512-B3xNrwkQBwye9ydlrvnYfbJyiLqwQEbpldfaJnjLvlW9xVhOFps2NfeRyXcdsvruaIwjml7aB18GVYDCd/PSlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -1985,7 +1941,6 @@
       "integrity": "sha512-4z8XrZ0InVArdHKO7L7uwAMwUwHyQKqSYShE74VHHWOibySciJ/zPx3hFO3eQ7EBL3Kj+4raun5Ah5jHUlDZwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0",
@@ -1998,7 +1953,6 @@
       "integrity": "sha512-wiK9WNZWZ5yFd3ouTZOcoUSm+2iNZIFlGTaTScnG/DiLCBs6DUvdbSbVHueY1cGWbOx/R8N01kZBls1fk8kaHw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "colord": "^2.9.3"
@@ -2010,7 +1964,6 @@
       "integrity": "sha512-IilZw7Qn+2QF80OXktnoY1RI45ggl8o+QyF5a6zjd2gl5BfwAVx/uFCnpDfjH6LKtRw9WvuPKHQyM0/mfi5I4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-popover-container": "1.16.0",
@@ -2023,7 +1976,6 @@
       "integrity": "sha512-GDlAv+75efrOq9K/mZSKLwmc/ZG82hCaRMpWI4guKKvJhcukIcg7Bt/jQrDrtEGKCYvMJpNzbqZ41b+x23EQEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2034,7 +1986,6 @@
       "integrity": "sha512-I+0iEkIGXzoDfLUj0duUJsdf71FC1EBqNzAH/X5noiWc+RZiAAw5EvXm7rZO69oDNOQMwt/yMCBLJQp2kYOQTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -2047,7 +1998,6 @@
       "integrity": "sha512-i58T2PRYzViBTo7OtJAGi5inVF8jxVYBmLL7nb3dpNjUFTZZufRKTr3AsVS7+pCGEogFmyNbcNztmmEMdU4ekA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-color-swatch": "1.16.0"
@@ -2059,7 +2009,6 @@
       "integrity": "sha512-zjeNG+7r5J4UgdeWh8Osktkjk/Uret5tu8mUtpp0Z6LIbxISUKEt9QlbjPPorxB3V0ENKUJ2c5KZZtpj7mLihQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -2076,7 +2025,6 @@
       "integrity": "sha512-gNFheYUtzMvQudvzoRhDgJk9zziFTxSyu92aYzyoyhh7M098gJfqU+fo7Teqqiuyb0NEiZPThcNrUT9MD2LD3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2098,7 +2046,6 @@
       "integrity": "sha512-dq+daSQKAIdsP+2QhM6HmU9Nr5VVzbxwQEYLVvAcmYcw4K98TVpP6AyHu5dPDP9vl4EBBXUrrZuXFjU+Mh8/xQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -2110,7 +2057,6 @@
       "integrity": "sha512-iRpmlzp1PAUpF6Ol2EWubdABIgpJE6QmBzaQONm3Mmwe1wLxMGp5+o33wHU9WSTh8kDrH/U5mWtua6Xtyf5JFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2121,7 +2067,6 @@
       "integrity": "sha512-B3Zy6jlyK68ntaC4idv7fzd9NVyc4VVjn68DgkvnHR76Mp8zmOgT0g7K7/WM33IPw/n/ZfBhM1KEb+ry3i9/bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file-dropzone": "1.16.0"
@@ -2133,7 +2078,6 @@
       "integrity": "sha512-A+jych/xEUOssZjqWtW04nD1GcVOHnonTlPdrDaFh9PhwQAL0PREBbHZnkLJBS4z+HKWhsXOUeQ9ju0YAtbRuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-symbol-file": "1.16.0",
@@ -2147,7 +2091,6 @@
       "integrity": "sha512-mZVeqQtKirPHCES6TcTywELJi3raBgSKRt2XKCmHMDzclK9P11qPuOve335Jd8WPISsqbbcw4mIAGQpww7TxIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2158,7 +2101,6 @@
       "integrity": "sha512-g1xYut9TQzAK1w0fijWyV2PlXJnaMw3MYgytvsEu3XD93hPut4XvkifM8Ja6YxpkRcKQpRRLa4WHroQ6OQY6LQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-form-validation-message": "1.16.0"
@@ -2170,7 +2112,6 @@
       "integrity": "sha512-55+WAkF02Im+bG1Xl1AABA7KIGXr5CZTgHbr3MsVVHJMtHv+gQZ04h+0TkvDzKZDSg8ucCXJKyD44Y4gOyS2oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2181,7 +2122,6 @@
       "integrity": "sha512-x7HX9OnKOTgjbFbSSZ9Pk0+Lf6yo8ggLe6XTnPClu3ByN2fl9/QqshI5lx4oz5Adr/ItSj3zqnNB2JbyM56TLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2192,7 +2132,6 @@
       "integrity": "sha512-o4l2bEYKdBcxAlSwEPO+cfnNvkGuGcZRyca026xvIz+nufbc/BBzskzS1UWIIjkFPu64rHEfxP/3KbSld64HYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0"
@@ -2204,7 +2143,6 @@
       "integrity": "sha512-HI4cnYhWpPtWFFgfEltjV6PPhOd3NQ58BhqfbCpRbwmHZUZ0OBzGRl4QgsPNKuhQqmcXene+Twfy8eoRk1/5nQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry": "1.16.0"
@@ -2216,7 +2154,6 @@
       "integrity": "sha512-2Mp15ObjyAuRD3bOTs/zuUHqaaMiuDhmGsjeK8ViOrlSMnz/bVUme5scN1OMkNIryVHkENshC4NK7x6++X0/qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2227,7 +2164,6 @@
       "integrity": "sha512-AxepSUJe0LmY4QmBA9UlzhZBBrVF+z88fFUWIH15PICFX0jfsPNIeiwQKlv7cN5pEInUh6qCRN64z8icf8fcdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-action-bar": "1.16.0",
         "@umbraco-ui/uui-base": "1.16.0",
@@ -2243,7 +2179,6 @@
       "integrity": "sha512-FTLj/2s+VImEtKe1GPSkAC2pmTabz5cGzvaFB/7xrJj/1evVxXGu8qQyyL96WoDe+RAmBNYfrnGx7OUSVhEyRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -2257,7 +2192,6 @@
       "integrity": "sha512-0gg8nAVHsMYlQscG76PN4L8ha3CpW15crlzgj4TMaW24OIgZ0khV18ZImJ5n9wv/zrq8LsrwJTyZ5/a/soaKyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon-registry-essential": "1.16.0",
@@ -2270,7 +2204,6 @@
       "integrity": "sha512-z9wlhONxtwkUCkPEKqt/vSH1qOTwHCIM2Cj/DQ21+bfWcywUR7cAp0vRveapymDn4eHSuRra5lrG7xgLYsYuVg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2281,7 +2214,6 @@
       "integrity": "sha512-1vQAKUR+frDEth8AMLS5KKpVK2LHD61lWUG95yMypF5C2+YBmzXb70QEakOubTMsmLnYcU3hfORfA5Wp9cYPnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2292,7 +2224,6 @@
       "integrity": "sha512-wcFUljPcrAR6YYuj5XLmtMpZBvzTBcakr9p+vISOoC3ta8UlE+OOLiQn+XYzTuV/ZbM77EHh5EEyiO5L45fQew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2303,7 +2234,6 @@
       "integrity": "sha512-xh6RCS60WPWPzf0dAA+lTTt0rF8hksQsYBLwITBsR/5k3qswhT9Ctu/2LvqUXoLPyEFTecA4fyqZK+NzhjZrdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2314,7 +2244,6 @@
       "integrity": "sha512-jawUHoiUwwZkp5YOLFlF00WvZ5yPowfbi22TufSyfls5hMajJM/p21IrCTStrc4ZimqyheaaYe/AqdGLDimfSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2325,7 +2254,6 @@
       "integrity": "sha512-tyyuehJSj1BU/EEsQ1LHN8eg+gcAKCzqGMwwpepEtKZDd7p1/Ioq1KEn2e20UOihXab5rFv5UNEWSeyEYRqL4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-loader-bar": "1.16.0",
@@ -2338,7 +2266,6 @@
       "integrity": "sha512-hqlXHjlGxEWEeX5c7W0xNlH25xDbb8vdgBIfYGUkBfrYrgO3j+AJ/B7OvmgWJogFTOHRRaPUvKDi8DkDnDH4zw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2349,7 +2276,6 @@
       "integrity": "sha512-bZQl5BwiYHSQqc0bjajQbu8ZX+z4qe56t6PiT6s+VUj6huXOOrT72hpY2u+ZE22sAWPaIu42Kg9ulxNV2pulRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -2362,7 +2288,6 @@
       "integrity": "sha512-ZtHPdupRjxwuSHmY5EiiGtZMBi5UsAyHOucn5SxMgdyHT7bRxrV1ebCblDu4eikXg/xx1nTDSFmmW4rXLftULg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2373,7 +2298,6 @@
       "integrity": "sha512-3N8M4hPQFcthVfqfhdCMX9B4q+0sG2zizoQf2SvDoLp3GAqND2zw2cwYClMy8HJh3XH9JINljz3PliyKMXVaXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2384,7 +2308,6 @@
       "integrity": "sha512-GE/ZW5Rq82LgVbArppIG8Zkd6QFmCTGEV4Iq5V4KPOl5iSVu2yuYJCDD77aR1LgclSjk1YiJ1/oge94RXqAtOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2395,7 +2318,6 @@
       "integrity": "sha512-r3JmVGeGzCzUPEKdOzxunsoRO2q7zGoI5eUtrSXdLSFiR2klW+hti/fjvqvruqzRZRjB0oumbJfMU4IxHcZblw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2406,7 +2328,6 @@
       "integrity": "sha512-9qx3Qj8kmIyHRbcVNexWTs4eGjsxs9FkjP7czpC1P0CPJFIt8LzeB6gBwSS/nJGuIo06RQ42qOc8FOza2tN+jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2417,7 +2338,6 @@
       "integrity": "sha512-+ptIzEx8a3Oy4XL6TFibR5Q5lWDpjCSPCN2DgIitBj9C0R8zWbBo8sxj2iLGP4RsBiHeTUbDiJlSY1seo2E+Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2428,7 +2348,6 @@
       "integrity": "sha512-MRxTX8CDvquBkkEGfpPsX5ttnsPGJ+Kb1KfR+arueXazQ9XfqyoFCAWWXfOxGL7A5txGTMnKEfj59dyLeCec5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2439,7 +2358,6 @@
       "integrity": "sha512-4IO02sBoJLlErxXPeFBXTtOZzQeFbCf0flpHCjMZ+vWKZ6GarlUMSvbXjuzh5SBEveVxWYhjd7Z7lP+g2pOHGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-icon": "1.16.0",
@@ -2452,7 +2370,6 @@
       "integrity": "sha512-0yRbSOoKl5gSAnRIEXTdFYlrt4NSvuLx1+TuQyeE/CV8lfObGqM1+y+ueX0AgPuNTXAf7j5rPIRLsVJHfCs2MA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2464,7 +2381,6 @@
       "integrity": "sha512-ORBBH6GRq5VFTNZd++f7dXCLJdgEGhtd1rcdbxjqtYnJrKeJ0dBNhJkF3kLoSQ1MiOG1SHOckGUZr5nLMUhc/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2476,7 +2392,6 @@
       "integrity": "sha512-Z3m2toN+LcZOXVe/3q6d9kyPyWXR9l8CJSk1NkEn/ojMYrRzmo5AW92xWw/twHV8bRsEBDSeKxSKMVGnJVyUHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2488,7 +2403,6 @@
       "integrity": "sha512-v9m/e5krM1IPV1gI/9dqVKgGYthyWXDlq9lCdiigpTfzv7xkCF+LPEmVksDZaKD498gGYtbYJReCXUxCwjxGTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2500,7 +2414,6 @@
       "integrity": "sha512-6z/oa4qX+L746nEet0EDx88roSTcfjnzQj5fH2ebW4WJ6Arh/b+QmPOE3UEn2QiqjJLovkIhNcwf0m9PM7rSSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2512,7 +2425,6 @@
       "integrity": "sha512-TdYTh+1pZfOFD9dKBtti1oDF1Pk5Bp3PyNKf1JLtcPm8uD/UPDxRkIYV7It04E6P7VWusdRabdlv/q9PRimA5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-ref-node": "1.16.0"
@@ -2524,7 +2436,6 @@
       "integrity": "sha512-+ArdQO09sGB1t24rzi+rk3YsZZayZRr5aKny53qAKkklJg0IDCJ+Vme9DvuSk0HBEzCe0YF313lv5mYjxFwCzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2535,7 +2446,6 @@
       "integrity": "sha512-/tXty/HSqTAwnqsmLIsDc8LsE7XW0pZaCu+B/Ov3FjYQSb312AqXBwP7Z59gAbh2M0XvI3qxcA/sLcFndqN1oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2546,7 +2456,6 @@
       "integrity": "sha512-zWXe+SOzXbhO2tN+DnVXbefEWICZ+FHCR1EGldZdab3hQO53M4HOKqTBd1akE6iFli7FN4BOnELGjnMnupaqvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2557,7 +2466,6 @@
       "integrity": "sha512-w9i+deCNhZ3TzwgMx2glGbpyvXQHyP0kCmuazXi4cYGFtEXM48d1OScm/PrGs04ICNuqEIwY/IZ+PGfRSI27lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2568,7 +2476,6 @@
       "integrity": "sha512-8iyZCjVAFvKrz1m0RTPiZmbXYLyb0Gs2blgg/uPyBzpNvptnXgx29UVTzITu2xvqVvwvureFNcxqeYL5WsfCiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2579,7 +2486,6 @@
       "integrity": "sha512-d9VJQTEBKwTHrvgPAXLgG4m3quDbxg1EhJhE03cxZr/yrZ81I2TD3wd4Pt9uxL1kvpZ95mP2vDfbedUfm/0fww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2590,7 +2496,6 @@
       "integrity": "sha512-PMm3lTtIAwyE+6Erz2xiamKPuHhqazk2aWHgqC9fzD/0ROlWQMYEP3M99onp8/YCIprzfvXPuH6ofs6kq9bY7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2601,7 +2506,6 @@
       "integrity": "sha512-vATvt+AcfP9pZxh99DKaq/wrD60EN4nvdtZ/BpHH6MOhX32T8LEboh57XisHmGamUSGbm2jQhASJTt+7cvjI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2612,7 +2516,6 @@
       "integrity": "sha512-mAFnPdUzlddfdLMTkBetCTnShV3QTWMpjqaG5fCaauizWmReye/rCwDur51URL+VkWMIWp29JvfYIIm8Yk+ZGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2623,7 +2526,6 @@
       "integrity": "sha512-WBd/6SNLVP04WU0Em8Uc9/GXsKYpYdHzlEjh7w5oU1TfbDEiNq1lXkOlpuvL79wJtd/2fTKfqui02+i79KU7ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2634,7 +2536,6 @@
       "integrity": "sha512-hBhvUmkPc5WgFcjKDm6jtQq2USCO+ysveJRI1oJReiZkyj06IjU5mYddUL/sOG4L7Ud6OFqVbY002Uw+j9QpYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2645,7 +2546,6 @@
       "integrity": "sha512-cVq84cwbgOvjoTn+5L4eboXPGkYdcIkWm/oU8GxbR1OdUtgPtqnPwB51Ial6ylyIHqvYbCDmDMzrjjnrB/qfJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2656,7 +2556,6 @@
       "integrity": "sha512-FBToNg7zgB9paPQPbpnuC66KAMz3iR/F+tmLhjWnwGSit7ubFspPqgrReSjVS9zdd+zbi7wTJOcmKnHmoyP1bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -2670,7 +2569,6 @@
       "integrity": "sha512-u6pBhOEvXYvUNTxNO1Ftcnflii1CmeuvNAXxuIj8TMmTXGXWmap0W5cGmzlEbbLAMGLv56AJXdz3rKDrWNyTvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2681,7 +2579,6 @@
       "integrity": "sha512-xTO4i/m4Q7wEeaxmV1bxT5e1bnLRJ1CoG+awe2FKGq6xw2ZHgksSrm6j3Ddbm5WzV019hIeVl22bnVQ5gOwrww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2692,7 +2589,6 @@
       "integrity": "sha512-ziOJ4uyQpIVCBym2RlZFJOuOb2feNr1sP0RxUjhXToREJdG2MH2bgYyy76K0OCZ7a+JKCsHdaBH4XquXIH93VA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-button": "1.16.0",
@@ -2707,7 +2603,6 @@
       "integrity": "sha512-8HwiYkOA8Rsxpp2ZGsDTq16odV7Ja7xAAp/0BcdosdQYn6L4KUbSimulGaP/Q1KATUCFT7QflQiv0gnwuPpngQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-toast-notification": "1.16.0"
@@ -2719,7 +2614,6 @@
       "integrity": "sha512-OTrTAGUPe8EQRuCWJD8GsCw8MfNJuXx50NLZLDDZKzw3TlDiWMxUD0c4l6zOMy4ih7n7D5sMekHqonW5x6lVuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-css": "1.16.0"
@@ -2731,7 +2625,6 @@
       "integrity": "sha512-opFdwN0LlH6l1xlzEv+e9tvLgySXRr4Ug5LBlzNRJKC/WhinUSq/okerIVyUJgk4oKdZV/y7T7u/07LiekCTAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0",
         "@umbraco-ui/uui-boolean-input": "1.16.0"
@@ -2743,7 +2636,6 @@
       "integrity": "sha512-fqcv9gZUey2FkE2IRWuDgpk+D5XCdC1gnmQ4bIlAs03cMhl2BWP7U04Zo1u78jcWCbjxfnp60rfE6h11ukd5sg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.16.0"
       }
@@ -2754,7 +2646,6 @@
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -3015,8 +2906,7 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "13.0.0",
@@ -3057,8 +2947,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -3186,7 +3075,6 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3239,7 +3127,6 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3260,7 +3147,6 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3271,7 +3157,6 @@
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3340,7 +3225,6 @@
       "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
       "dev": true,
       "license": "Unlicense",
-      "peer": true,
       "dependencies": {
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
@@ -3664,7 +3548,6 @@
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -3674,8 +3557,7 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lit": {
       "version": "3.3.1",
@@ -3683,6 +3565,7 @@
       "integrity": "sha512-Ksr/8L3PTapbdXJCk+EJVB78jDodUMaP54gD24W186zGRARvwrsPfS60wae/SSCTCNZVPd1chXqio1qHQmu4NA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -3735,7 +3618,6 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -3767,8 +3649,7 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3836,7 +3717,6 @@
       "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.1.7",
         "marked": "14.0.0"
@@ -3847,8 +3727,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
       "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
       "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",
@@ -3856,7 +3735,6 @@
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4011,8 +3889,7 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4128,7 +4005,6 @@
       "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
       }
@@ -4139,7 +4015,6 @@
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -4150,7 +4025,6 @@
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -4163,7 +4037,6 @@
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -4176,7 +4049,6 @@
       "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -4190,7 +4062,6 @@
       "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -4204,7 +4075,6 @@
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -4216,7 +4086,6 @@
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -4228,7 +4097,6 @@
       "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
@@ -4241,7 +4109,6 @@
       "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "crelt": "^1.0.0",
         "prosemirror-commands": "^1.0.0",
@@ -4266,7 +4133,6 @@
       "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.0"
       }
@@ -4277,7 +4143,6 @@
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -4303,7 +4168,6 @@
       "integrity": "sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.25.0",
@@ -4318,7 +4182,6 @@
       "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
@@ -4335,7 +4198,6 @@
       "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
@@ -4359,7 +4221,6 @@
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -4373,7 +4234,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4384,7 +4244,6 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4394,8 +4253,7 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4448,8 +4306,7 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4603,6 +4460,7 @@
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4643,8 +4501,7 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -4712,8 +4569,7 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -4807,7 +4663,6 @@
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -4824,7 +4679,6 @@
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4834,16 +4688,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -4864,6 +4716,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4877,8 +4730,7 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -4910,7 +4762,6 @@
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -4937,6 +4788,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5261,8 +5113,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -5279,8 +5130,7 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -5288,7 +5138,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5307,7 +5156,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.0.1",
+  "version": "17.0.3",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",


### PR DESCRIPTION
Adds code, the will cause uSync to send out the reload requests for all the tree types in the settings section after a sync completes. 

this just means things like document types will appear once the sync has happened, and you won't have to press refresh to see them. 