### PR TITLE
A few IO improvements based on suggestions from AI prompts.

### DIFF
--- a/uSync.BackOffice/Services/ISyncActionService.cs
+++ b/uSync.BackOffice/Services/ISyncActionService.cs
@@ -68,5 +68,12 @@ public interface ISyncActionService
     /// <summary>
     ///  unpacks a zip archive (stream) to disk, checks it and copies it over the existing uSync folder. 
     /// </summary>
-    UploadImportResult UnpackImportFromStream(Stream stream);
+    [Obsolete("Use UnpackImportFromStreamAsync(Stream stream) will be removed in v19")]
+    UploadImportResult UnpackImportFromStream(Stream stream)
+        => UnpackImportFromStreamAsync(stream).GetAwaiter().GetResult();
+
+    /// <summary>
+    ///  unpacks a zip archive (stream) to disk, checks it and copies it over the existing uSync folder. 
+    /// </summary>
+    Task<UploadImportResult> UnpackImportFromStreamAsync(Stream stream);
 }

--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -200,5 +201,12 @@ public interface ISyncFileService
     /// <summary>
     ///  run some basic checks on a folder to see if it looks ok. 
     /// </summary>
-    List<string> VerifyFolder(string folder, string extension);
+    [Obsolete("Use VerifyFolderAsync instead will be removed in v19")]
+    List<string> VerifyFolder(string folder, string extension)
+        => VerifyFolderAsync(folder, extension).GetAwaiter().GetResult();
+
+    /// <summary>
+    ///  run some basic checks on a folder to see if it looks ok. 
+    /// </summary>
+    Task<List<string>> VerifyFolderAsync(string folder, string extension);
 }

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -231,7 +231,7 @@ internal class SyncActionService : ISyncActionService
         return _uSyncService.CompressFolder(_uSyncConfig.GetWorkingFolder());
     }
 
