### PR TITLE
Fix: Cannot create templates during sync when running in production mode (Umbraco 17.3+)

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
@@ -23,6 +23,7 @@ using uSync.BackOffice.SyncHandlers.Interfaces;
 using uSync.BackOffice.SyncHandlers.Models;
 using uSync.Core;
 using uSync.Core.Serialization;
+using uSync.Core.Templates;
 
 using static Umbraco.Cms.Core.Constants;
 
@@ -42,7 +43,7 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
     INotificationAsyncHandler<MovingNotification<ITemplate>>
 {
     private readonly IFileSystem? _viewFileSystem;
-    private readonly ITemplateService _templateService;
+    private readonly ISyncTemplateService _templateService;
 
     private readonly ITemplateContentParserService _templateContentParserService;
 
@@ -51,7 +52,6 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
     public TemplateHandler(
         ILogger<TemplateHandler> logger,
         IEntityService entityService,
-        ITemplateService templateService,
         FileSystems fileSystems,
         ITemplateContentParserService templateContentParserService,
         AppCaches appCaches,
@@ -59,12 +59,13 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
         ISyncFileService syncFileService,
         ISyncEventService mutexService,
         ISyncConfigService uSyncConfig,
-        ISyncItemFactory syncItemFactory)
+        ISyncItemFactory syncItemFactory,
+        ISyncTemplateService syncTemplateService)
         : base(logger, entityService, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, syncItemFactory)
     {
-        _templateService = templateService;
         _viewFileSystem = fileSystems.MvcViewsFileSystem;
         _templateContentParserService = templateContentParserService;
+        _templateService = syncTemplateService;
     }
 
     /// <inheritdoc/>

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -14,6 +14,7 @@ using uSync.Core.Documents;
 using uSync.Core.Extensions;
 using uSync.Core.Mapping;
 using uSync.Core.Models;
+using uSync.Core.Templates;
 
 namespace uSync.Core.Serialization.Serializers;
 
@@ -23,7 +24,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
     protected readonly IContentService contentService;
     protected readonly IUserService userService;
 
-    protected readonly ITemplateService _templateService;
+    protected readonly ISyncTemplateService _templateService;
     protected readonly ISyncDocumentUrlCleaner? _urlCleaner;
 
     [Obsolete("Use the constructor with urlCleaner, will be removed in v19")]
@@ -36,8 +37,8 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         IContentService contentService,
         SyncValueMapperCollection syncMappers,
         IUserService userService,
-        ITemplateService templateService
-    ) : this(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, templateService, null)
+        ISyncTemplateService syncTemplateService
+    ) : this(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, syncTemplateService, null)
     { }
 
     public ContentSerializer(
@@ -49,7 +50,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         IContentService contentService,
         SyncValueMapperCollection syncMappers,
         IUserService userService,
-        ITemplateService templateService,
+        ISyncTemplateService syncTemplateService,
         ISyncDocumentUrlCleaner? urlCleaner)
         : base(entityService, languageService, relationService, shortStringHelper, logger, UmbracoObjectTypes.Document, syncMappers)
     {
@@ -57,7 +58,7 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
 
         this.relationAlias = Constants.Conventions.RelationTypes.RelateParentDocumentOnDeleteAlias;
         this.userService = userService;
-        _templateService = templateService;
+        _templateService = syncTemplateService;
         _urlCleaner = urlCleaner;
     }
 

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -12,6 +12,7 @@ using uSync.Core.Documents;
 using uSync.Core.Extensions;
 using uSync.Core.Mapping;
 using uSync.Core.Models;
+using uSync.Core.Templates;
 
 namespace uSync.Core.Serialization.Serializers;
 
@@ -30,7 +31,7 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
         IContentTypeService contentTypeService,
         SyncValueMapperCollection syncMappers,
         IUserService userService,
