### PR TITLE
V17/image upload mapper

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,36 +1,36 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <!-- umbraco site -->
-  <ItemGroup>
-    <PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
-    <PackageVersion Include="Umbraco.Cms" Version="17.3.0" />
-    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.3.0" />
-    <PackageVersion Include="Clean.Core" Version="7.0.5" />
-  </ItemGroup>
-  <!-- umbraco libraries for packages -->
-  <ItemGroup>
-    <PackageVersion Include="Umbraco.Cms.Core" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Web.Website" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.0" />
-  </ItemGroup>
-  <!-- source link -->
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
-  </ItemGroup>
-  <!-- testing -->
-  <ItemGroup>
-    <PackageVersion Include="Umbraco.Cms.Tests" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Tests.Integration" Version="17.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-  </ItemGroup>
-  <!-- command line -->
-  <ItemGroup>
-    <PackageVersion Include="NJsonSchema" Version="11.5.2" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<!-- umbraco site -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms" Version="17.4.2" />
+		<PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.4.2" />
+		<PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
+		<PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+		<PackageVersion Include="Clean.Core" Version="7.0.5" />
+	</ItemGroup>
+	<!-- umbraco libraries for packages -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms.Core" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Web.Website" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.0" />
+	</ItemGroup>
+	<!-- source link -->
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+	</ItemGroup>
+	<!-- testing -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms.Tests" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Tests.Integration" Version="17.3.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+		<PackageVersion Include="coverlet.collector" Version="8.0.1" />
+	</ItemGroup>
+	<!-- command line -->
+	<ItemGroup>
+		<PackageVersion Include="NJsonSchema" Version="11.5.2" />
+		<PackageVersion Include="CommandLineParser" Version="2.9.1" />
+	</ItemGroup>
 </Project>

--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -137,7 +137,9 @@ public static class uSyncActionExtensions
     public static bool RequiresSave<TObject>(this SyncAttempt<TObject> attempt)
         => attempt.Success && attempt.Change > Core.ChangeType.NoChange && !attempt.Saved && attempt.Item != null;
 
-
+    /// <summary>
+    ///  return the uSyncAction as an ActionView (used in the controllers)
+    /// </summary>
     public static uSyncActionView AsActionView(this uSyncAction action)
     {
         var msg = string.IsNullOrWhiteSpace(action.Message) is false

--- a/uSync.BackOffice/Services/ISyncVersionFileService.cs
+++ b/uSync.BackOffice/Services/ISyncVersionFileService.cs
@@ -2,8 +2,20 @@
 
 namespace uSync.BackOffice.Services;
 
+/// <summary>
+///  Controls the version file we write to disk on syncs (used to warn if sync is old)
+/// </summary>
 public interface ISyncVersionFileService
 {
+    /// <summary>
+    ///  get the Sync file version information for a folder. 
+    /// </summary>
     Task<SyncFileVersionCheckResult> GetSyncFileInfo(string folder);
+
+    /// <summary>
+    ///  write the version information to disk. 
+    /// </summary>
+    /// <param name="folder"></param>
+    /// <returns></returns>
     Task WriteVersionFileAsync(string folder);
 }

--- a/uSync.BackOffice/Services/SyncVersionFileService.cs
+++ b/uSync.BackOffice/Services/SyncVersionFileService.cs
@@ -119,9 +119,23 @@ internal class SyncVersionFileService : ISyncVersionFileService
     }
 }
 
+/// <summary>
+///  results of a check of the version file 
+/// </summary>
 public class SyncFileVersionCheckResult
 {
+    /// <summary>
+    ///  the sync on disk is current to the current format we are writing. 
+    /// </summary>
     public bool IsCurrent { get; set; }
+
+    /// <summary>
+    ///  the version we are writing to disk
+    /// </summary>
     public string? FormatVersion { get; set; }
+
+    /// <summary>
+    ///  the hmac value for the folders matches. (reserved)
+    /// </summary>
     public bool HmacMatch { get; set; }
 }

