### PR TITLE
Fix double-encoding of non-string JSON values in nested blocks and add SingleBlock mapper

### DIFF
--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -520,4 +520,15 @@ public static class JsonTextExtensions
 
     #endregion
 
+    #region Type Checks 
+
+    /// <summary>
+    ///  checks if the value is a non-string JSON value (array, object, number, boolean).
+    /// </summary>
+    public static bool IsNonStringJsonValue(this object? value)
+        => value is JsonElement { ValueKind: not JsonValueKind.String and not JsonValueKind.Undefined }
+           || value is JsonArray or JsonObject;
+
+    #endregion
+
 }

--- a/uSync.Core/Mapping/Mappers/SingleBlockMapper.cs
+++ b/uSync.Core/Mapping/Mappers/SingleBlockMapper.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Services;
+
+namespace uSync.Core.Mapping.Mappers;
+
+internal class SingleBlockMapper : SyncBlockMapperBase<SingleBlockValue>, ISyncMapper
+{
+    public override string Name => "NuBlock Single Block mapper";
+
+    public override string[] Editors => [Constants.PropertyEditors.Aliases.SingleBlock];
+
+    public SingleBlockMapper(
+        IEntityService entityService,
+        IContentTypeService contentTypeService,
+        Lazy<SyncValueMapperCollection> mapperCollection,
+        ILogger<SingleBlockMapper> logger)
+        : base(entityService, contentTypeService, mapperCollection, logger)
+    {
+    }
+}

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 
 using System.Collections;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 using Umbraco.Cms.Core;
@@ -61,8 +62,25 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
             _logger.LogDebug("Importing block value for {PropertyEditorAlias} {valueType}", propertyType.PropertyEditorAlias, value?.GetType().Name ?? "blank");
 
         var importString = SyncBlockMapperBase<TBlockValue>.GetStringValue(value) ?? string.Empty;
-        return await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
+        var result = await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
+
+        // When the original value was a non-string JSON type (array, object, number, etc.),
+        // convert string results back to JsonNode to preserve the correct JSON type
+        // and prevent double-encoding when the block value is re-serialized.
+        if (result is string stringResult && IsNonStringJsonValue(value))
+        {
+            return stringResult.ConvertToJsonNode() ?? result;
+        }
+
+        return result;
     }
+
+    /// <summary>
+    ///  checks if the value is a non-string JSON value (array, object, number, boolean).
+    /// </summary>
+    private static bool IsNonStringJsonValue(object? value)
+        => value is JsonElement { ValueKind: not JsonValueKind.String and not JsonValueKind.Undefined }
+           || value is JsonArray or JsonObject;
 
     private async Task<object?> GetExportProperty(object? value, IPropertyType? propertyType, SyncSerializerOptions options)
     {

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -67,20 +67,13 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
         // When the original value was a non-string JSON type (array, object, number, etc.),
         // convert string results back to JsonNode to preserve the correct JSON type
         // and prevent double-encoding when the block value is re-serialized.
-        if (result is string stringResult && IsNonStringJsonValue(value))
+        if (result is string stringResult && value.IsNonStringJsonValue())
         {
             return stringResult.ConvertToJsonNode() ?? result;
         }
 
         return result;
     }
-
-    /// <summary>
-    ///  checks if the value is a non-string JSON value (array, object, number, boolean).
-    /// </summary>
-    private static bool IsNonStringJsonValue(object? value)
-        => value is JsonElement { ValueKind: not JsonValueKind.String and not JsonValueKind.Undefined }
-           || value is JsonArray or JsonObject;
 
     private async Task<object?> GetExportProperty(object? value, IPropertyType? propertyType, SyncSerializerOptions options)
     {


### PR DESCRIPTION
## Fix: Double-encoding of non-string JSON values inside block properties during import + missing SingleBlock mapper

### Problem

When importing content that contains nested block structures (e.g. a BlockGrid with an area containing items that have SingleBlock properties with DropDown.Flexible fields), non-string JSON values get corrupted during import.

For example, a dropdown value `["Orange"]` (a JSON array) is correctly stored in the serialized XML, but after import it becomes the JSON string `"[\"Orange\"]"` (double-encoded). This causes `JsonReaderException` errors when rendering the page and shows invalid values in the backoffice.

### Root cause

`SyncBlockMapperBase<T>.GetImportProperty()` converts each block property value to a string via `GetStringValue()`, sends it through the mapper collection, and assigns the result back to `BlockPropertyValue.Value`. For editors without a dedicated mapper (e.g. `Umbraco.DropDown.Flexible`), the raw string is returned and assigned back. When the parent block is re-serialized via `SerializeJsonString()`, values that were originally JSON arrays/objects/numbers (but are now C# strings) get double-encoded.

The export side (`GetExportProperty`) already handles this correctly by converting the result back to a `JsonNode`:

```csharp
return result.ConvertToJsonNode()?.ExpandAllJsonInToken() ?? result;
```

But the import side was missing this conversion.

### Fix

1. **`SyncBlockMapperBase.GetImportProperty()`** — When the original `BlockPropertyValue.Value` was a non-string JSON type (`JsonElement` with `ValueKind` of Array, Object, Number, etc.), the string result is now converted back to a `JsonNode` before being assigned back. This preserves the correct JSON type and prevents double-encoding. String-type values are left unchanged to avoid altering their type.

2. **New `SingleBlockMapper`** — Added a mapper for `Umbraco.SingleBlock` (analogous to existing `BlockListMapper` and `BlockGridMapper`). Without this, properties inside SingleBlock editors were never recursively processed during import — UDIs in MultiUrlPickers, media references, etc. inside SingleBlock were not mapped, and the entire SingleBlock value was subject to the double-encoding issue.

### Affected scenarios

Any property editor without a dedicated ISyncMapper that stores non-string JSON values (arrays, objects, numbers) inside any block type (BlockGrid, BlockList, SingleBlock). The most visible case is `Umbraco.DropDown.Flexible` which stores values as `["SelectedValue"]`.

### How to reproduce

1. Create a page with a BlockGrid containing blocks that have a SingleBlock field
2. Inside the SingleBlock, add a block with a DropDown.Flexible property, select a value (e.g. "Orange")
3. Export via uSync
4. On a different instance (clean DB), import via uSync
5. The dropdown value is corrupted — page rendering fails with `JsonReaderException`