-        ITemplateService templateService,
+        ISyncTemplateService templateService,
         ISyncDocumentUrlCleaner urlCleaner)
         : base(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, templateService, urlCleaner)
     {

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -119,13 +119,6 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
             return SyncAttempt<ITemplate>.Succeed(name, item, ChangeType.Import, "Created", true, details);
         }
 
-        if (item is null)
-        {
-            // creating went wrong
-            logger.LogWarning("Failed to create template - item is null after create process.");
-            return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template - no new item created.");
-        }
-
         if (item.Key != key)
         {
             details.AddUpdate(uSyncConstants.Xml.Key, item.Key, key);

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -14,6 +14,7 @@ using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.Core.Models;
+using uSync.Core.Templates;
 using uSync.Core.Versions;
 
 namespace uSync.Core.Serialization.Serializers;
@@ -21,10 +22,9 @@ namespace uSync.Core.Serialization.Serializers;
 [SyncSerializer("D0E0769D-CCAE-47B4-AD34-4182C587B08A", "Template Serializer", uSyncConstants.Serialization.Template)]
 public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer<ITemplate>
 {
-    private readonly IShortStringHelper _shortStringHelper;
     private readonly IFileSystem? _viewFileSystem;
 
-    private readonly ITemplateService _templateService;
+    private readonly ISyncTemplateService _templateService;
     private readonly IUserIdKeyResolver _userIdKeyResolver;
 
     private readonly uSyncCapabilityChecker _capabilityChecker;
@@ -38,17 +38,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         FileSystems fileSystems,
         IConfiguration configuration,
         uSyncCapabilityChecker capabilityChecker,
-        ITemplateService templateService,
-        IUserIdKeyResolver userIdKeyResolver)
+        IUserIdKeyResolver userIdKeyResolver,
+        ISyncTemplateService syncTemplateService)
         : base(entityService, logger)
     {
-        _shortStringHelper = shortStringHelper;
-
         _viewFileSystem = fileSystems.MvcViewsFileSystem;
         _configuration = configuration;
         _capabilityChecker = capabilityChecker;
-        _templateService = templateService;
         _userIdKeyResolver = userIdKeyResolver;
+        _templateService = syncTemplateService;
     }
 
     protected override async Task<SyncAttempt<ITemplate>> ProcessDeleteAsync(Guid key, string alias, SerializerFlags flags)
@@ -103,7 +101,13 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 userKey, key);
 
             if (attempt.Success is false)
-                return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template");
+            {
+                logger.LogWarning("Failed to create template {alias} {name} - {error} - {status}",
+                    alias, name, attempt.Exception?.Message ?? "Unknown error", attempt.Status);
+                
+                return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, 
+                    $"Failed to create template {alias} {name} - {attempt.Exception?.Message ?? "Unknown error"} - {attempt.Status}");
+            }
 
             item = attempt.Result;
             details.AddNew(alias, alias, "Template");
@@ -118,8 +122,8 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         if (item is null)
         {
             // creating went wrong
-            logger.LogWarning("Failed to create template");
-            return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template");
+            logger.LogWarning("Failed to create template - item is null after create process.");
+            return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template - no new item created.");
         }
 
         if (item.Key != key)

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -10,7 +10,6 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.IO;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Strings;
 using Umbraco.Extensions;
 
 using uSync.Core.Models;
