### PR TITLE
V17/block encoding

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
 		<PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.4.2" />
 		<PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
 		<PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+		<PackageVersion Include="Clean" Version="7.0.5" />
 		<PackageVersion Include="Clean.Core" Version="7.0.5" />
 	</ItemGroup>
 	<!-- umbraco libraries for packages -->

--- a/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
+++ b/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -23,7 +24,6 @@ public class SyncFolderIntegrityChecks : HealthCheck
     private readonly ISyncConfigService? _configService;
     private readonly ISyncFileService? _fileService;
 
-
     public SyncFolderIntegrityChecks() { }
 
     /// <summary>
@@ -44,17 +44,8 @@ public class SyncFolderIntegrityChecks : HealthCheck
     /// <inheritdoc/>
     public override Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
     {
-        if (_configService is null || _fileService is null)
-        {
-            return Task.FromResult((IEnumerable<HealthCheckStatus>)new List<HealthCheckStatus>
-            {
-                new HealthCheckStatus("uSync services not available")
-                {
-                    Description = "The uSync services are not available, this likely means the site has no backoffice loaded.",
-                    ResultType = StatusResultType.Info
-                }
-            });
-        }
+        if (_configService is null || _fileService is null) 
+            return Task.FromResult(Enumerable.Empty<HealthCheckStatus>());
 
         var items = new List<HealthCheckStatus>
         {
@@ -67,6 +58,9 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private HealthCheckStatus CheckuSyncFolder()
     {
+        if (_configService is null || _fileService is null)
+            return new HealthCheckStatus("Unable to check uSync folder integrity");
+
         var root = _fileService.GetAbsPath(_configService.GetWorkingFolder());
 
         if (_fileService.DirectoryExists(root) is false)
@@ -100,6 +94,8 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private List<string> CheckFolder(string folder)
     {
+        if (_fileService is null) return [];
+
         var _keys = new Dictionary<Guid, string>();
 
         var clashes = new List<string>();
@@ -143,6 +139,9 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private HealthCheckStatus CheckConfigFolderValidity()
     {
+        if (_configService is null || _fileService is null)
+            return new HealthCheckStatus("Unable to check uSync folder integrity");
+
         var root = _fileService.GetAbsPath(_configService.GetWorkingFolder());
 
         if (_fileService.DirectoryExists(root) is false)

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.3",
+	"version": "17.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.3",
+			"version": "17.3.4",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.3",
+	"version": "17.3.4",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -62,18 +62,11 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
             _logger.LogDebug("Importing block value for {PropertyEditorAlias} {valueType}", propertyType.PropertyEditorAlias, value?.GetType().Name ?? "blank");
 
         var importString = SyncBlockMapperBase<TBlockValue>.GetStringValue(value) ?? string.Empty;
-        var result = await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
 
-        // When the original value was a non-string JSON type (array, object, number, etc.),
-        // convert string results back to JsonNode to preserve the correct JSON type
-        // and prevent double-encoding when the block value is re-serialized.
-        if (result is string stringResult && value.IsNonStringJsonValue())
-        {
-            return stringResult.ConvertStringToExpandedJson() ?? result;
-            // return stringResult.ConvertToJsonNode() ?? result;
-        }
-
-        return result;
+        // revert this back to the old way - we don't expand the json we get back because umbraco is very 
+        // sensitve to what the exact format of the blocks is, and if we expand them, then calls during render
+        // can return null. 
+        return await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
     }
 
     private async Task<object?> GetExportProperty(object? value, IPropertyType? propertyType, SyncSerializerOptions options)

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.3",
+      "version": "17.3.4",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.95.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",


### PR DESCRIPTION
Reverts the encoding change in the #955.

Umbraco is sensitive to how blocks are encoded on the frond end. (so while the backend loads the json when its saved as a json blob, some of the front end stuff still wants it to be encoded). so we shouldn't do this,

We knew this, and really its our own fault for not double checking all possible outcomes when we accepted the PR.

(the single block stuff is still there and supported)