-    public UploadImportResult UnpackImportFromStream(Stream stream)
+    public async Task<UploadImportResult> UnpackImportFromStreamAsync(Stream stream)
     {
         var tempFolder = Path.Combine(_uSyncTempPath, Path.GetFileNameWithoutExtension(Path.GetRandomFileName())) 
             ?? $"{_uSyncTempPath}{Path.DirectorySeparatorChar}{Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) ?? Guid.NewGuid().ToString()}";
@@ -242,7 +242,7 @@ internal class SyncActionService : ISyncActionService
         {
             _uSyncService.DeCompressFile(stream, tempFolder);
 
-            var errors = _syncFileService.VerifyFolder(tempFolder,
+            var errors = await _syncFileService.VerifyFolderAsync(tempFolder,
                 _uSyncConfig.Settings.DefaultExtension);
 
             if (errors.Count > 0)

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -198,7 +198,7 @@ internal class SyncFileService : ISyncFileService
                 if (stream is null)
                     throw new FileNotFoundException($"Cannot create stream for {file}"); ;
 
-                using (var xmlReader = XmlReader.Create(stream, _readerSettings))
+                using (var xmlReader = XmlReader.Create(stream, _readerSettings.Clone()))
                 {
                     return await XElement.LoadAsync(xmlReader, LoadOptions.PreserveWhitespace, CancellationToken.None);    
                 }

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -348,7 +349,7 @@ internal class SyncFileService : ISyncFileService
     }
 
     /// <inheritdoc/>
-    public List<string> VerifyFolder(string folder, string extension)
+    public async Task<List<string>> VerifyFolderAsync(string folder, string extension)
     {
         var resolvedFolder = GetAbsPath(folder);
         if (!DirectoryExists(resolvedFolder))
@@ -371,7 +372,7 @@ internal class SyncFileService : ISyncFileService
         {
             try
             {
-                var node = LoadXElementAsync(file).Result;
+                var node = await LoadXElementAsync(file);
 
                 if (!node.IsEmptyItem())
                 {
@@ -489,29 +490,33 @@ internal class SyncFileService : ISyncFileService
     private static XElement MergeNodes(XElement source, XElement target, ISyncTrackerBase? trackerBase)
         => trackerBase is null ? target : trackerBase.MergeFiles(source, target) ?? target;
 
-    private async Task<IEnumerable<KeyValuePair<string, OrderedNodeInfo>>> GetFolderItemsAsync(string folder, string extension)
+    private async Task<IEnumerable<KeyValuePair<string, OrderedNodeInfo>>> GetFolderItemsAsync(
+        string folder, string extension)
     {
-        var items = new List<KeyValuePair<string, OrderedNodeInfo>>();
+        var filePaths = GetFilePaths(folder, extension);
+        var results = new ConcurrentBag<KeyValuePair<string, OrderedNodeInfo>>();
 
-        foreach (var file in GetFilePaths(folder, extension))
-        {
-            var element = await LoadXElementSafeAsync(file);
-            if (element != null)
+        await Parallel.ForEachAsync(
+            filePaths,
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+            async (file, _) =>
             {
-                var path = file.Substring(folder.Length);
+                var element = await LoadXElementSafeAsync(file);
+                if (element is not null)
+                {
+                    var path = file.Substring(folder.Length);
+                    results.Add(new KeyValuePair<string, OrderedNodeInfo>(
+                        key: path,
+                        value: new OrderedNodeInfo(
+                            filename: file,
+                            node: element,
+                            level: (element.GetLevel() * 1000) + element.GetItemSortOrder(),
+                            path: path,
+                            isRoot: true)));
+                }
+            });
 
-                items.Add(new KeyValuePair<string, OrderedNodeInfo>(
-                    key: path,
-                    value: new OrderedNodeInfo(
-                        filename: file,
-                        node: element,
-                        level: (element.GetLevel() * 1000) + element.GetItemSortOrder(),
-                        path: path,
-                        isRoot: true)));
-            }
-        }
-
-        return items;
+        return results;
     }
 
     /// <inheritdoc/>

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -74,7 +74,7 @@ public abstract class SyncHandlerBase<TObject>
         // be a little slower (not much though)
 
         // we cache this, (it is cleared on an ImportAll)
-        var keys = GetFolderKeys(folder, flat);
+        var keys = await GetFolderKeysAsync(folder, flat);
         if (keys.Count > 0)
         {
             // move parent to here, we only need to check it if there are files.

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -690,18 +690,20 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             logger.LogDebug("Getting Folder Keys : {cacheKey}", cacheKey);
 
         // when it's not flat structure we also get the sub folders. (extra defensive get them all)
-        var keys = new List<Guid>();
+        var keySet = new HashSet<Guid>();
         var files = syncFileService.GetFiles(folder, $"*.{this.uSyncConfig.Settings.DefaultExtension}", !flat);
 
         foreach (var file in files)
         {
             var node = await syncFileService.LoadXElementAsync(file);
             var key = node.GetKey();
-            if (key != Guid.Empty && !keys.Contains(key))
+            if (key != Guid.Empty)
             {
-                keys.Add(key);
+                keySet.Add(key);
             }
         }
+
+        var keys = keySet.ToList();
 
         if (logger.IsEnabled(LogLevel.Debug))
             logger.LogDebug("Loaded {count} keys from {folder} [{cacheKey}]", keys.Count, folder, cacheKey);

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1554,7 +1554,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         }
         catch (Exception ex)
         {
-            logger.LogWarning("Error while checking if should export deleted file: {message}", ex.Message);
+            logger.LogWarning(ex, "Error while checking if should export deleted file.");
             return true;
         }
     }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -617,7 +617,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         // be a little slower (not much though)
 
         // we cache this, (it is cleared on an ImportAll)
-        var keys = GetFolderKeys(folder, flat);
+        var keys = await GetFolderKeysAsync(folder, flat);
         if (keys.Count > 0)
         {
             // move parent to here, we only need to check it if there are files.
@@ -664,39 +664,50 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     ///  so we cache it, and if we are using the flat folder structure, then
     ///  we only do it once, so its quicker. 
     /// </remarks>
+    [Obsolete("Use GetFolderKeysAsync instead, will be removed in v19")]
     protected IList<Guid> GetFolderKeys(string folder, bool flat)
+        => GetFolderKeysAsync(folder, flat).GetAwaiter().GetResult();
+
+    /// <summary>
+    ///  Get the GUIDs for all items in a folder
+    /// </summary>
+    /// <remarks>
+    ///  This is disk intensive, (checking the .config files all the time)
+    ///  so we cache it, and if we are using the flat folder structure, then
+    ///  we only do it once, so its quicker. 
+    /// </remarks>
+    protected async Task<IList<Guid>> GetFolderKeysAsync(string folder, bool flat)
     {
         // We only need to load all the keys once per handler (if all items are in a folder that key will be used).
         var folderKey = folder.GetHashCode();
 
         var cacheKey = $"{GetCacheKeyBase()}_{folderKey}";
 
+        var cached = runtimeCache.GetCacheItem<IList<Guid>>(cacheKey);
+        if (cached is not null) return cached;
 
-        return runtimeCache.GetCacheItem(cacheKey, () =>
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug("Getting Folder Keys : {cacheKey}", cacheKey);
+
+        // when it's not flat structure we also get the sub folders. (extra defensive get them all)
+        var keys = new List<Guid>();
+        var files = syncFileService.GetFiles(folder, $"*.{this.uSyncConfig.Settings.DefaultExtension}", !flat);
+
+        foreach (var file in files)
         {
-            if (logger.IsEnabled(LogLevel.Debug))
-                logger.LogDebug("Getting Folder Keys : {cacheKey}", cacheKey);
-
-            // when it's not flat structure we also get the sub folders. (extra defensive get them all)
-            var keys = new List<Guid>();
-            var files = syncFileService.GetFiles(folder, $"*.{this.uSyncConfig.Settings.DefaultExtension}", !flat).ToList();
-
-            foreach (var file in files)
+            var node = await syncFileService.LoadXElementAsync(file);
+            var key = node.GetKey();
+            if (key != Guid.Empty && !keys.Contains(key))
             {
-                var node = syncFileService.LoadXElementAsync(file).Result;
-                var key = node.GetKey();
-                if (key != Guid.Empty && !keys.Contains(key))
-                {
-                    keys.Add(key);
-                }
+                keys.Add(key);
             }
+        }
 
-            if (logger.IsEnabled(LogLevel.Debug))
-                logger.LogDebug("Loaded {count} keys from {folder} [{cacheKey}]", keys.Count, folder, cacheKey);
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug("Loaded {count} keys from {folder} [{cacheKey}]", keys.Count, folder, cacheKey);
 
-            return keys;
-
-        }, null) ?? [];
+        runtimeCache.GetCacheItem(cacheKey, () => keys);
+        return keys;
     }
 
     /// <summary>
@@ -872,7 +883,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         return [uSyncAction.Fail(nameof(udi), this.handlerType, this.ItemType, ChangeType.Fail, $"Item not found {udi}",
              new KeyNotFoundException(nameof(udi)))];
-            
+
     }
 
     /// <summary>
@@ -1325,7 +1336,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         {
             return [uSyncActionHelper<TObject>
                 .ReportActionFail(Path.GetFileName(node.GetAlias()), $"format error {fex.Message}")];
-                
+
         }
     }
 
@@ -1501,17 +1512,16 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         if (item == null) return;
 
         var targetFolder = folders.Last();
-
         var filename = (await GetPathAsync(targetFolder, item, config.GuidNames, config.UseFlatStructure))
             .ToAppSafeFileName();
 
         if (IsLockedAtRoot(folders, filename.Substring(targetFolder.Length + 1)))
-        {
-            // don't do anything this thing exists at a higher level. ! 
             return;
-        }
 
-        if (await ShouldExportDeletedFileAsync(item, config) is false) return;
+        // Only perform the expensive full-serialize check if this handler
+        // actually overrides ShouldExportAsync (i.e. has filtering logic).
+        if (HandlerHasShouldExportOverride() && await ShouldExportDeletedFileAsync(item, config) is false)
+            return;
 
         var attempt = await serializer.SerializeEmptyAsync(item, SyncActionType.Delete, string.Empty);
         if (attempt.Item is not null && await ShouldExportAsync(attempt.Item, config) is true)
@@ -1520,16 +1530,19 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             {
                 await syncFileService.SaveXElementAsync(attempt.Item, filename);
 
-                // so check - it shouldn't (under normal operation) 
-                // be possible for a clash to exist at delete, because nothing else 
-                // will have changed (like name or location) 
-
-                // we only then do this if we are not using flat structure. 
                 if (!DefaultConfig.UseFlatStructure)
                     await this.CleanUpAsync(item, filename, Path.Combine(folders.Last(), this.DefaultFolder));
             }
         }
     }
