### PR TITLE
Add explicity JsonConverters to all enums, so they are always serialized as strings

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
 
 namespace uSync.BackOffice.Configuration;
 
@@ -264,6 +265,7 @@ public class uSyncSettings
 /// <summary>
 ///  uSync's folder mode - normal, root or production
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<SyncFolderMode>))]
 public enum SyncFolderMode
 {
     /// <summary>
@@ -285,6 +287,7 @@ public enum SyncFolderMode
 /// <summary>
 ///  Mode is where the processing happens - normal or background  
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<SyncProcessingMode>))]
 public enum SyncProcessingMode
 {
     /// <summary>

--- a/uSync.BackOffice/SyncHandlers/Models/HandlerActionNames.cs
+++ b/uSync.BackOffice/SyncHandlers/Models/HandlerActionNames.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Text.Json.Serialization;
 
 namespace uSync.BackOffice.SyncHandlers.Models;
 
 /// <summary>
 ///  Possible actions a handler can do (stored in config)
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<HandlerActions>))]
 public enum HandlerActions
 {
     /// <summary>

--- a/uSync.Core/ChangeType.cs
+++ b/uSync.Core/ChangeType.cs
@@ -1,10 +1,12 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace uSync.Core;
 
 /// <summary>
 ///  Type of change performed
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<ChangeType>))]
 public enum ChangeType : int
 {
     [EnumMember(Value = "Clean")]

--- a/uSync.Core/Dependency/uSyncDependency.cs
+++ b/uSync.Core/Dependency/uSyncDependency.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core;
+﻿using System.Text.Json.Serialization;
+
+using Umbraco.Cms.Core;
 
 namespace uSync.Core.Dependency;
 
@@ -90,6 +92,7 @@ public class uSyncDependency
 /// <summary>
 ///  the match mode for the dependency (reserved)
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<DependencyMode>))]
 public enum DependencyMode
 {
     MustMatch,

--- a/uSync.Core/Models/uSyncChange.cs
+++ b/uSync.Core/Models/uSyncChange.cs
@@ -100,6 +100,7 @@ public class uSyncChange
         };
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<ChangeDetailType>))]
 public enum ChangeDetailType
 {
     NoChange,

--- a/uSync.Core/Sync/SyncTreeType.cs
+++ b/uSync.Core/Sync/SyncTreeType.cs
@@ -1,4 +1,6 @@
-﻿namespace uSync.Core.Sync;
+﻿using System.Text.Json.Serialization;
+
+namespace uSync.Core.Sync;
 
 /// <summary>
 ///  The type of tree item this is.
@@ -15,6 +17,7 @@
 ///  we can treat it as a 'settings' tree and show the 
 ///  menus when they are valid.
 /// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<SyncTreeType>))]
 public enum SyncTreeType
 {
     /// <summary>

--- a/uSync.Core/SyncActionType.cs
+++ b/uSync.Core/SyncActionType.cs
@@ -1,9 +1,12 @@
-﻿namespace uSync.Core;
+﻿using System.Text.Json.Serialization;
+
+namespace uSync.Core;
 
 /// <summary>
 ///  indicates what happened to an item to cause a ghost file 
 ///  to be present. 
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<SyncActionType>))]
 public enum SyncActionType
 {
     None = 0,

--- a/uSync.Core/Tracking/SyncXmlTracker.cs
+++ b/uSync.Core/Tracking/SyncXmlTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
@@ -414,6 +415,7 @@ public class TrackingKey
     public bool IsAttribute { get; set; }
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<TrackingDirection>))]
 public enum TrackingDirection
 {
     TargetToSource,

--- a/uSync.Core/uSyncContentState.cs
+++ b/uSync.Core/uSyncContentState.cs
@@ -1,8 +1,11 @@
-﻿namespace uSync.Core;
+﻿using System.Text.Json.Serialization;
+
+namespace uSync.Core;
 
 /// <summary>
 ///  the state we thing a culture / content item should be in.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<uSyncContentState>))]
 public enum uSyncContentState
 {
     Saved, Unpublished, Published


### PR DESCRIPTION
Not sure if this is the issue, but some reports that one of the enums in the ActionViews is returning to the user as a number not a string.

It's likely there is some global setting at play, but as with Newtonsoft, we can probibly overcome that by being explict with what to do with the enums.