--- a/uSync.BackOffice/uSyncBackOffice.cs
+++ b/uSync.BackOffice/uSyncBackOffice.cs
@@ -7,6 +7,9 @@ namespace uSync.BackOffice;
 /// </summary>
 public class uSync
 {
+    /// <summary>
+    ///  assembly version for uSync
+    /// </summary>
     public static Version Version => typeof(uSync).Assembly.GetName().Version ?? new Version(15, 0, 0);
 
     /// <summary>

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.2",
+	"version": "17.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.2",
+			"version": "17.3.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.2",
+	"version": "17.3.3",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -31,8 +31,8 @@ public class ImagePathMapper : ImagePathMapperBase, ISyncMapper
 
     public ImagePathMapper(
         IEntityService entityService,
-        IConfiguration configuration,
         ILogger<ImagePathMapper> logger,
+        IConfiguration configuration,
         IOptionsMonitor<GlobalSettings> globalOptions,
         IImageUrlGenerator imageUrlGenerator) : base(entityService, logger, configuration, globalOptions)
     {

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -49,6 +49,9 @@ public class ImagePathMapper : ImagePathMapperBase, ISyncMapper
     {
         return uSyncTaskHelper.FromResultOf(() =>
         {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Getting export value for ImageCropper with value {Value}", value);
+
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
 

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -2,8 +2,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-using System.Text.RegularExpressions;
-
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Media;
@@ -11,7 +9,6 @@ using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
-using uSync.Core.Dependency;
 using uSync.Core.Extensions;
 using uSync.Core.Serialization;
 
@@ -28,43 +25,24 @@ namespace uSync.Core.Mapping;
 /// becomes 
 /// {"src":"/media/2cud1lzo/15656993711_ccd199b83e_k.jpg","crops":null}
 /// </remarks>
-public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
+public class ImagePathMapper : ImagePathMapperBase, ISyncMapper
 {
-    private const string _genericMediaPath = "/media";
-
-    private readonly string _siteRoot;
-    private string? _mediaFolder;
-    private readonly ILogger<ImagePathMapper> _logger;
-    private readonly IConfiguration _configuration;
     private readonly IImageUrlGenerator _imageUrlGenerator;
 
     public ImagePathMapper(
-        IConfiguration configuration,
-        IOptionsMonitor<GlobalSettings> _globalOptions,
         IEntityService entityService,
+        IConfiguration configuration,
         ILogger<ImagePathMapper> logger,
-        IImageUrlGenerator imageUrlGenerator) : base(entityService)
+        IOptionsMonitor<GlobalSettings> globalOptions,
+        IImageUrlGenerator imageUrlGenerator) : base(entityService, logger, configuration, globalOptions)
     {
-        _logger = logger;
-        _configuration = configuration;
-
-        // todo: site root might need us to include extra NuGet.
-        _siteRoot = "";
-
-        _mediaFolder = GetMediaFolderSetting(_globalOptions.CurrentValue.UmbracoMediaPath.TrimStart('~'));
-        _globalOptions.OnChange(x => _mediaFolder = GetMediaFolderSetting(x.UmbracoMediaPath.TrimStart('~')));
-
-        if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Media Folders: [{media}]", _mediaFolder ?? "(Blank)");
-
         _imageUrlGenerator = imageUrlGenerator;
     }
 
     public override string Name => "ImageCropper Mapper";
 
     public override string[] Editors => [
-        Constants.PropertyEditors.Aliases.ImageCropper,
-        Constants.PropertyEditors.Aliases.UploadField
+        Constants.PropertyEditors.Aliases.ImageCropper
     ];
 
     public override Task<string?> GetExportValueAsync(object value, string editorAlias)
@@ -107,76 +85,6 @@ public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
         });
     }
 
-    private string StripSitePath(string filePath)
-    {
-        var path = filePath;
-        if (_siteRoot.Length > 0 && !string.IsNullOrWhiteSpace(filePath) && filePath.InvariantStartsWith(_siteRoot))
-            path = filePath.Substring(_siteRoot.Length);
-
-        return ReplacePath(path, _mediaFolder, _genericMediaPath);
-    }
-
-    private string PrePendSitePath(string filePath)
-    {
-        var path = filePath;
-        if (_siteRoot.Length > 0 && !string.IsNullOrEmpty(filePath))
-            path = $"{_siteRoot}{filePath}";
-
-        return ReplacePath(path, _genericMediaPath, _mediaFolder);
-    }
-
-
-    /// <summary>
-    ///  makes a specific media path generic. 
-    /// </summary>
-    /// <remarks>
-    ///  sometimes paths may be defined by umbraco settings, (especially blob settings)
-    ///  that mean they are not stored as /media 
-    ///  
-    ///  for the sake of generic importing we want the folder stored to be /media. 
-    ///  so we re-write the setting on import and export 
-    ///  
-    ///  assumes you have a app setting in the web.config 
-    ///  
-    ///     <add key="uSync.mediaFolder">/someFolder</add>
-    ///
-    /// </remarks>
-    /// <returns></returns>
-    private static string ReplacePath(string filePath, string? currentPath, string? targetPath)
-    {
-        if (!string.IsNullOrWhiteSpace(targetPath)
-            && !string.IsNullOrWhiteSpace(currentPath)
-            && !currentPath.Equals(targetPath))
-        {
-            return Regex.Replace(filePath, $"^{currentPath}", targetPath, RegexOptions.IgnoreCase);
-        }
-
-        return filePath;
-    }
-
-    /// <summary>
-    ///  Get the media rewrite folder 
-    /// </summary>
-    /// <remarks>
-    ///     looks in appSettings for uSync:mediaFolder 
-    ///     
-    ///  <add key="uSync.mediaFolder" value="/something" />
-    /// 
-    ///  or in uSync8.config for media setting 
-    ///  
-    ///  <backoffice>
-    ///     <media>
-    ///         <folder>/someFolder</folder>
-    ///     </media>
-    ///  </backoffice>
-    /// </remarks>
-    private string GetMediaFolderSetting(string umbracoMediaPath)
-    {
-        var folder = this._configuration.GetValue<string>("uSync:MediaFolder", string.Empty);
-        if (!string.IsNullOrEmpty(folder)) return folder;
-
-        return umbracoMediaPath;
-    }
 
     public override Task<string?> GetImportValueAsync(string value, string editorAlias, SyncSerializerOptions options)
     {
@@ -201,50 +109,5 @@ public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
 
             return json.SerializeJsonNode(true);
         });
-    }
-
-    /// <summary>
-    ///  Get the actual media file as a dependency. 
-    /// </summary>
-    public override Task<IEnumerable<uSyncDependency>> GetDependenciesAsync(object value, string editorAlias, DependencyFlags flags)
-    {
-        return uSyncTaskHelper.FromResultOf<IEnumerable<uSyncDependency>>(() =>
-        {
-
-            var stringValue = value?.ToString();
-            if (string.IsNullOrWhiteSpace(stringValue))
-                return [];
-
-            var stringPath = GetImagePath(stringValue).TrimStart('/').ToLower();
-
-            if (!string.IsNullOrWhiteSpace(stringPath))
-            {
-                return [new uSyncDependency()
-                {
-                    Name = $"File: {Path.GetFileName(stringPath)}",
-                    Udi = Udi.Create(Constants.UdiEntityType.MediaFile, stringPath),
-                    Flags = flags,
-                    Order = DependencyOrders.OrderFromEntityType(Constants.UdiEntityType.MediaFile),
-                    Level = 0
-                }];
-            }
-
-            return [];
-        });
-    }
-
-    private string GetImagePath(string stringValue)
-    {
-        if (stringValue.TryParseToJsonObject(out var json) is false || json is null)
-            return StripSitePath(stringValue);
-
-
-        if (json.TryGetPropertyValue("src", out var srcNode) is true)
-        {
-            var source = srcNode?.GetValue<string>() ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(source) is false) return source;
-        }
-
-        return string.Empty;
     }
 }

