### PR TITLE
Add single export method to service.

### DIFF
--- a/uSync.BackOffice/Services/ISyncService.cs
+++ b/uSync.BackOffice/Services/ISyncService.cs
@@ -170,5 +170,12 @@ public interface ISyncService
     ///  merge the given folders in single 'production' files for each handler.
     /// </summary>
     Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers);
+
+    /// <summary>
+    ///  export a single item to the specified folders using the supplied handler options.
+    /// </summary>
+    /// <param name="udi">The unique document identifier of the item to export.</param>
+    /// <param name="folders">The target folders to export the item into.</param>
+    /// <param name="options">The handler options to use during export.</param>
     Task<IEnumerable<uSyncAction>> ExportSingleItem(Udi udi, string[] folders, SyncHandlerOptions options);
 }

--- a/uSync.BackOffice/Services/ISyncService.cs
+++ b/uSync.BackOffice/Services/ISyncService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
+using Umbraco.Cms.Core;
+
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Models;
 using uSync.BackOffice.SyncHandlers.Interfaces;
@@ -168,4 +170,5 @@ public interface ISyncService
     ///  merge the given folders in single 'production' files for each handler.
     /// </summary>
     Task<int> MergeExportFolder(string[] paths, IEnumerable<HandlerConfigPair> handlers);
+    Task<IEnumerable<uSyncAction>> ExportSingleItem(Udi udi, string[] folders, SyncHandlerOptions options);
 }

--- a/uSync.BackOffice/Services/SyncService_Single.cs
+++ b/uSync.BackOffice/Services/SyncService_Single.cs
@@ -372,8 +372,7 @@ public partial class SyncService
     public async Task<IEnumerable<uSyncAction>> ExportSingleItem(Udi udi, string[] folders, SyncHandlerOptions options)
     {
         var handler = _handlerFactory.GetValidHandlerByEntityType(udi.EntityType, options);
-        if (handler == null) return [uSyncAction.Fail("Single", "Not Found", udi.EntityType, ChangeType.Fail, "Could not find handler", new KeyNotFoundException(udi.EntityType))];
-        
+        if (handler == null) return [uSyncAction.Fail("Single", "Unknown", udi.EntityType, ChangeType.Fail, $"Could not find handler for entity type '{udi.EntityType}'", new KeyNotFoundException(udi.EntityType))];
         return await handler.Handler.ExportAsync(udi, folders, handler.Settings);
     }
 }

--- a/uSync.BackOffice/Services/SyncService_Single.cs
+++ b/uSync.BackOffice/Services/SyncService_Single.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
+using Umbraco.Cms.Core;
 using Umbraco.Extensions;
 
 using uSync.BackOffice.Extensions;
@@ -360,4 +361,19 @@ public partial class SyncService
     /// </remarks>
     private static int CalculateProgress(int value, int total, int min, int max)
         => (int)(min + (((float)value / total) * (max - min)));
+
+
+    /// <summary>
+    ///  export a single item via the correct handler. 
+    /// </summary>
+    /// <remarks>
+    ///  this method isn't used directly in the code, but is here as a helper .
+    /// </remarks>
+    public async Task<IEnumerable<uSyncAction>> ExportSingleItem(Udi udi, string[] folders, SyncHandlerOptions options)
+    {
+        var handler = _handlerFactory.GetValidHandlerByEntityType(udi.EntityType, options);
+        if (handler == null) return [uSyncAction.Fail("Single", "Not Found", udi.EntityType, ChangeType.Fail, "Could not find handler", new KeyNotFoundException(udi.EntityType))];
+        
+        return await handler.Handler.ExportAsync(udi, folders, handler.Settings);
+    }
 }


### PR DESCRIPTION
Adds a `ExportSingleItem` method to the service so you can just export one thing if you want to. 

to used in the main export flow but here to provide a quick way to do it.

https://forum.umbraco.com/t/usync-api-for-a-single-item/7802/7