@@ -34,7 +33,6 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
     public TemplateSerializer(
         IEntityService entityService,
         ILogger<TemplateSerializer> logger,
-        IShortStringHelper shortStringHelper,
         FileSystems fileSystems,
         IConfiguration configuration,
         uSyncCapabilityChecker capabilityChecker,

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -1,6 +1,4 @@
-﻿using Lucene.Net.Queries.Function.ValueSources;
-
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/uSync.Core/Templates/ISyncTemplateService.cs
+++ b/uSync.Core/Templates/ISyncTemplateService.cs
@@ -1,0 +1,16 @@
+﻿using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services.OperationStatus;
+
+namespace uSync.Core.Templates;
+
+public interface ISyncTemplateService
+{
+    Task<Attempt<ITemplate, TemplateOperationStatus>> CreateAsync(string name, string alias, string? content, Guid userKey, Guid key);
+    Task DeleteAsync(string alias, Guid userKey);
+    Task<ITemplate?> GetAsync(string alias);
+    Task<ITemplate?> GetAsync(Guid key);
+    Task<ITemplate?> GetAsync(int id);
+    Task<IEnumerable<ITemplate>> GetChildrenAsync(int templateId);
+    Task<Attempt<ITemplate, TemplateOperationStatus>> UpdateAsync(ITemplate template, Guid userKey);
+}

--- a/uSync.Core/Templates/SyncTemplateService.cs
+++ b/uSync.Core/Templates/SyncTemplateService.cs
@@ -13,7 +13,7 @@ using uSync.Core.Versions;
 namespace uSync.Core.Templates;
 
 /// <summary>
-///  does creating of templates, espeically if we are in production mode. 
+///  handles creation of templates, especially when running in production mode.
 /// </summary>
 internal class SyncTemplateService : ISyncTemplateService
 {
@@ -34,29 +34,33 @@ internal class SyncTemplateService : ISyncTemplateService
     }
 
     /// <summary>
-    ///  creates a template, but only if we are in production mode. 
+    ///  creates a template, using the service when possible and falling back to the repository when in production mode.
     /// </summary>
-    /// <param name="name"></param>
-    /// <param name="alias"></param>
-    /// <param name="description"></param>
+    /// <param name="name">The display name of the template.</param>
+    /// <param name="alias">The alias of the template.</param>
+    /// <param name="content">The template content.</param>
+    /// <param name="userKey">The key of the user performing the operation.</param>
+    /// <param name="key">The key to assign to the new template.</param>
     /// <returns></returns>
     public async Task<Attempt<ITemplate, TemplateOperationStatus>> CreateAsync(string name, string alias, string? content, Guid userKey, Guid key)
     {
-        TemplateOperationStatus lastKnownStatus = TemplateOperationStatus.Success;
-
         if (IsInProductionMode() is false)
         {
             var attempt = await _templateService.CreateAsync(name, alias, content, userKey, key);
             if (attempt.Success)
                 return attempt;
+
+            // only fall back to the repository when blocked by production mode restrictions
+            if (attempt.Status is not TemplateOperationStatus.NotAllowedInProductionMode)
+                return attempt;
         }
 
-        // else - lets try the repository way (surely this is a hack?)
+        // in production mode (or blocked by it) - use the repository directly
         // https://github.com/umbraco/Umbraco-CMS/pull/21600#issuecomment-4205232583
-        return await CreateTemplateInternal(name, alias, content, userKey, key, lastKnownStatus);
+        return await CreateTemplateInternal(name, alias, content, userKey, key);
     }
 
-    private async Task<Attempt<ITemplate, TemplateOperationStatus>> CreateTemplateInternal(string name, string alias, string? content, Guid userKey, Guid key, TemplateOperationStatus lastKnownStatus) 
+    private Task<Attempt<ITemplate, TemplateOperationStatus>> CreateTemplateInternal(string name, string alias, string? content, Guid userKey, Guid key)
     {
         var template = new Template(_shortStringHelper, name, alias)
         {
@@ -66,17 +70,14 @@ internal class SyncTemplateService : ISyncTemplateService
 
         try
         {
-            using (var scope = _scopeProvider.CreateCoreScope(autoComplete: true))
-            {
-                _templateRepository.Save(template);
-                scope.Complete();
+            using var scope = _scopeProvider.CreateCoreScope(autoComplete: true);
+            _templateRepository.Save(template);
 
-                return Attempt.SucceedWithStatus<ITemplate, TemplateOperationStatus>(TemplateOperationStatus.Success, template);
-            }
+            return Task.FromResult(Attempt.SucceedWithStatus<ITemplate, TemplateOperationStatus>(TemplateOperationStatus.Success, template));
         }
         catch (Exception ex)
         {
-            return Attempt.FailWithStatus<ITemplate, TemplateOperationStatus>(lastKnownStatus, template, ex);
+            return Task.FromResult(Attempt.FailWithStatus<ITemplate, TemplateOperationStatus>(TemplateOperationStatus.NotAllowedInProductionMode, template, ex));
         }
     }
 

--- a/uSync.Core/Templates/SyncTemplateService.cs
+++ b/uSync.Core/Templates/SyncTemplateService.cs
@@ -34,7 +34,8 @@ internal class SyncTemplateService : ISyncTemplateService
     }
 
     /// <summary>
-    ///  creates a template, using the service when possible and falling back to the repository when in production mode.
+    ///  creates a template, using the service when possible and falling back to the repository
+    ///  when already in production mode or when the service returns <see cref="TemplateOperationStatus.NotAllowedInProductionMode"/>.
     /// </summary>
     /// <param name="name">The display name of the template.</param>
     /// <param name="alias">The alias of the template.</param>

--- a/uSync.Core/Templates/SyncTemplateService.cs
+++ b/uSync.Core/Templates/SyncTemplateService.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Extensions.Configuration;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Persistence.Repositories;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Core.Versions;
+
+namespace uSync.Core.Templates;
+
+/// <summary>
+///  does creating of templates, espeically if we are in production mode. 
+/// </summary>
+internal class SyncTemplateService : ISyncTemplateService
+{
+    private readonly ITemplateService _templateService;
+    private readonly IConfiguration _configuration;
+    private readonly ICoreScopeProvider _scopeProvider;
+
+    private readonly ITemplateRepository _templateRepository;
+    private readonly IShortStringHelper _shortStringHelper;
+
+    public SyncTemplateService(ITemplateService templateService, IConfiguration configuration, ICoreScopeProvider scopeProvider, ITemplateRepository templateRepository, IShortStringHelper shortStringHelper)
+    {
+        _templateService = templateService;
+        _configuration = configuration;
+        _scopeProvider = scopeProvider;
+        _templateRepository = templateRepository;
+        _shortStringHelper = shortStringHelper;
+    }
+
+    /// <summary>
+    ///  creates a template, but only if we are in production mode. 
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="alias"></param>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    public async Task<Attempt<ITemplate, TemplateOperationStatus>> CreateAsync(string name, string alias, string? content, Guid userKey, Guid key)
+    {
+        TemplateOperationStatus lastKnownStatus = TemplateOperationStatus.Success;
+
+        if (IsInProductionMode() is false)
+        {
+            var attempt = await _templateService.CreateAsync(name, alias, content, userKey, key);
+            if (attempt.Success)
+                return attempt;
+        }
+
+        // else - lets try the repository way (surely this is a hack?)
+        // https://github.com/umbraco/Umbraco-CMS/pull/21600#issuecomment-4205232583
+        return await CreateTemplateInternal(name, alias, content, userKey, key, lastKnownStatus);
+    }
+
+    private async Task<Attempt<ITemplate, TemplateOperationStatus>> CreateTemplateInternal(string name, string alias, string? content, Guid userKey, Guid key, TemplateOperationStatus lastKnownStatus) 
+    {
+        var template = new Template(_shortStringHelper, name, alias)
+        {
+            Content = content,
+            Key = key,
+        };
+
+        try
+        {
+            using (var scope = _scopeProvider.CreateCoreScope(autoComplete: true))
+            {
+                _templateRepository.Save(template);
+                scope.Complete();
+
+                return Attempt.SucceedWithStatus<ITemplate, TemplateOperationStatus>(TemplateOperationStatus.Success, template);
+            }
+        }
+        catch (Exception ex)
+        {
+            return Attempt.FailWithStatus<ITemplate, TemplateOperationStatus>(lastKnownStatus, template, ex);
+        }
+    }
+
+
+    public async Task<ITemplate?> GetAsync(Guid key)
+        => await _templateService.GetAsync(key);
+
+    public async Task<ITemplate?> GetAsync(string alias)
+        => await _templateService.GetAsync(alias);
+
+    public async Task<ITemplate?> GetAsync(int id)
+        => await _templateService.GetAsync(id);
+
+    public async Task<Attempt<ITemplate, TemplateOperationStatus>> UpdateAsync(ITemplate template, Guid userKey)
+        => await _templateService.UpdateAsync(template, userKey);
+
+    public async Task DeleteAsync(string alias, Guid userKey)
+        => await _templateService.DeleteAsync(alias, userKey);
+
+    public async Task<IEnumerable<ITemplate>> GetChildrenAsync(int templateId)
+        => await _templateService.GetChildrenAsync(templateId);
+
+    private bool IsInProductionMode()
+      => _configuration.IsUmbracoRunningInProductionMode();
+}

--- a/uSync.Core/uSyncCoreBuilderExtensions.cs
+++ b/uSync.Core/uSyncCoreBuilderExtensions.cs
@@ -11,6 +11,7 @@ using uSync.Core.Mapping;
 using uSync.Core.Mapping.Tracking;
 using uSync.Core.Roots.Configs;
 using uSync.Core.Serialization;
+using uSync.Core.Templates;
 using uSync.Core.Tracking;
 
 namespace uSync.Core;
@@ -40,6 +41,9 @@ public static class uSyncCoreBuilderExtensions
 
         // cache for entity items, we use it to speed up lookups.
         builder.Services.AddSingleton<SyncEntityCache>();
+
+        // templates have a wrapper service because we have to do work when in production mode
+        builder.Services.AddSingleton<ISyncTemplateService, SyncTemplateService>();
 
         // register *all* ConfigurationSerializers except those marked [HideFromTypeFinder]
         // has to happen before the DataTypeSerializer is loaded, because that is where


### PR DESCRIPTION
Addresses all outstanding review comments on the production-mode template creation workaround introduced in the previous commit.

## `SyncTemplateService`

- **`CreateAsync`**: Repository fallback now only triggers when already in production mode *or* when the service returns `NotAllowedInProductionMode`. Previously it fell through to the repo on any service failure, bypassing service-level validation and eventing for unrelated errors (e.g. duplicate alias).

```csharp
// Before: fell back to repo on ANY service failure
if (IsInProductionMode() is false)
{
    var attempt = await _templateService.CreateAsync(...);
    if (attempt.Success)
        return attempt;
    // fell through to repo even for DuplicateAlias, InvalidAlias, etc.
}

// After: only falls back for production-mode-specific rejection
if (IsInProductionMode() is false)
{
    var attempt = await _templateService.CreateAsync(...);
    if (attempt.Success) return attempt;
    if (attempt.Status is not TemplateOperationStatus.NotAllowedInProductionMode)
        return attempt;  // honour the service's rejection
}
```

- **`CreateTemplateInternal`**: Removed spurious `async` (no awaits present); returns `Task.FromResult(...)` directly. Template construction moved before the `try` so `template` is non-null in the catch. Removed redundant `scope.Complete()` — `autoComplete: true` with `using var` is sufficient. Failure status in catch is now `NotAllowedInProductionMode` instead of the misleading `Success`.

- **XML docs**: Fixed "espeically" typo, corrected class summary, replaced wrong `<param name="description">` with accurate param tags for all five parameters.

## `TemplateSerializer`

- Removed unused `IShortStringHelper shortStringHelper` constructor parameter and its `using` directive.
- Removed unreachable second `if (item is null)` block — the preceding creation branch always exits via `return` on both success and failure paths.