+
+    // Cached reflection result — only computed once per handler type.
+    private bool? _hasShouldExportOverride;
+    private bool HandlerHasShouldExportOverride()
+        => _hasShouldExportOverride ??= GetType()
+            .GetMethod(nameof(ShouldExportAsync),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?.DeclaringType != typeof(SyncHandlerRoot<TObject, TContainer>);
 
     private async Task<bool> ShouldExportDeletedFileAsync(TObject item, HandlerSettings config)
     {
@@ -1541,7 +1554,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to calculate if this item should be exported when deleted, the common option is yes, so we will");
+            logger.LogWarning("Error while checking if should export deleted file: {message}", ex.Message);
             return true;
         }
     }
@@ -1608,7 +1621,6 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             await CleanUpAsync(item, newFile, children);
         }
     }
-
     #endregion
 
     // 98% of the time the serializer can do all these calls for us, 

--- a/uSync.Core/Serialization/SyncContainerSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncContainerSerializerBase.cs
@@ -194,18 +194,20 @@ public abstract class SyncContainerSerializerBase<TObject>
     {
         if (entityTypeContainerTypeService is null) return [];
 
-        var parent = await entityTypeContainerTypeService.GetParentAsync(item);
-        if (parent is null) return [];
+        if (_containersCache.TryGetValue(item.ParentId, out var cached) && cached is not null)
+            return cached;
 
-        var containers = new List<EntityContainer>() { parent };
+        var containers = new List<EntityContainer>();
+
+        var parent = await entityTypeContainerTypeService.GetParentAsync(item);
 
         while (parent is not null)
         {
+            containers.Add(parent);
             parent = await entityTypeContainerTypeService.GetParentAsync(parent);
-            if (parent is not null)
-                containers.Add(parent);
         }
 
+        _containersCache.TryAdd(item.ParentId, containers);
         return containers;
     }
 
