### PR TITLE
remove unused parameter on download, make it an admin feature.

### DIFF
--- a/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncPerformActionController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncPerformActionController.cs
@@ -1,5 +1,6 @@
 ﻿using Asp.Versioning;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
@@ -9,6 +10,7 @@ using System.Text;
 
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Web.Common.Authorization;
 
 using uSync.Backoffice.Management.Api.Models;
 using uSync.Backoffice.Management.Api.Services;
@@ -43,7 +45,8 @@ public class uSyncPerformActionController : uSyncControllerBase
 
     [HttpPost("Download")]
     [ProducesResponseType<FileContentResult>(StatusCodes.Status200OK)]
-    public ActionResult Download(string requestId)
+    [Authorize(Policy = AuthorizationPolicies.RequireAdminAccess)]
+    public ActionResult Download()
     {
         var filename = "uSync.zip";
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/api/types.gen.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/api/types.gen.ts
@@ -1048,9 +1048,7 @@ export type GetActionsBySetResponse = GetActionsBySetResponses[keyof GetActionsB
 export type DownloadData = {
     body?: never;
     path?: never;
-    query?: {
-        requestId?: string;
-    };
+    query?: never;
     url: '/umbraco/usync/api/v1/Download';
 };
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/repository/SyncAction.respositoy.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/repository/SyncAction.respositoy.ts
@@ -127,8 +127,8 @@ export class uSyncActionRepository extends UmbControllerBase {
 		return await this.#migrartionDataSource.copyLegacy();
 	}
 
-	async downloadFile(requestId: string) {
-		var result = await this.#actionDataSource.downloadFile(requestId);
+	async downloadFile() {
+		var result = await this.#actionDataSource.downloadFile();
 
 		console.log('Download result', result);
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/repository/sources/SyncAction.source.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/repository/sources/SyncAction.source.ts
@@ -49,15 +49,8 @@ export class uSyncActionDataSource implements SyncActionDataSource {
 		);
 	}
 
-	async downloadFile(requestId: string) {
-		return await tryExecute(
-			this.#host,
-			ActionsService.download({
-				query: {
-					requestId: requestId,
-				},
-			}),
-		);
+	async downloadFile() {
+		return await tryExecute(this.#host, ActionsService.download());
 	}
 
 	async processUpload(fileId: string) {

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/workspace.context.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/workspace.context.ts
@@ -274,7 +274,7 @@ export class uSyncWorkspaceContext
 		// post action
 		if (options.file && options.action === 'Export') {
 			// post export , open the dialog offer the download.
-			await this.downloadFile(id);
+			await this.downloadFile();
 		}
 
 		if (!this.#inBackground.getValue()) {
@@ -300,8 +300,8 @@ export class uSyncWorkspaceContext
 		return true;
 	}
 
-	async downloadFile(requestId: string) {
-		const response = await this.#repository.downloadFile(requestId);
+	async downloadFile() {
+		const response = await this.#repository.downloadFile();
 
 		if (!response) return;
 


### PR DESCRIPTION
- this removes the requestId from the download file as it was never used. 
- also to remove confusion we are making the download method admin only (previously you needed access to the uSync tree). 