--- a/uSync.Core/Mapping/Mappers/ImagePathMapperBase.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapperBase.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using System.Text.RegularExpressions;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+using uSync.Core.Dependency;
+using uSync.Core.Extensions;
+
+namespace uSync.Core.Mapping;
+
+public abstract class ImagePathMapperBase : SyncValueMapperBase
+{
+    private readonly IConfiguration _configuration;
+    protected readonly ILogger<ImagePathMapperBase> _logger;
+
+    private const string _genericMediaPath = "/media";
+    private readonly string _siteRoot;
+    private string? _mediaFolder;
+
+    public ImagePathMapperBase(
+        IEntityService entityService,
+        ILogger<ImagePathMapperBase> logger,
+        IConfiguration configuration,
+        IOptionsMonitor<GlobalSettings> globalOptions
+    ) : base(entityService)
+    {
+        _configuration = configuration;
+        _logger = logger;
+
+        // todo: site root might need us to include extra NuGet.
+        _siteRoot = "";
+
+        _mediaFolder = GetMediaFolderSetting(globalOptions.CurrentValue.UmbracoMediaPath.TrimStart('~'));
+        globalOptions.OnChange(x => _mediaFolder = GetMediaFolderSetting(x.UmbracoMediaPath.TrimStart('~')));
+
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug("Media Folders: [{media}]", _mediaFolder ?? "(Blank)");
+
+    }
+
+
+    protected string StripSitePath(string filePath)
+    {
+        var path = filePath;
+        if (_siteRoot.Length > 0 && !string.IsNullOrWhiteSpace(filePath) && filePath.InvariantStartsWith(_siteRoot))
+            path = filePath.Substring(_siteRoot.Length);
+
+        return ReplacePath(path, _mediaFolder, _genericMediaPath);
+    }
+
+    protected string PrePendSitePath(string filePath)
+    {
+        var path = filePath;
+        if (_siteRoot.Length > 0 && !string.IsNullOrEmpty(filePath))
+            path = $"{_siteRoot}{filePath}";
+
+        return ReplacePath(path, _genericMediaPath, _mediaFolder);
+    }
+
+
+    /// <summary>
+    ///  makes a specific media path generic. 
+    /// </summary>
+    /// <remarks>
+    ///  sometimes paths may be defined by umbraco settings, (especially blob settings)
+    ///  that mean they are not stored as /media 
+    ///  
+    ///  for the sake of generic importing we want the folder stored to be /media. 
+    ///  so we re-write the setting on import and export 
+    ///  
+    ///  assumes you have a app setting in the web.config 
+    ///  
+    ///     <add key="uSync.mediaFolder">/someFolder</add>
+    ///
+    /// </remarks>
+    /// <returns></returns>
+    private static string ReplacePath(string filePath, string? currentPath, string? targetPath)
+    {
+        if (!string.IsNullOrWhiteSpace(targetPath)
+            && !string.IsNullOrWhiteSpace(currentPath)
+            && !currentPath.Equals(targetPath))
+        {
+            return Regex.Replace(filePath, $"^{currentPath}", targetPath, RegexOptions.IgnoreCase);
+        }
+
+        return filePath;
+    }
+
+    /// <summary>
+    ///  Get the media rewrite folder 
+    /// </summary>
+    /// <remarks>
+    ///     looks in appSettings for uSync:mediaFolder 
+    ///     
+    ///  <add key="uSync.mediaFolder" value="/something" />
+    /// 
+    ///  or in uSync8.config for media setting 
+    ///  
+    ///  <backoffice>
+    ///     <media>
+    ///         <folder>/someFolder</folder>
+    ///     </media>
+    ///  </backoffice>
+    /// </remarks>
+    private string GetMediaFolderSetting(string umbracoMediaPath)
+    {
+        var folder = this._configuration.GetValue<string>("uSync:MediaFolder", string.Empty);
+        if (!string.IsNullOrEmpty(folder)) return folder;
+
+        return umbracoMediaPath;
+    }
+
+    /// <summary>
+    ///  Get the actual media file as a dependency. 
+    /// </summary>
+    public override Task<IEnumerable<uSyncDependency>> GetDependenciesAsync(object value, string editorAlias, DependencyFlags flags)
+    {
+        return uSyncTaskHelper.FromResultOf<IEnumerable<uSyncDependency>>(() =>
+        {
+
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue))
+                return [];
+
+            var stringPath = GetImagePath(stringValue).TrimStart('/').ToLower();
+
+            if (!string.IsNullOrWhiteSpace(stringPath))
+            {
+                return [new uSyncDependency()
+                {
+                    Name = $"File: {Path.GetFileName(stringPath)}",
+                    Udi = Udi.Create(Constants.UdiEntityType.MediaFile, stringPath),
+                    Flags = flags,
+                    Order = DependencyOrders.OrderFromEntityType(Constants.UdiEntityType.MediaFile),
+                    Level = 0
+                }];
+            }
+
+            return [];
+        });
+    }
+
+    private string GetImagePath(string stringValue)
+    {
+        if (stringValue.TryParseToJsonObject(out var json) is false || json is null)
+            return StripSitePath(stringValue);
+
+
+        if (json.TryGetPropertyValue("src", out var srcNode) is true)
+        {
+            var source = srcNode?.GetValue<string>() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(source) is false) return source;
+        }
+
+        return string.Empty;
+    }
+}