@@ -302,9 +304,13 @@ public abstract class SyncContainerSerializerBase<TObject>
     ///  only used on serialization, allows us to only build the folder path for a set of containers once.
     /// </remarks>
     private ConcurrentDictionary<int, XElement> _folderCache = [];
+    private ConcurrentDictionary<int, List<EntityContainer>> _containersCache = [];
 
     private void ClearFolderCache()
-        => _folderCache = [];
+    {
+        _folderCache = [];
+        _containersCache = [];
+    }
 
     public void InitializeCache()
     {

--- a/uSync.Core/Serialization/SyncContainerSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncContainerSerializerBase.cs
@@ -305,7 +305,7 @@ public abstract class SyncContainerSerializerBase<TObject>
     ///  only used on serialization, allows us to only build the folder path for a set of containers once.
     /// </remarks>
     private ConcurrentDictionary<int, XElement> _folderCache = [];
-    private ConcurrentDictionary<int, List<EntityContainer>> _containersCache = [];
+    private ConcurrentDictionary<int, EntityContainer[]> _containersCache = [];
 
     private void ClearFolderCache()
     {

--- a/uSync.Core/Serialization/SyncContainerSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncContainerSerializerBase.cs
@@ -207,8 +207,9 @@ public abstract class SyncContainerSerializerBase<TObject>
             parent = await entityTypeContainerTypeService.GetParentAsync(parent);
         }
 
-        _containersCache.TryAdd(item.ParentId, containers);
-        return containers;
+        var containersArray = containers.ToArray();
+        _containersCache.TryAdd(item.ParentId, containersArray);
+        return containersArray;
     }
 
 


### PR DESCRIPTION
Based on the prompt "Analyse this code base for any performance improvements, ignore the minor improvements in things like string allocation and concentrate on any potential reduction in database calls or file IO that could be improved upon"

A few different IO things across mainly the root handler, file service, and serializer base. These either reduce some DB calls or some IO file reading, with reductions mainly on content types or datatypes.

## Changes Made

- **Cache container ancestry lookups** (`SyncContainerSerializerBase`): Caches container ancestry as an immutable `EntityContainer[]` to reduce repeated service calls and prevent accidental cache mutation.
- **Async folder key discovery** (`SyncHandlerRoot`): Made `GetFolderKeysAsync` fully async and replaced `List<Guid>` with `HashSet<Guid>` for O(1) deduplication, materializing to a list before caching.
- **Parallel folder item loading** (`SyncFileService`): Parallelizes folder item XML loading during merge using `Parallel.ForEachAsync`, with `XmlReaderSettings` cloned per call to ensure thread safety.
- **Async ZIP import verification** (`SyncFileService`): Made import ZIP verification async to avoid blocking.
- **Improved exception logging** (`SyncHandlerRoot`): Pass exception object to `LogWarning` to preserve stack trace and inner-exception details.

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