--- a/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
@@ -30,6 +30,9 @@ public class ImageUploadMapper : ImagePathMapperBase, ISyncMapper
     {
         return uSyncTaskHelper.FromResultOf(() =>
         {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Getting export value for ImageUpload with value {Value}", value);
+
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
             return StripSitePath(stringValue);

--- a/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.Extensions;
+using uSync.Core.Serialization;
+
+namespace uSync.Core.Mapping;
+
+/// <summary>
+///  image uploads don't store any of the json, stuff, so they are similar to image croppers,
+///  but a bit simpler. 
+/// </summary>
+public class ImageUploadMapper : ImagePathMapperBase, ISyncMapper
+{
+    public ImageUploadMapper(
+        IEntityService entityService,
+        ILogger<ImagePathMapperBase> logger,
+        IConfiguration configuration,
+        IOptionsMonitor<GlobalSettings> globalOptions) : base(entityService, logger, configuration, globalOptions)
+    { }
+
+    public override string Name => "Image Upload Mapper";
+    public override string[] Editors => [Constants.PropertyEditors.Aliases.UploadField];
+    public override Task<string?> GetExportValueAsync(object value, string editorAlias)
+    {
+        return uSyncTaskHelper.FromResultOf(() =>
+        {
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
+            return StripSitePath(stringValue);
+        });
+    }
+
+    public override Task<string?> GetImportValueAsync(string value, string editorAlias, SyncSerializerOptions options)
+    {
+        return uSyncTaskHelper.FromResultOf(() =>
+        {
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
+            return PrePendSitePath(stringValue);
+        });
+    }
+}

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -69,7 +69,8 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
         // and prevent double-encoding when the block value is re-serialized.
         if (result is string stringResult && value.IsNonStringJsonValue())
         {
-            return stringResult.ConvertToJsonNode() ?? result;
+            return stringResult.ConvertStringToExpandedJson() ?? result;
+            // return stringResult.ConvertToJsonNode() ?? result;
         }
 
         return result;

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.2",
+  "version": "17.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.2",
+      "version": "17.3.3",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.95.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.2",
+  "version": "17.3.3",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.Tests/appsettings-schema.json
+++ b/uSync.Tests/appsettings-schema.json
@@ -6,11 +6,11 @@
       "description": "Settings for WebOptimizer.Core",
       "properties": {
         "enableCaching": {
-          "description": "Determines if the \"cache-control\" HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.",
+          "description": "Determines if the \u0022cache-control\u0022 HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.",
           "type": "boolean"
         },
         "enableTagHelperBundling": {
-          "description": "Determines if `<script>` and `<link>` elements should point to the bundled path or a reference per source file should be created. This is helpful to disable when in development mode.",
+          "description": "Determines if \u0060\u003Cscript\u003E\u0060 and \u0060\u003Clink\u003E\u0060 elements should point to the bundled path or a reference per source file should be created. This is helpful to disable when in development mode.",
           "type": "boolean",
           "default": true
         }
@@ -23,10 +23,10 @@
         "url": {
           "description": "An absolute URL used as a prefix for static resources",
           "type": "string",
-          "pattern": "^((//|https?://).+|)$"
+          "pattern": "^((//|https?://).\u002B|)$"
         },
         "prefetch": {
-          "description": "If true, injects a <link rel='dns-prefetch'> tag that speeds up DNS resolution to the CDN.",
+          "description": "If true, injects a \u003Clink rel=\u0027dns-prefetch\u0027\u003E tag that speeds up DNS resolution to the CDN.",
           "type": "boolean",
           "default": true
         }
@@ -142,12 +142,12 @@
           "type": "string"
         },
         "Store": {
-          "description": "The certificate store name. Defaults to 'My'.",
+          "description": "The certificate store name. Defaults to \u0027My\u0027.",
           "type": "string",
           "default": "My"
         },
         "Location": {
-          "description": "The certificate store location. Defaults to 'CurrentUser'.",
+          "description": "The certificate store location. Defaults to \u0027CurrentUser\u0027.",
           "type": "string",
           "enum": [
             "LocalMachine",
@@ -163,7 +163,7 @@
       }
     },
     "sslProtocols": {
-      "description": "Specifies allowable SSL protocols. Defaults to 'None' which allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this default. Available in .NET 5 and later.",
+      "description": "Specifies allowable SSL protocols. Defaults to \u0027None\u0027 which allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this default. Available in .NET 5 and later.",
       "type": "array",
       "items": {
         "type": "string",
@@ -178,7 +178,7 @@
       }
     },
     "clientCertificateMode": {
-      "description": "Specifies the client certificate requirements for a HTTPS connection. Defaults to 'NoCertificate'. Available in .NET 5 and later.",
+      "description": "Specifies the client certificate requirements for a HTTPS connection. Defaults to \u0027NoCertificate\u0027. Available in .NET 5 and later.",
       "type": "string",
       "enum": [
         "NoCertificate",
@@ -216,7 +216,7 @@
                 "$ref": "#/definitions/clientCertificateMode"
               },
               "Sni": {
-                "description": "Server Name Indication (SNI) configuration. This enables the mapping of client requested host names to certificates and other TLS settings. Wildcard names prefixed with '*.', as well as a top level '*' are supported. Available in .NET 5 and later.",
+                "description": "Server Name Indication (SNI) configuration. This enables the mapping of client requested host names to certificates and other TLS settings. Wildcard names prefixed with \u0027*.\u0027, as well as a top level \u0027*\u0027 are supported. Available in .NET 5 and later.",
                 "type": "object",
                 "additionalProperties": {
                   "description": "Endpoint SNI configuration.",
@@ -259,7 +259,7 @@
           }
         },
         "Certificates": {
-          "description": "Certificates that Kestrel uses with HTTPS endpoints. Each certificate has a name specified by its JSON property name. The 'Default' certificate is used by HTTPS endpoints that haven't specified a certificate.",
+          "description": "Certificates that Kestrel uses with HTTPS endpoints. Each certificate has a name specified by its JSON property name. The \u0027Default\u0027 certificate is used by HTTPS endpoints that haven\u0027t specified a certificate.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/certificate"
@@ -300,7 +300,7 @@
               "$ref": "#/definitions/logLevel"
             },
             "FormatterName": {
-              "description": "Name of the log message formatter to use. Defaults to 'simple'.",
+              "description": "Name of the log message formatter to use. Defaults to \u0027simple\u0027.",
               "type": "string",
               "default": "simple"
             },
@@ -368,7 +368,7 @@
       },
       "additionalProperties": {
         "type": "object",
-        "description": "Logging configuration for a provider. The provider name must match the configuration's JSON property property name.",
+        "description": "Logging configuration for a provider. The provider name must match the configuration\u0027s JSON property property name.",
         "properties": {
           "LogLevel": {
             "$ref": "#/definitions/logLevel"
@@ -377,7 +377,7 @@
       }
     },
     "allowedHosts": {
-      "description": "ASP.NET Core host filtering middleware configuration. Allowed hosts is a semicolon-delimited list of host names without port numbers. Requests without a matching host name will be refused. Host names may be prefixed with a '*.' wildcard, or use '*' to allow all hosts.",
+      "description": "ASP.NET Core host filtering middleware configuration. Allowed hosts is a semicolon-delimited list of host names without port numbers. Requests without a matching host name will be refused. Host names may be prefixed with a \u0027*.\u0027 wildcard, or use \u0027*\u0027 to allow all hosts.",
       "type": "string"
     },
     "connectionStrings": {
@@ -455,7 +455,7 @@
         },
         "autoShutdown": {
           "type": "boolean",
-          "description": "Automatically call `LogFactory.Shutdown` on AppDomain.Unload or AppDomain.ProcessExit",
+          "description": "Automatically call \u0060LogFactory.Shutdown\u0060 on AppDomain.Unload or AppDomain.ProcessExit",
           "default": "true"
         },
         "extensions": {
@@ -488,7 +488,7 @@
           "type": "object",
           "description": "Key-value pair of variables",
           "propertyNames": {
-            "pattern": "^[A-Za-z0-9_.-]+$"
+            "pattern": "^[A-Za-z0-9_.-]\u002B$"
           },
           "patternProperties": {
             ".*": {
@@ -538,7 +538,7 @@
             {
               "type": "object",
               "propertyNames": {
-                "pattern": "^[0-9]+$"
+                "pattern": "^[0-9]\u002B$"
               },
               "patternProperties": {
                 ".*": {
@@ -560,7 +560,7 @@
       "properties": {
         "logger": {
           "type": "string",
-          "description": "Match Logger objects based on their Logger-name. Can use wildcard characters ('*' or '?')."
+          "description": "Match Logger objects based on their Logger-name. Can use wildcard characters (\u0027*\u0027 or \u0027?\u0027)."
         },
         "ruleName": {
           "type": "string",
@@ -1165,7 +1165,7 @@
               "default": "1.00:00:00"
             },
             "NotificationMethods": {
-              "description": "A collection of health check notification methods that are set by their alias such as 'email'",
+              "description": "A collection of health check notification methods that are set by their alias such as \u0027email\u0027",
               "type": "object",
               "additionalProperties": {
                 "type": "object",
@@ -1188,7 +1188,7 @@
                     "default": false
                   },
                   "Settings": {
-                    "description": "An object of Health Check Notification provider specific settings. For the email notification it uses a setting 'RecipientEmail'",
+                    "description": "An object of Health Check Notification provider specific settings. For the email notification it uses a setting \u0027RecipientEmail\u0027",
                     "type": "object"
                   }
                 }
@@ -1298,7 +1298,7 @@
           }
         },
         "Plugins": {
-          "description": "An array of TinyMCE Plugins to load such as 'paste', 'table'",
+          "description": "An array of TinyMCE Plugins to load such as \u0027paste\u0027, \u0027table\u0027",
           "type": [
             "string"
           ]
@@ -1370,7 +1370,7 @@
       "properties": {
         "Char": {
           "type": "string",
-          "default": "ä"
+          "default": "\u00E4"
         },
         "Replacement": {
           "type": "string",
@@ -1425,7 +1425,7 @@
           "$ref": "#/definitions/umbracoMemberPassword"
         },
         "UsernameIsEmail": {
-          "description": "Indicating whether the user's email address is to be considered as their username",
+          "description": "Indicating whether the user\u0027s email address is to be considered as their username",
           "type": "boolean",
           "default": true
         },
@@ -1711,7 +1711,7 @@
       ]
     }
   },
-  "title": "JSON schema ASP.NET Core's appsettings.json file",
+  "title": "JSON schema ASP.NET Core\u0027s appsettings.json file",
   "type": "object",
   "allOf": [
     {

--- a/uSync.Tests/appsettings-schema.json
+++ b/uSync.Tests/appsettings-schema.json
@@ -6,11 +6,11 @@
       "description": "Settings for WebOptimizer.Core",
       "properties": {
         "enableCaching": {
-          "description": "Determines if the \u0022cache-control\u0022 HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.",
+          "description": "Determines if the \"cache-control\" HTTP headers should be set and if conditional GET (304) requests should be supported. This could be helpful to disable while in development mode.",
           "type": "boolean"
         },
         "enableTagHelperBundling": {
-          "description": "Determines if \u0060\u003Cscript\u003E\u0060 and \u0060\u003Clink\u003E\u0060 elements should point to the bundled path or a reference per source file should be created. This is helpful to disable when in development mode.",
+          "description": "Determines if `<script>` and `<link>` elements should point to the bundled path or a reference per source file should be created. This is helpful to disable when in development mode.",
           "type": "boolean",
           "default": true
         }
@@ -23,10 +23,10 @@
         "url": {
           "description": "An absolute URL used as a prefix for static resources",
           "type": "string",
-          "pattern": "^((//|https?://).\u002B|)$"
+          "pattern": "^((//|https?://).+|)$"
         },
         "prefetch": {
-          "description": "If true, injects a \u003Clink rel=\u0027dns-prefetch\u0027\u003E tag that speeds up DNS resolution to the CDN.",
+          "description": "If true, injects a <link rel='dns-prefetch'> tag that speeds up DNS resolution to the CDN.",
           "type": "boolean",
           "default": true
         }
@@ -142,12 +142,12 @@
           "type": "string"
         },
         "Store": {
-          "description": "The certificate store name. Defaults to \u0027My\u0027.",
+          "description": "The certificate store name. Defaults to 'My'.",
           "type": "string",
           "default": "My"
         },
         "Location": {
-          "description": "The certificate store location. Defaults to \u0027CurrentUser\u0027.",
+          "description": "The certificate store location. Defaults to 'CurrentUser'.",
           "type": "string",
           "enum": [
             "LocalMachine",
@@ -163,7 +163,7 @@
       }
     },
     "sslProtocols": {
-      "description": "Specifies allowable SSL protocols. Defaults to \u0027None\u0027 which allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this default. Available in .NET 5 and later.",
+      "description": "Specifies allowable SSL protocols. Defaults to 'None' which allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this default. Available in .NET 5 and later.",
       "type": "array",
       "items": {
         "type": "string",
@@ -178,7 +178,7 @@
       }
     },
     "clientCertificateMode": {
-      "description": "Specifies the client certificate requirements for a HTTPS connection. Defaults to \u0027NoCertificate\u0027. Available in .NET 5 and later.",
+      "description": "Specifies the client certificate requirements for a HTTPS connection. Defaults to 'NoCertificate'. Available in .NET 5 and later.",
       "type": "string",
       "enum": [
         "NoCertificate",
@@ -216,7 +216,7 @@
                 "$ref": "#/definitions/clientCertificateMode"
               },
               "Sni": {
-                "description": "Server Name Indication (SNI) configuration. This enables the mapping of client requested host names to certificates and other TLS settings. Wildcard names prefixed with \u0027*.\u0027, as well as a top level \u0027*\u0027 are supported. Available in .NET 5 and later.",
+                "description": "Server Name Indication (SNI) configuration. This enables the mapping of client requested host names to certificates and other TLS settings. Wildcard names prefixed with '*.', as well as a top level '*' are supported. Available in .NET 5 and later.",
                 "type": "object",
                 "additionalProperties": {
                   "description": "Endpoint SNI configuration.",
@@ -259,7 +259,7 @@
           }
         },
         "Certificates": {
-          "description": "Certificates that Kestrel uses with HTTPS endpoints. Each certificate has a name specified by its JSON property name. The \u0027Default\u0027 certificate is used by HTTPS endpoints that haven\u0027t specified a certificate.",
+          "description": "Certificates that Kestrel uses with HTTPS endpoints. Each certificate has a name specified by its JSON property name. The 'Default' certificate is used by HTTPS endpoints that haven't specified a certificate.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/certificate"
@@ -300,7 +300,7 @@
               "$ref": "#/definitions/logLevel"
             },
             "FormatterName": {
-              "description": "Name of the log message formatter to use. Defaults to \u0027simple\u0027.",
+              "description": "Name of the log message formatter to use. Defaults to 'simple'.",
               "type": "string",
               "default": "simple"
             },
@@ -368,7 +368,7 @@
       },
       "additionalProperties": {
         "type": "object",
-        "description": "Logging configuration for a provider. The provider name must match the configuration\u0027s JSON property property name.",
+        "description": "Logging configuration for a provider. The provider name must match the configuration's JSON property property name.",
         "properties": {
           "LogLevel": {
             "$ref": "#/definitions/logLevel"
@@ -377,7 +377,7 @@
       }
     },
     "allowedHosts": {
-      "description": "ASP.NET Core host filtering middleware configuration. Allowed hosts is a semicolon-delimited list of host names without port numbers. Requests without a matching host name will be refused. Host names may be prefixed with a \u0027*.\u0027 wildcard, or use \u0027*\u0027 to allow all hosts.",
+      "description": "ASP.NET Core host filtering middleware configuration. Allowed hosts is a semicolon-delimited list of host names without port numbers. Requests without a matching host name will be refused. Host names may be prefixed with a '*.' wildcard, or use '*' to allow all hosts.",
       "type": "string"
     },
     "connectionStrings": {
@@ -455,7 +455,7 @@
         },
         "autoShutdown": {
           "type": "boolean",
-          "description": "Automatically call \u0060LogFactory.Shutdown\u0060 on AppDomain.Unload or AppDomain.ProcessExit",
+          "description": "Automatically call `LogFactory.Shutdown` on AppDomain.Unload or AppDomain.ProcessExit",
           "default": "true"
         },
         "extensions": {
@@ -488,7 +488,7 @@
           "type": "object",
           "description": "Key-value pair of variables",
           "propertyNames": {
-            "pattern": "^[A-Za-z0-9_.-]\u002B$"
+            "pattern": "^[A-Za-z0-9_.-]+$"
           },
           "patternProperties": {
             ".*": {
@@ -538,7 +538,7 @@
             {
               "type": "object",
               "propertyNames": {
-                "pattern": "^[0-9]\u002B$"
+                "pattern": "^[0-9]+$"
               },
               "patternProperties": {
                 ".*": {
@@ -560,7 +560,7 @@
       "properties": {
         "logger": {
           "type": "string",
-          "description": "Match Logger objects based on their Logger-name. Can use wildcard characters (\u0027*\u0027 or \u0027?\u0027)."
+          "description": "Match Logger objects based on their Logger-name. Can use wildcard characters ('*' or '?')."
         },
         "ruleName": {
           "type": "string",
@@ -1165,7 +1165,7 @@
               "default": "1.00:00:00"
             },
             "NotificationMethods": {
-              "description": "A collection of health check notification methods that are set by their alias such as \u0027email\u0027",
+              "description": "A collection of health check notification methods that are set by their alias such as 'email'",
               "type": "object",
               "additionalProperties": {
                 "type": "object",
@@ -1188,7 +1188,7 @@
                     "default": false
                   },
                   "Settings": {
-                    "description": "An object of Health Check Notification provider specific settings. For the email notification it uses a setting \u0027RecipientEmail\u0027",
+                    "description": "An object of Health Check Notification provider specific settings. For the email notification it uses a setting 'RecipientEmail'",
                     "type": "object"
                   }
                 }
@@ -1298,7 +1298,7 @@
           }
         },
         "Plugins": {
-          "description": "An array of TinyMCE Plugins to load such as \u0027paste\u0027, \u0027table\u0027",
+          "description": "An array of TinyMCE Plugins to load such as 'paste', 'table'",
           "type": [
             "string"
           ]
@@ -1370,7 +1370,7 @@
       "properties": {
         "Char": {
           "type": "string",
-          "default": "\u00E4"
+          "default": "ä"
         },
         "Replacement": {
           "type": "string",
@@ -1425,7 +1425,7 @@
           "$ref": "#/definitions/umbracoMemberPassword"
         },
         "UsernameIsEmail": {
-          "description": "Indicating whether the user\u0027s email address is to be considered as their username",
+          "description": "Indicating whether the user's email address is to be considered as their username",
           "type": "boolean",
           "default": true
         },
@@ -1711,7 +1711,7 @@
       ]
     }
   },
-  "title": "JSON schema ASP.NET Core\u0027s appsettings.json file",
+  "title": "JSON schema ASP.NET Core's appsettings.json file",
   "type": "object",
   "allOf": [
     {

--- a/uSync.Tests/packages.lock.json
+++ b/uSync.Tests/packages.lock.json
@@ -2617,7 +2617,7 @@
       "Umbraco.Cms": {
         "type": "CentralTransitive",
         "requested": "[17.4.2, )",
-        "resolved": "17.4.2",
+        "resolved": "17.3.0",
         "contentHash": "yaG/li5/5RT7354r6rloErE96HojsDEHyYE+iVxcb+ySCLn2PF424qVSXEYq5ZXAbN4Zbx2/6oytTA4HX5w2rg==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",

--- a/uSync.Tests/packages.lock.json
+++ b/uSync.Tests/packages.lock.json
@@ -2616,7 +2616,7 @@
       },
       "Umbraco.Cms": {
         "type": "CentralTransitive",
-        "requested": "[17.3.0, )",
+        "requested": "[17.4.2, )",
         "resolved": "17.3.0",
         "contentHash": "yaG/li5/5RT7354r6rloErE96HojsDEHyYE+iVxcb+ySCLn2PF424qVSXEYq5ZXAbN4Zbx2/6oytTA4HX5w2rg==",
         "dependencies": {

--- a/uSync.Tests/packages.lock.json
+++ b/uSync.Tests/packages.lock.json
@@ -2617,7 +2617,7 @@
       "Umbraco.Cms": {
         "type": "CentralTransitive",
         "requested": "[17.4.2, )",
-        "resolved": "17.3.0",
+        "resolved": "17.4.2",
         "contentHash": "yaG/li5/5RT7354r6rloErE96HojsDEHyYE+iVxcb+ySCLn2PF424qVSXEYq5ZXAbN4Zbx2/6oytTA4HX5w2rg==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",


### PR DESCRIPTION
Splits the imageCropper and ImageUploadMapper into two different mappers. 

- previously we handled these two controls as one, because the image cropper could contain the same structure (a simple string) as the image upload. 
- but in reality the image cropper should be a JSON string, and the upload is just a string.
- #812 fixed cropper inconsistencies (turned the string into JSON) but this causes problems for the image upload. 
- rather than code a condition we have separated the mappers and given them a shared base, 
- this resolved the issue now and keeps the code clean