### PR TITLE
Add localization fallback defaults and translate UI into 5 languages

### DIFF
--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-action-box.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-action-box.ts
@@ -63,7 +63,7 @@ export class uSyncActionBox extends UmbLitElement {
 			<uui-box class="action-box ${this.disabled ? 'disabled' : ''}">
 				<div class="box-content">
 					<h2 class="box-heading" title=${this.getLastSyncDate()}>
-						${this.group?.groupName}
+						${this.localize.termOrDefault(`uSync_group${this.group?.groupName}`, this.group?.groupName ?? '')}
 					</h2>
 					<umb-icon name=${this.group?.icon}></umb-icon>
 					<div class="box-buttons">${dropdownButtons}</div>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-progress-box.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-progress-box.ts
@@ -63,6 +63,14 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 		}, 2000);
 	}
 
+	#camelize(str: string) {
+		return str
+			.replace(/(?:^\w|[A-Z]|\b\w)/g, function (word: string, index: number) {
+				return index === 0 ? word.toLowerCase() : word.toUpperCase();
+			})
+			.replace(/\s+/g, '');
+	}
+
 	render() {
 		let actions = this.actions;
 		if (!this.actions || this.actions.length === 0) {
@@ -79,6 +87,8 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 		let actionHtml = actions?.map((action) => {
 			if (action.status == HandlerStatus.COMPLETE) progress++;
 
+			const actionName = this.#camelize(action.name ?? 'unknown');
+
 			return html`
 				<div
 					class="action 
@@ -88,7 +98,7 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 						<uui-icon .name=${action.icon ?? 'icon-box'}></uui-icon>
 						${this.renderBadge(action)}
 					</div>
-					<h4>${action.name ?? 'unknown'}</h4>
+					<h4>${this.localize.termOrDefault(`treeHeaders_${actionName}`, actionName)}</h4>
 				</div>
 			`;
 		});
@@ -107,7 +117,7 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 
 		return html`
 			<uui-box>
-				<h2>${this.title}</h2>
+				<h2>${this.localize.termOrDefault(`uSync_group${this.title}`, this.title)}</h2>
 				<div class="action-list">${actionHtml}</div>
 				<div class="update-box">${this.updateMsg?.message}</div>
 				<uui-progress-bar

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
@@ -42,7 +42,7 @@ export class uSyncResultGroupView extends UmbLitElement {
 				<div
 					class="summary ${when(this.expanded, () => 'expanded')}"
 					@click=${() => (this.expanded = !this.expanded)}>
-					<h4>${this.localize.term('uSync_' + this.groupName)}</h4>
+					<h4>${this.localize.termOrDefault('uSync_' + this.groupName, this.groupName)}</h4>
 					<div class="summary-right">
 						<h4 class="count">${changeCount}/${this.results?.length}</h4>
 						<uui-icon

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-view.ts
@@ -117,7 +117,7 @@ export class uSyncResultsView extends UmbElementMixin(LitElement) {
 
 		return html`<div class="result-header">
 			<uui-toggle
-				.label=${this.localize.term('uSync_showAll')}
+				.label=${this.localize.termOrDefault('uSync_showAll', 'Show all items')}
 				?checked=${this.showAll}
 				@change=${this.#toggleShowAll}></uui-toggle>
 			<umb-localize .key=${localKey} .args=${[count, changes]}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/details-modal-element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/details-modal-element.ts
@@ -86,7 +86,7 @@ export class uSyncDetailsModalElement extends UmbModalBaseElement<
 			type="button"
 			look="outline"
 			.state=${this.importState}
-			.label=${this.localize.term('uSync_importSingle')}
+			.label=${this.localize.termOrDefault('uSync_importSingle', 'Import')}
 			@click="${this.#onImport}"></uui-button>`;
 	}
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/legacy-modal-element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/legacy-modal-element.ts
@@ -30,7 +30,7 @@ export class uSyncLegacyModalElement extends UmbModalBaseElement<
 	renderLegacyFolder(folder: string | null | undefined) {
 		return folder === undefined || folder === null
 			? nothing
-			: html`${this.localize.term('uSync.legacyInfo', [folder])}`;
+			: html`${this.localize.termOrDefault('uSync.legacyInfo', 'uSync has found a legacy uSync folder', folder)}`;
 	}
 
 	renderLegacyTypes(legacyTypes: Array<string> | undefined) {
@@ -43,14 +43,12 @@ export class uSyncLegacyModalElement extends UmbModalBaseElement<
 		});
 
 		return html`<div>
-			${this.localize.term('uSync.legacyObsolete', [legacyTypeHtml])}
+			${this.localize.termOrDefault('uSync.legacyObsolete', 'Obsolete DataTypes', legacyTypeHtml)}
 		</div>`;
 	}
 
 	renderCopy() {
-		return html`${this.localize.term('uSync.legacyCopy', [
-			this.data?.legacyFolder ?? 'uSync/v15',
-		])} `;
+		return html`${this.localize.termOrDefault('uSync.legacyCopy', 'Copy to uSync folder', this.data?.legacyFolder ?? 'uSync/v15')} `;
 	}
 
 	static styles = css`

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/single-import-modal.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/single-import-modal.element.ts
@@ -64,7 +64,7 @@ export default class SyncImportSingleModalElement extends UmbModalBaseElement<
 							color="positive"
 							type="button"
 							.state=${this.importState}
-							.label=${this.localize.term('uSync_importSingle')}
+							.label=${this.localize.termOrDefault('uSync_importSingle', 'Import')}
 							@click="${this.#doImport}"></uui-button>`,
 				)}
 			</div>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
@@ -1,0 +1,179 @@
+export default {
+	uSync: {
+		section: 'Synkronisering',
+		name: 'uSync',
+		banner: 'uSync alt på én gang',
+
+		Report: 'Rapport',
+		Import: 'Importer',
+		Export: 'Eksporter',
+		ImportForce: 'Importer (Tvungen)',
+		ExportClean: 'Eksporter (Ren)',
+		ExportFile: 'Eksporter til fil',
+		ImportFile: 'Importer fra fil',
+
+		noChange: 'Intet har ændret sig',
+		showAll: 'Vis alle elementer',
+
+		detailHeadline: 'Registrerede ændringer',
+		detailHeader: 'Ting der er anderledes',
+
+		runningInBackground:
+			'uSync kører denne proces i baggrunden. Hvis du navigerer væk fra denne side, vil den fortsætte med at køre.',
+
+		connectionLost:
+			'Forbindelsen til serveren er gået tabt. Processen vil fortsætte med at køre i baggrunden, men du vil ikke se opdateringer her.',
+
+		importSingle: 'Importer',
+		importSingleWarning:
+			'Dette vil importere dette element til Umbraco. Hvis dette element har afhængigheder, vil de ikke blive importeret og skal løses manuelt.',
+		importSingleSuccess: 'Elementet er blevet importeret korrekt',
+		importSingleFailed: `<p>Der opstod en fejl ved import af elementet</p><strong>%0%</strong>`,
+
+		changeAction: 'Handling',
+		changeItem: 'Element',
+		changeDiffrence: 'Forskel',
+		changeCreate: 'Dette element findes ikke i Umbraco og oprettes',
+		noChangesImport: 'Der blev ikke foretaget ændringer i dette element',
+		noChangesReport: 'Ingen ændringer registreret',
+		noChangesDelete: 'Dette element er blevet slettet fra Umbraco',
+
+		importHeader: 'Importer fra fil',
+
+		success: 'Succes',
+		change: 'Ændring',
+		changeType: 'Type',
+		changeName: 'Navn',
+		changeDetail: 'Detalje',
+		changeHeading: 'Resultater',
+		changeCount: '{1}/{0} ændringer',
+		noChangeCount: '0/{0} ændringer',
+
+		legacyInfo: `<p>uSync har fundet en ældre uSync-mappe på <strong>%0%</strong>.<br />
+						Det er sandsynligt, at indholdet skal konverteres på en eller anden måde</p>`,
+
+		legacyObsolete: `<h4>Forældede datatyper</h4>
+				<ul>%0%</ul>
+				<p>Du kan konvertere disse datatyper ved hjælp af
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(I den fulde uSync-udgivelse vil konvertering ske her.)</em></p>`,
+
+		legacyCopy: `<h4>Kopiér til uSync/v14</h4>
+					<p>Du kan kopiere din %0%-mappe til ~/uSync/v14-mappen<br />og køre en import.</p>
+					<p>Hvis intet skal konverteres, bør alt importeres korrekt.</p>
+					<p><strong>Fjern eller omdøb %0%-mappen for at forhindre denne popup</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-uoverensstemmelse <uui-icon name="alert"></uui-icon></h4>
+			<p>Det ser ud til, at indstillingen <code>Imaging:HMAC</code>, der bruges til at generere filerne i uSync-mappen, ikke stemmer overens med den aktuelle indstilling for dette websted.</p>
+			<p>Billeder i RTE-kontrolelementer vil have HMAC-værdien tilføjet til URL-værdien, og uden yderligere konfiguration vises disse billeder muligvis ikke korrekt.</p>
+			<ul><li>Du kan aktivere "HMAC-mapping" i uSync,</li>
+			<li>eller du kan sikre, at HMAC-værdien i indstillingen <code>Imaging:HMAC</code> stemmer overens med den værdi, der bruges til at generere filerne i uSync-mappen</li></ul>`,
+		formatMismatch:
+			'Synkroniseringsfilformatversionen stemmer ikke overens med den forventede version. Dette kan indikere et potentielt kompatibilitetsproblem.',
+
+		legacyBanner:
+			'Dette websted indeholder filer fra en tidligere version af uSync. Se detaljerne under fanen Ældre.',
+
+		legacyCopyTitle: 'Overskriv v%0%-filer',
+		legacyCopyContent:
+			'Er du sikker på, at du vil overskrive indholdet af mappen %0% med de ældre uSync-mappefilerne?',
+
+		legacyIgnoreTitle: 'Ignorer ældre filer',
+		legacyIgnoreContent:
+			'Er du sikker på, at du vil ignorere filerne i den ældre uSync-mappe?',
+
+		errorHeader:
+			'Dette element stødte på en fejl under processen. Detaljerne er nedenfor:',
+
+		uploadIntro: 'Vælg en zip-fil med uSync-filer, som du vil uploade',
+		uploadSuccess: 'Filerne er blevet uploadet og udtrukket til uSync-mappen',
+		uploadError: 'Der opstod en fejl ved upload af filerne',
+
+		ILanguage: 'Sprog',
+		IDictionaryItem: 'Ordbogselementer',
+		IDataType: 'Datatyper',
+		ITemplate: 'Skabeloner',
+		IContentType: 'Indholdstyper',
+		IMediaType: 'Medietyper',
+		IMemberType: 'Medlemstyper',
+		IContent: 'Indhold',
+		IMedia: 'Medie',
+		IDomain: 'Domæner',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Relationstyper',
+		MediaFile: 'Mediefiler',
+		XElement: 'Andet',
+		LanguageHandler: 'Sprog',
+		DictionaryHandler: 'Ordbogselementer',
+		DataTypeHandler: 'Datatyper',
+		TemplateHandler: 'Skabeloner',
+		ContentTypeHandler: 'Indholdstyper',
+		MediaTypeHandler: 'Medietyper',
+		MemberTypeHandler: 'Medlemstyper',
+		ContentHandler: 'Indhold',
+		MediaHandler: 'Medie',
+		RelationTypeHandler: 'Relationstyper',
+		EntityContainer: 'Containere',
+	},
+	USyncSettings: {
+		settings: 'uSync-indstillinger',
+		filesAndFolders: 'Filer og mapper',
+		handlerDefaults: 'Handlerstandarder',
+
+		processingMode: 'Behandlingstilstand',
+		processingModeDesc:
+			'Hvordan uSync-processen kører, enten i baggrunden eller interaktivt (Normal)',
+
+		importAtStartup: 'Importer ved opstart',
+		importAtStartupDesc: 'Kør en import af filer fra disken, når Umbraco starter',
+
+		exportAtStartup: 'Eksporter ved opstart',
+		exportAtStartupDesc: 'Eksporter Umbraco-indstillingerne, når webstedet starter',
+
+		exportOnSave: 'Eksporter ved gem',
+		exportOnSaveDesc: 'Generer uSync-filer, når elementer gemmes',
+
+		uiEnabledGroups: 'Aktiverede UI-grupper',
+		uiEnabledGroupsDesc: 'Handlergrupper, der kan ses/bruges på dashboardet',
+
+		failOnMissingParent: 'Fejl ved manglende overordnet',
+		failOnMissingParentDesc: 'Fejl ved manglende overordnet element',
+
+		currentHandlerSet: 'Aktuelt sæt',
+
+		handlerSet: 'Standardhandlersæt',
+		handlerSetDesc: 'Det standardhandlersæt, der bruges for webstedet',
+
+		flatStructure: 'Flad struktur',
+		flatStructureDesc: 'Alle elementer af en type gemmes i en flad mappestruktur',
+
+		guidNames: 'Brug GUID som filnavne',
+		guidNamesDesc: 'Brug et elements GUID som filnavn',
+
+		handlerGroups: 'Handlergrupper',
+		handlerGroupsDesc: 'Grupper til at begrænse handlersættet til',
+
+		disabledHandlers: 'Deaktiverede handlere',
+		disabledHandlersDesc: 'Handlere eksplicit deaktiveret for dette handlersæt',
+
+		folders: 'Mapper',
+		foldersDesc:
+			'Mapper uSync vil søge efter filer i (elementer gemmes normalt i den sidste mappe på listen)',
+
+		rootSite: 'Rodwebsted',
+		rootSiteDesc: 'Er dette websted en rod for andre websteder.',
+
+		rootLocked: 'Rod låst',
+		rootLockedDesc: 'Er ændringer for elementer fra rodwebstedet låst?',
+
+		help: 'Indstillinger styres via filen appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Se vores dokumentation</a>',
+
+		bootSettings: 'Indstillinger for første opstart 🥾',
+
+		firstBoot: 'Importer ved første opstart',
+		firstBootDesc: 'Kør importprocessen ved webstedets første opstart',
+
+		firstBootGroup: 'Grupper for første opstart',
+		firstBootGroupDesc: 'De grupper, der køres ved første opstart',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync alt på én gang',
 
+		migrate: 'Migrer',
+		defaultView: 'Standard',
+		settingsView: 'Indstillinger',
+		addons: 'Tilføjelser',
+
+		groupEverything: 'Alt',
+		groupContent: 'Indhold',
+		groupSettings: 'Indstillinger',
+		groupForms: 'Formularer',
+		groupMedia: 'Medie',
+		groupMembers: 'Medlemmer',
+
 		Report: 'Rapport',
 		Import: 'Importer',
 		Export: 'Eksporter',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
@@ -1,0 +1,179 @@
+export default {
+	uSync: {
+		section: 'Synchronisation',
+		name: 'uSync',
+		banner: 'uSync für alles',
+
+		Report: 'Bericht',
+		Import: 'Importieren',
+		Export: 'Exportieren',
+		ImportForce: 'Importieren (Erzwingen)',
+		ExportClean: 'Exportieren (Bereinigt)',
+		ExportFile: 'In Datei exportieren',
+		ImportFile: 'Aus Datei importieren',
+
+		noChange: 'Es hat sich nichts geändert',
+		showAll: 'Alle Elemente anzeigen',
+
+		detailHeadline: 'Erkannte Änderungen',
+		detailHeader: 'Was sich unterscheidet',
+
+		runningInBackground:
+			'uSync führt diesen Prozess im Hintergrund aus. Wenn Sie diese Seite verlassen, wird er weiterhin ausgeführt.',
+
+		connectionLost:
+			'Die Verbindung zum Server wurde unterbrochen. Der Prozess wird im Hintergrund weiter ausgeführt, aber Sie werden hier keine Aktualisierungen sehen.',
+
+		importSingle: 'Importieren',
+		importSingleWarning:
+			'Dadurch wird dieses Element in Umbraco importiert. Wenn dieses Element Abhängigkeiten hat, werden diese nicht importiert und müssen manuell aufgelöst werden.',
+		importSingleSuccess: 'Das Element wurde erfolgreich importiert',
+		importSingleFailed: `<p>Beim Importieren des Elements ist ein Fehler aufgetreten</p><strong>%0%</strong>`,
+
+		changeAction: 'Aktion',
+		changeItem: 'Element',
+		changeDiffrence: 'Unterschied',
+		changeCreate: 'Dieses Element existiert nicht in Umbraco und wird erstellt',
+		noChangesImport: 'Es wurden keine Änderungen an diesem Element vorgenommen',
+		noChangesReport: 'Keine Änderungen erkannt',
+		noChangesDelete: 'Dieses Element wurde aus Umbraco gelöscht',
+
+		importHeader: 'Aus Datei importieren',
+
+		success: 'Erfolg',
+		change: 'Änderung',
+		changeType: 'Typ',
+		changeName: 'Name',
+		changeDetail: 'Detail',
+		changeHeading: 'Ergebnisse',
+		changeCount: '{1}/{0} Änderungen',
+		noChangeCount: '0/{0} Änderungen',
+
+		legacyInfo: `<p>uSync hat einen Legacy-uSync-Ordner unter <strong>%0%</strong> gefunden.<br />
+						Der Inhalt muss wahrscheinlich konvertiert werden</p>`,
+
+		legacyObsolete: `<h4>Veraltete Datentypen</h4>
+				<ul>%0%</ul>
+				<p>Sie können diese Datentypen mit
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a> konvertieren<br />
+					<em>(In der vollständigen uSync-Version wird die Konvertierung hier stattfinden.)</em></p>`,
+
+		legacyCopy: `<h4>Nach uSync/v14 kopieren</h4>
+					<p>Sie können Ihren %0%-Ordner in den ~/uSync/v14-Ordner kopieren<br />und einen Import ausführen.</p>
+					<p>Wenn nichts konvertiert werden muss, sollte alles korrekt importiert werden.</p>
+					<p><strong>Entfernen oder benennen Sie den %0%-Ordner um, um dieses Popup zu verhindern</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-Abweichung <uui-icon name="alert"></uui-icon></h4>
+			<p>Es scheint, dass die <code>Imaging:HMAC</code>-Einstellung, die zum Generieren der Dateien im uSync-Ordner verwendet wurde, nicht mit der aktuellen Einstellung dieser Website übereinstimmt.</p>
+			<p>Bilder in RTE-Steuerelementen haben den HMAC-Wert an die URL angehängt. Ohne zusätzliche Konfiguration werden diese Bilder möglicherweise nicht korrekt dargestellt.</p>
+			<ul><li>Sie können die "HMAC-Zuordnung" in uSync aktivieren,</li>
+			<li>oder Sie können sicherstellen, dass der HMAC-Wert in der <code>Imaging:HMAC</code>-Einstellung mit dem Wert übereinstimmt, der zum Generieren der Dateien im uSync-Ordner verwendet wurde</li></ul>`,
+		formatMismatch:
+			'Die Formatversion der Synchronisierungsdatei stimmt nicht mit der erwarteten Version überein. Dies kann auf ein potenzielles Kompatibilitätsproblem hinweisen.',
+
+		legacyBanner:
+			'Diese Website enthält Dateien einer früheren Version von uSync. Details finden Sie auf der Registerkarte Legacy.',
+
+		legacyCopyTitle: 'v%0%-Dateien überschreiben',
+		legacyCopyContent:
+			'Möchten Sie den Inhalt des Ordners %0% wirklich mit den Legacy-uSync-Ordnerdateien überschreiben?',
+
+		legacyIgnoreTitle: 'Legacy-Dateien ignorieren',
+		legacyIgnoreContent:
+			'Möchten Sie die Dateien im Legacy-uSync-Ordner wirklich ignorieren?',
+
+		errorHeader:
+			'Bei diesem Element ist während des Prozesses ein Fehler aufgetreten. Die Details sind unten aufgeführt:',
+
+		uploadIntro: 'Wählen Sie eine ZIP-Datei mit uSync-Dateien aus, die Sie hochladen möchten',
+		uploadSuccess: 'Die Dateien wurden hochgeladen und in den uSync-Ordner extrahiert',
+		uploadError: 'Beim Hochladen der Dateien ist ein Fehler aufgetreten',
+
+		ILanguage: 'Sprache',
+		IDictionaryItem: 'Wörterbuchelemente',
+		IDataType: 'Datentypen',
+		ITemplate: 'Vorlagen',
+		IContentType: 'Inhaltstypen',
+		IMediaType: 'Medientypen',
+		IMemberType: 'Mitgliedstypen',
+		IContent: 'Inhalt',
+		IMedia: 'Medien',
+		IDomain: 'Domänen',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Beziehungstypen',
+		MediaFile: 'Mediendateien',
+		XElement: 'Sonstiges',
+		LanguageHandler: 'Sprachen',
+		DictionaryHandler: 'Wörterbuchelemente',
+		DataTypeHandler: 'Datentypen',
+		TemplateHandler: 'Vorlagen',
+		ContentTypeHandler: 'Inhaltstypen',
+		MediaTypeHandler: 'Medientypen',
+		MemberTypeHandler: 'Mitgliedstypen',
+		ContentHandler: 'Inhalt',
+		MediaHandler: 'Medien',
+		RelationTypeHandler: 'Beziehungstypen',
+		EntityContainer: 'Container',
+	},
+	USyncSettings: {
+		settings: 'uSync-Einstellungen',
+		filesAndFolders: 'Dateien und Ordner',
+		handlerDefaults: 'Handler-Standardwerte',
+
+		processingMode: 'Verarbeitungsmodus',
+		processingModeDesc:
+			'Wie der uSync-Prozess ausgeführt wird, entweder im Hintergrund oder interaktiv (Normal)',
+
+		importAtStartup: 'Beim Start importieren',
+		importAtStartupDesc: 'Einen Import von Dateien von der Festplatte beim Start von Umbraco ausführen',
+
+		exportAtStartup: 'Beim Start exportieren',
+		exportAtStartupDesc: 'Die Umbraco-Einstellungen beim Start der Website exportieren',
+
+		exportOnSave: 'Beim Speichern exportieren',
+		exportOnSaveDesc: 'uSync-Dateien generieren, wenn Elemente gespeichert werden',
+
+		uiEnabledGroups: 'UI-aktivierte Gruppen',
+		uiEnabledGroupsDesc: 'Handler-Gruppen, die im Dashboard angezeigt/verwendet werden können',
+
+		failOnMissingParent: 'Fehler bei fehlendem Elternelement',
+		failOnMissingParentDesc: 'Fehler bei fehlendem Elternelement',
+
+		currentHandlerSet: 'Aktuelles Set',
+
+		handlerSet: 'Standard-Handler-Set',
+		handlerSetDesc: 'Das Standard-Handler-Set für die Website',
+
+		flatStructure: 'Flache Struktur',
+		flatStructureDesc: 'Alle Elemente eines Typs werden in einer flachen Ordnerstruktur gespeichert',
+
+		guidNames: 'GUIDs als Dateinamen verwenden',
+		guidNamesDesc: 'Die GUID eines Elements als Dateiname verwenden',
+
+		handlerGroups: 'Handler-Gruppen',
+		handlerGroupsDesc: 'Gruppen zur Einschränkung des Handler-Sets',
+
+		disabledHandlers: 'Deaktivierte Handler',
+		disabledHandlersDesc: 'Handler, die für dieses Handler-Set explizit deaktiviert sind',
+
+		folders: 'Ordner',
+		foldersDesc:
+			'Ordner, in denen uSync nach Dateien sucht (Elemente werden normalerweise im letzten Ordner der Liste gespeichert)',
+
+		rootSite: 'Root-Website',
+		rootSiteDesc: 'Ist diese Website ein Root für andere Websites.',
+
+		rootLocked: 'Root gesperrt',
+		rootLockedDesc: 'Sind Änderungen an Elementen der Root-Website gesperrt?',
+
+		help: 'Die Einstellungen werden über die Datei appsettings.json gesteuert. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Siehe unsere Dokumentation</a>',
+
+		bootSettings: 'Einstellungen für den ersten Start 🥾',
+
+		firstBoot: 'Beim ersten Start importieren',
+		firstBootDesc: 'Den Importprozess beim ersten Start der Website ausführen',
+
+		firstBootGroup: 'Gruppen für den ersten Start',
+		firstBootGroupDesc: 'Die Gruppen, die beim ersten Start ausgeführt werden',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync für alles',
 
+		migrate: 'Migrieren',
+		defaultView: 'Standard',
+		settingsView: 'Einstellungen',
+		addons: 'Erweiterungen',
+
+		groupEverything: 'Alles',
+		groupContent: 'Inhalt',
+		groupSettings: 'Einstellungen',
+		groupForms: 'Formulare',
+		groupMedia: 'Medien',
+		groupMembers: 'Mitglieder',
+
 		Report: 'Bericht',
 		Import: 'Importieren',
 		Export: 'Exportieren',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync all the things',
 
+		migrate: 'Migrate',
+		defaultView: 'Default',
+		settingsView: 'Settings',
+		addons: 'Add-ons',
+
+		groupEverything: 'Everything',
+		groupContent: 'Content',
+		groupSettings: 'Settings',
+		groupForms: 'Forms',
+		groupMedia: 'Media',
+		groupMembers: 'Members',
+
 		Report: 'Report',
 		Import: 'Import',
 		Export: 'Export',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync para todo',
 
+		migrate: 'Migrar',
+		defaultView: 'Predeterminado',
+		settingsView: 'Configuración',
+		addons: 'Complementos',
+
+		groupEverything: 'Todo',
+		groupContent: 'Contenido',
+		groupSettings: 'Configuración',
+		groupForms: 'Formularios',
+		groupMedia: 'Medios',
+		groupMembers: 'Miembros',
+
 		Report: 'Informe',
 		Import: 'Importar',
 		Export: 'Exportar',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
@@ -1,0 +1,179 @@
+export default {
+	uSync: {
+		section: 'Sincronización',
+		name: 'uSync',
+		banner: 'uSync para todo',
+
+		Report: 'Informe',
+		Import: 'Importar',
+		Export: 'Exportar',
+		ImportForce: 'Importar (Forzar)',
+		ExportClean: 'Exportar (Limpio)',
+		ExportFile: 'Exportar a archivo',
+		ImportFile: 'Importar desde archivo',
+
+		noChange: 'Nada ha cambiado',
+		showAll: 'Mostrar todos los elementos',
+
+		detailHeadline: 'Cambios detectados',
+		detailHeader: 'Cosas que son diferentes',
+
+		runningInBackground:
+			'uSync está ejecutando este proceso en segundo plano. Si navega fuera de esta página, continuará ejecutándose.',
+
+		connectionLost:
+			'Se ha perdido la conexión con el servidor. El proceso continuará ejecutándose en segundo plano, pero no verá actualizaciones aquí.',
+
+		importSingle: 'Importar',
+		importSingleWarning:
+			'Esto importará este elemento en Umbraco. Si este elemento tiene dependencias, no serán importadas y deberán resolverse manualmente.',
+		importSingleSuccess: 'El elemento se ha importado correctamente',
+		importSingleFailed: `<p>Se produjo un error al importar el elemento</p><strong>%0%</strong>`,
+
+		changeAction: 'Acción',
+		changeItem: 'Elemento',
+		changeDiffrence: 'Diferencia',
+		changeCreate: 'Este elemento no existe en Umbraco y está siendo creado',
+		noChangesImport: 'No se realizaron cambios en este elemento',
+		noChangesReport: 'No se detectaron cambios',
+		noChangesDelete: 'Este elemento ha sido eliminado de Umbraco',
+
+		importHeader: 'Importar desde archivo',
+
+		success: 'Éxito',
+		change: 'Cambio',
+		changeType: 'Tipo',
+		changeName: 'Nombre',
+		changeDetail: 'Detalle',
+		changeHeading: 'Resultados',
+		changeCount: '{1}/{0} cambios',
+		noChangeCount: '0/{0} cambios',
+
+		legacyInfo: `<p>uSync ha encontrado una carpeta uSync heredada en <strong>%0%</strong>.<br />
+						Es probable que su contenido necesite convertirse de alguna manera</p>`,
+
+		legacyObsolete: `<h4>Tipos de datos obsoletos</h4>
+				<ul>%0%</ul>
+				<p>Puede convertir estos tipos de datos usando
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(En la versión completa de uSync, la conversión se realizará aquí.)</em></p>`,
+
+		legacyCopy: `<h4>Copiar a uSync/v14</h4>
+					<p>Puede copiar su carpeta %0% a la carpeta ~/uSync/v14<br />y ejecutar una importación.</p>
+					<p>Si nada necesita convertirse, todo debería importarse correctamente.</p>
+					<p><strong>Elimine o cambie el nombre de la carpeta %0% para evitar este popup</strong></p>`,
+
+		hmacMismatch: `<h4>Discrepancia HMAC <uui-icon name="alert"></uui-icon></h4>
+			<p>Parece que la configuración <code>Imaging:HMAC</code> utilizada para generar los archivos en la carpeta uSync no coincide con la configuración actual de este sitio.</p>
+			<p>Las imágenes dentro de los controles RTE tendrán el valor HMAC añadido a la URL, y sin configuración adicional, estas imágenes pueden no mostrarse correctamente.</p>
+			<ul><li>Puede activar el "mapeo HMAC" en uSync,</li>
+			<li>o puede asegurarse de que el valor HMAC en la configuración <code>Imaging:HMAC</code> coincida con el valor utilizado para generar los archivos en la carpeta uSync</li></ul>`,
+		formatMismatch:
+			'La versión del formato del archivo de sincronización no coincide con la versión esperada. Esto puede indicar un posible problema de compatibilidad.',
+
+		legacyBanner:
+			'Este sitio contiene archivos de una versión anterior de uSync. Consulte los detalles en la pestaña Heredado.',
+
+		legacyCopyTitle: 'Sobrescribir archivos v%0%',
+		legacyCopyContent:
+			'¿Está seguro de que desea sobrescribir el contenido de la carpeta %0% con los archivos de la carpeta uSync heredada?',
+
+		legacyIgnoreTitle: 'Ignorar archivos heredados',
+		legacyIgnoreContent:
+			'¿Está seguro de que desea ignorar los archivos en la carpeta uSync heredada?',
+
+		errorHeader:
+			'Este elemento encontró un error durante el proceso. Los detalles se muestran a continuación:',
+
+		uploadIntro: 'Seleccione un archivo zip que contenga los archivos uSync que desea cargar',
+		uploadSuccess: 'Los archivos han sido cargados y extraídos en la carpeta uSync',
+		uploadError: 'Se produjo un error al cargar los archivos',
+
+		ILanguage: 'Idioma',
+		IDictionaryItem: 'Elementos del diccionario',
+		IDataType: 'Tipos de datos',
+		ITemplate: 'Plantillas',
+		IContentType: 'Tipos de contenido',
+		IMediaType: 'Tipos de medios',
+		IMemberType: 'Tipos de miembros',
+		IContent: 'Contenido',
+		IMedia: 'Medios',
+		IDomain: 'Dominios',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Tipos de relaciones',
+		MediaFile: 'Archivos de medios',
+		XElement: 'Otro',
+		LanguageHandler: 'Idiomas',
+		DictionaryHandler: 'Elementos del diccionario',
+		DataTypeHandler: 'Tipos de datos',
+		TemplateHandler: 'Plantillas',
+		ContentTypeHandler: 'Tipos de contenido',
+		MediaTypeHandler: 'Tipos de medios',
+		MemberTypeHandler: 'Tipos de miembros',
+		ContentHandler: 'Contenido',
+		MediaHandler: 'Medios',
+		RelationTypeHandler: 'Tipos de relaciones',
+		EntityContainer: 'Contenedores',
+	},
+	USyncSettings: {
+		settings: 'Configuración de uSync',
+		filesAndFolders: 'Archivos y carpetas',
+		handlerDefaults: 'Valores predeterminados del controlador',
+
+		processingMode: 'Modo de procesamiento',
+		processingModeDesc:
+			'Cómo se ejecuta el proceso uSync, ya sea en segundo plano o de forma interactiva (Normal)',
+
+		importAtStartup: 'Importar al inicio',
+		importAtStartupDesc: 'Ejecutar una importación de archivos desde el disco cuando Umbraco se inicia',
+
+		exportAtStartup: 'Exportar al inicio',
+		exportAtStartupDesc: 'Exportar la configuración de Umbraco cuando el sitio se inicia',
+
+		exportOnSave: 'Exportar al guardar',
+		exportOnSaveDesc: 'Generar archivos uSync cuando se guardan elementos',
+
+		uiEnabledGroups: 'Grupos habilitados en la interfaz',
+		uiEnabledGroupsDesc: 'Grupos de controladores que se pueden ver/usar en el panel',
+
+		failOnMissingParent: 'Error si falta el padre',
+		failOnMissingParentDesc: 'Error si falta el elemento padre',
+
+		currentHandlerSet: 'Conjunto actual',
+
+		handlerSet: 'Conjunto de controladores predeterminado',
+		handlerSetDesc: 'El conjunto de controladores predeterminado a usar para el sitio',
+
+		flatStructure: 'Estructura plana',
+		flatStructureDesc: 'Todos los elementos de un tipo se almacenan en una estructura de carpetas plana',
+
+		guidNames: 'Usar GUID como nombres de archivo',
+		guidNamesDesc: 'Usar el GUID de un elemento como nombre de archivo',
+
+		handlerGroups: 'Grupos de controladores',
+		handlerGroupsDesc: 'Grupos para limitar el conjunto de controladores',
+
+		disabledHandlers: 'Controladores deshabilitados',
+		disabledHandlersDesc: 'Controladores explícitamente deshabilitados para este conjunto de controladores',
+
+		folders: 'Carpetas',
+		foldersDesc:
+			'Carpetas donde uSync buscará archivos (los elementos normalmente se guardan en la última carpeta de la lista)',
+
+		rootSite: 'Sitio raíz',
+		rootSiteDesc: 'Este sitio es una raíz para otros sitios.',
+
+		rootLocked: 'Raíz bloqueada',
+		rootLockedDesc: '¿Están bloqueados los cambios de los elementos que provienen del sitio raíz?',
+
+		help: 'La configuración se controla mediante el archivo appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Ver nuestra documentación</a>',
+
+		bootSettings: 'Configuración del primer arranque 🥾',
+
+		firstBoot: 'Importar en el primer arranque',
+		firstBootDesc: 'Ejecutar el proceso de importación en el primer arranque del sitio',
+
+		firstBootGroup: 'Grupos del primer arranque',
+		firstBootGroupDesc: 'Los grupos a ejecutar en el primer arranque',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync pour tout synchroniser',
 
+		migrate: 'Migrer',
+		defaultView: 'Défaut',
+		settingsView: 'Paramètres',
+		addons: 'Extensions',
+
+		groupEverything: 'Tout',
+		groupContent: 'Contenu',
+		groupSettings: 'Paramètres',
+		groupForms: 'Formulaires',
+		groupMedia: 'Médias',
+		groupMembers: 'Membres',
+
 		Report: 'Rapport',
 		Import: 'Importer',
 		Export: 'Exporter',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
@@ -1,0 +1,179 @@
+export default {
+	uSync: {
+		section: 'Synchronisation',
+		name: 'uSync',
+		banner: 'uSync pour tout synchroniser',
+
+		Report: 'Rapport',
+		Import: 'Importer',
+		Export: 'Exporter',
+		ImportForce: 'Importer (Forcer)',
+		ExportClean: 'Exporter (Propre)',
+		ExportFile: 'Exporter vers fichier',
+		ImportFile: 'Importer depuis fichier',
+
+		noChange: 'Rien n\'a changé',
+		showAll: 'Afficher tous les éléments',
+
+		detailHeadline: 'Modifications détectées',
+		detailHeader: 'Ce qui est différent',
+
+		runningInBackground:
+			'uSync exécute ce processus en arrière-plan. Si vous quittez cette page, il continuera de fonctionner.',
+
+		connectionLost:
+			'La connexion au serveur a été perdue. Le processus continuera de s\'exécuter en arrière-plan, mais vous ne verrez pas les mises à jour ici.',
+
+		importSingle: 'Importer',
+		importSingleWarning:
+			'Cela importera cet élément dans Umbraco. Si cet élément a des dépendances, elles ne seront pas importées et devront être résolues manuellement.',
+		importSingleSuccess: 'L\'élément a été importé avec succès',
+		importSingleFailed: `<p>Une erreur s'est produite lors de l'importation de l'élément</p><strong>%0%</strong>`,
+
+		changeAction: 'Action',
+		changeItem: 'Élément',
+		changeDiffrence: 'Différence',
+		changeCreate: 'Cet élément n\'existe pas dans Umbraco et est en cours de création',
+		noChangesImport: 'Aucune modification n\'a été apportée à cet élément',
+		noChangesReport: 'Aucune modification détectée',
+		noChangesDelete: 'Cet élément a été supprimé d\'Umbraco',
+
+		importHeader: 'Importer depuis un fichier',
+
+		success: 'Succès',
+		change: 'Modification',
+		changeType: 'Type',
+		changeName: 'Nom',
+		changeDetail: 'Détail',
+		changeHeading: 'Résultats',
+		changeCount: '{1}/{0} modifications',
+		noChangeCount: '0/{0} modifications',
+
+		legacyInfo: `<p>uSync a trouvé un dossier uSync hérité à <strong>%0%</strong>.<br />
+						Il est probable que son contenu devra être converti d'une façon ou d'une autre</p>`,
+
+		legacyObsolete: `<h4>Types de données obsolètes</h4>
+				<ul>%0%</ul>
+				<p>Vous pouvez convertir ces types de données en utilisant
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(Dans la version complète d'uSync, la conversion se fera ici.)</em></p>`,
+
+		legacyCopy: `<h4>Copier vers uSync/v14</h4>
+					<p>Vous pouvez copier votre dossier %0% vers le dossier ~/uSync/v14<br />et exécuter une importation.</p>
+					<p>Si rien ne nécessite de conversion, tout devrait s'importer correctement.</p>
+					<p><strong>Supprimez ou renommez le dossier %0% pour éviter cette popup</strong></p>`,
+
+		hmacMismatch: `<h4>Incompatibilité HMAC <uui-icon name="alert"></uui-icon></h4>
+			<p>Il semble que le paramètre <code>Imaging:HMAC</code> utilisé pour générer les fichiers dans le dossier uSync ne corresponde pas au paramètre actuel de ce site.</p>
+			<p>Les images dans les contrôles RTE auront la valeur HMAC ajoutée à l'URL, et sans configuration supplémentaire, ces images pourraient ne pas s'afficher correctement.</p>
+			<ul><li>Vous pouvez activer le "mappage HMAC" dans uSync,</li>
+			<li>ou vous pouvez vous assurer que la valeur HMAC dans le paramètre <code>Imaging:HMAC</code> correspond à la valeur utilisée pour générer les fichiers dans le dossier uSync</li></ul>`,
+		formatMismatch:
+			'La version du format du fichier de synchronisation ne correspond pas à la version attendue. Cela peut indiquer un problème de compatibilité potentiel.',
+
+		legacyBanner:
+			'Ce site contient des fichiers d\'une version précédente d\'uSync. Consultez les détails dans l\'onglet Héritage.',
+
+		legacyCopyTitle: 'Écraser les fichiers v%0%',
+		legacyCopyContent:
+			'Êtes-vous sûr de vouloir écraser le contenu du dossier %0% avec les fichiers du dossier uSync hérité ?',
+
+		legacyIgnoreTitle: 'Ignorer les fichiers hérités',
+		legacyIgnoreContent:
+			'Êtes-vous sûr de vouloir ignorer les fichiers dans le dossier uSync hérité ?',
+
+		errorHeader:
+			'Cet élément a rencontré une erreur lors du processus. Les détails sont ci-dessous :',
+
+		uploadIntro: 'Sélectionnez un fichier zip contenant les fichiers uSync que vous souhaitez télécharger',
+		uploadSuccess: 'Les fichiers ont été téléchargés et extraits dans le dossier uSync',
+		uploadError: 'Une erreur s\'est produite lors du téléchargement des fichiers',
+
+		ILanguage: 'Langue',
+		IDictionaryItem: 'Éléments du dictionnaire',
+		IDataType: 'Types de données',
+		ITemplate: 'Modèles',
+		IContentType: 'Types de contenu',
+		IMediaType: 'Types de médias',
+		IMemberType: 'Types de membres',
+		IContent: 'Contenu',
+		IMedia: 'Média',
+		IDomain: 'Domaines',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Types de relations',
+		MediaFile: 'Fichiers médias',
+		XElement: 'Autre',
+		LanguageHandler: 'Langues',
+		DictionaryHandler: 'Éléments du dictionnaire',
+		DataTypeHandler: 'Types de données',
+		TemplateHandler: 'Modèles',
+		ContentTypeHandler: 'Types de contenu',
+		MediaTypeHandler: 'Types de médias',
+		MemberTypeHandler: 'Types de membres',
+		ContentHandler: 'Contenu',
+		MediaHandler: 'Média',
+		RelationTypeHandler: 'Types de relations',
+		EntityContainer: 'Conteneurs',
+	},
+	USyncSettings: {
+		settings: 'Paramètres uSync',
+		filesAndFolders: 'Fichiers et dossiers',
+		handlerDefaults: 'Paramètres par défaut des gestionnaires',
+
+		processingMode: 'Mode de traitement',
+		processingModeDesc:
+			'Comment le processus uSync s\'exécute, soit en arrière-plan, soit de manière interactive (Normal)',
+
+		importAtStartup: 'Importer au démarrage',
+		importAtStartupDesc: 'Exécuter une importation de fichiers depuis le disque au démarrage d\'Umbraco',
+
+		exportAtStartup: 'Exporter au démarrage',
+		exportAtStartupDesc: 'Exporter les paramètres Umbraco au démarrage du site',
+
+		exportOnSave: 'Exporter à l\'enregistrement',
+		exportOnSaveDesc: 'Générer des fichiers uSync lors de l\'enregistrement des éléments',
+
+		uiEnabledGroups: 'Groupes activés dans l\'interface',
+		uiEnabledGroupsDesc: 'Groupes de gestionnaires visibles/utilisables sur le tableau de bord',
+
+		failOnMissingParent: 'Échec si parent manquant',
+		failOnMissingParentDesc: 'Échec si l\'élément parent est manquant',
+
+		currentHandlerSet: 'Ensemble actuel',
+
+		handlerSet: 'Ensemble de gestionnaires par défaut',
+		handlerSetDesc: 'L\'ensemble de gestionnaires par défaut à utiliser pour le site',
+
+		flatStructure: 'Structure plate',
+		flatStructureDesc: 'Tous les éléments d\'un type sont stockés dans une structure de dossiers plate',
+
+		guidNames: 'Utiliser les GUID comme noms de fichiers',
+		guidNamesDesc: 'Utiliser le GUID d\'un élément comme nom de fichier',
+
+		handlerGroups: 'Groupes de gestionnaires',
+		handlerGroupsDesc: 'Groupes pour limiter l\'ensemble de gestionnaires',
+
+		disabledHandlers: 'Gestionnaires désactivés',
+		disabledHandlersDesc: 'Gestionnaires explicitement désactivés pour cet ensemble de gestionnaires',
+
+		folders: 'Dossiers',
+		foldersDesc:
+			'Dossiers dans lesquels uSync recherchera des fichiers (les éléments sont normalement enregistrés dans le dernier dossier de la liste)',
+
+		rootSite: 'Site racine',
+		rootSiteDesc: 'Ce site est-il une racine pour d\'autres sites.',
+
+		rootLocked: 'Racine verrouillée',
+		rootLockedDesc: 'Les modifications des éléments provenant du site racine sont-elles verrouillées ?',
+
+		help: 'Les paramètres sont contrôlés via le fichier appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Voir notre documentation</a>',
+
+		bootSettings: 'Paramètres du premier démarrage 🥾',
+
+		firstBoot: 'Importer au premier démarrage',
+		firstBootDesc: 'Exécuter le processus d\'importation au premier démarrage du site',
+
+		firstBootGroup: 'Groupes du premier démarrage',
+		firstBootGroupDesc: 'Les groupes à exécuter au premier démarrage',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
@@ -1,0 +1,179 @@
+export default {
+	uSync: {
+		section: 'Synchronisatie',
+		name: 'uSync',
+		banner: 'uSync voor alles',
+
+		Report: 'Rapport',
+		Import: 'Importeren',
+		Export: 'Exporteren',
+		ImportForce: 'Importeren (Forceren)',
+		ExportClean: 'Exporteren (Schoon)',
+		ExportFile: 'Exporteren naar bestand',
+		ImportFile: 'Importeren vanuit bestand',
+
+		noChange: 'Er is niets veranderd',
+		showAll: 'Alle items weergeven',
+
+		detailHeadline: 'Gedetecteerde wijzigingen',
+		detailHeader: 'Wat er anders is',
+
+		runningInBackground:
+			'uSync voert dit proces op de achtergrond uit. Als u van deze pagina navigeert, blijft het doorlopen.',
+
+		connectionLost:
+			'De verbinding met de server is verbroken. Het proces blijft op de achtergrond draaien, maar u ziet hier geen updates.',
+
+		importSingle: 'Importeren',
+		importSingleWarning:
+			'Dit importeert dit item in Umbraco. Als dit item afhankelijkheden heeft, worden deze niet geïmporteerd en moeten handmatig worden opgelost.',
+		importSingleSuccess: 'Het item is succesvol geïmporteerd',
+		importSingleFailed: `<p>Er is een fout opgetreden bij het importeren van het item</p><strong>%0%</strong>`,
+
+		changeAction: 'Actie',
+		changeItem: 'Item',
+		changeDiffrence: 'Verschil',
+		changeCreate: 'Dit item bestaat niet in Umbraco en wordt aangemaakt',
+		noChangesImport: 'Er zijn geen wijzigingen aangebracht aan dit item',
+		noChangesReport: 'Geen wijzigingen gedetecteerd',
+		noChangesDelete: 'Dit item is verwijderd uit Umbraco',
+
+		importHeader: 'Importeren vanuit bestand',
+
+		success: 'Succes',
+		change: 'Wijziging',
+		changeType: 'Type',
+		changeName: 'Naam',
+		changeDetail: 'Detail',
+		changeHeading: 'Resultaten',
+		changeCount: '{1}/{0} wijzigingen',
+		noChangeCount: '0/{0} wijzigingen',
+
+		legacyInfo: `<p>uSync heeft een verouderde uSync-map gevonden op <strong>%0%</strong>.<br />
+						Het is waarschijnlijk dat de inhoud op de een of andere manier geconverteerd moet worden</p>`,
+
+		legacyObsolete: `<h4>Verouderde gegevenstypen</h4>
+				<ul>%0%</ul>
+				<p>U kunt deze gegevenstypen converteren met
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(In de volledige uSync-release zal de conversie hier plaatsvinden.)</em></p>`,
+
+		legacyCopy: `<h4>Kopiëren naar uSync/v14</h4>
+					<p>U kunt uw %0%-map kopiëren naar de ~/uSync/v14-map<br />en een import uitvoeren.</p>
+					<p>Als er niets geconverteerd hoeft te worden, zou alles correct moeten importeren.</p>
+					<p><strong>Verwijder of hernoem de %0%-map om deze popup te voorkomen</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-mismatch <uui-icon name="alert"></uui-icon></h4>
+			<p>Het lijkt erop dat de <code>Imaging:HMAC</code>-instelling die werd gebruikt om de bestanden in de uSync-map te genereren, niet overeenkomt met de huidige instelling voor deze site.</p>
+			<p>Afbeeldingen in RTE-besturingselementen hebben de HMAC-waarde toegevoegd aan de URL-waarde, en zonder aanvullende configuratie worden deze afbeeldingen mogelijk niet correct weergegeven.</p>
+			<ul><li>U kunt "HMAC-mapping" inschakelen in uSync,</li>
+			<li>of u kunt ervoor zorgen dat de HMAC-waarde in de <code>Imaging:HMAC</code>-instelling overeenkomt met de waarde die werd gebruikt om de bestanden in de uSync-map te genereren</li></ul>`,
+		formatMismatch:
+			'De versie van het synchronisatiebestandsformaat komt niet overeen met de verwachte versie. Dit kan wijzen op een mogelijk compatibiliteitsprobleem.',
+
+		legacyBanner:
+			'Deze site bevat bestanden van een eerdere versie van uSync. Bekijk de details op het tabblad Verouderd.',
+
+		legacyCopyTitle: 'v%0%-bestanden overschrijven',
+		legacyCopyContent:
+			'Weet u zeker dat u de inhoud van de map %0% wilt overschrijven met de verouderde uSync-mapbestanden?',
+
+		legacyIgnoreTitle: 'Verouderde bestanden negeren',
+		legacyIgnoreContent:
+			'Weet u zeker dat u de bestanden in de verouderde uSync-map wilt negeren?',
+
+		errorHeader:
+			'Dit item heeft een fout ondervonden tijdens het proces. De details staan hieronder:',
+
+		uploadIntro: 'Selecteer een zip-bestand met uSync-bestanden die u wilt uploaden',
+		uploadSuccess: 'De bestanden zijn geüpload en uitgepakt naar de uSync-map',
+		uploadError: 'Er is een fout opgetreden bij het uploaden van de bestanden',
+
+		ILanguage: 'Taal',
+		IDictionaryItem: 'Woordenboekitems',
+		IDataType: 'Gegevenstypen',
+		ITemplate: 'Sjablonen',
+		IContentType: 'Inhoudstypen',
+		IMediaType: 'Mediatypen',
+		IMemberType: 'Ledentypen',
+		IContent: 'Inhoud',
+		IMedia: 'Media',
+		IDomain: 'Domeinen',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Relatietypen',
+		MediaFile: 'Mediabestanden',
+		XElement: 'Overig',
+		LanguageHandler: 'Talen',
+		DictionaryHandler: 'Woordenboekitems',
+		DataTypeHandler: 'Gegevenstypen',
+		TemplateHandler: 'Sjablonen',
+		ContentTypeHandler: 'Inhoudstypen',
+		MediaTypeHandler: 'Mediatypen',
+		MemberTypeHandler: 'Ledentypen',
+		ContentHandler: 'Inhoud',
+		MediaHandler: 'Media',
+		RelationTypeHandler: 'Relatietypen',
+		EntityContainer: 'Containers',
+	},
+	USyncSettings: {
+		settings: 'uSync-instellingen',
+		filesAndFolders: 'Bestanden en mappen',
+		handlerDefaults: 'Handler-standaardwaarden',
+
+		processingMode: 'Verwerkingsmodus',
+		processingModeDesc:
+			'Hoe het uSync-proces wordt uitgevoerd, op de achtergrond of interactief (Normaal)',
+
+		importAtStartup: 'Importeren bij opstarten',
+		importAtStartupDesc: 'Een import van bestanden van de schijf uitvoeren wanneer Umbraco start',
+
+		exportAtStartup: 'Exporteren bij opstarten',
+		exportAtStartupDesc: 'De Umbraco-instellingen exporteren wanneer de site opstart',
+
+		exportOnSave: 'Exporteren bij opslaan',
+		exportOnSaveDesc: 'uSync-bestanden genereren wanneer items worden opgeslagen',
+
+		uiEnabledGroups: 'UI-ingeschakelde groepen',
+		uiEnabledGroupsDesc: 'Handlergroepen die zichtbaar/bruikbaar zijn op het dashboard',
+
+		failOnMissingParent: 'Fout bij ontbrekend bovenliggend item',
+		failOnMissingParentDesc: 'Fout bij ontbrekend bovenliggend item',
+
+		currentHandlerSet: 'Huidige set',
+
+		handlerSet: 'Standaard handlerset',
+		handlerSetDesc: 'De standaard handlerset voor de site',
+
+		flatStructure: 'Platte structuur',
+		flatStructureDesc: 'Alle items van een type worden opgeslagen in een platte mappenstructuur',
+
+		guidNames: 'GUID\'s als bestandsnamen gebruiken',
+		guidNamesDesc: 'De GUID van een item als bestandsnaam gebruiken',
+
+		handlerGroups: 'Handlergroepen',
+		handlerGroupsDesc: 'Groepen om de handlerset te beperken',
+
+		disabledHandlers: 'Uitgeschakelde handlers',
+		disabledHandlersDesc: 'Handlers die expliciet zijn uitgeschakeld voor deze handlerset',
+
+		folders: 'Mappen',
+		foldersDesc:
+			'Mappen waarin uSync naar bestanden zoekt (items worden normaal opgeslagen in de laatste map in de lijst)',
+
+		rootSite: 'Rootsite',
+		rootSiteDesc: 'Is deze site een root voor andere sites.',
+
+		rootLocked: 'Root vergrendeld',
+		rootLockedDesc: 'Zijn wijzigingen voor items van de rootsite vergrendeld?',
+
+		help: 'Instellingen worden beheerd via het bestand appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Zie onze documentatie</a>',
+
+		bootSettings: 'Instellingen voor eerste opstart 🥾',
+
+		firstBoot: 'Importeren bij eerste opstart',
+		firstBootDesc: 'Het importproces uitvoeren bij de eerste opstart van de site',
+
+		firstBootGroup: 'Groepen voor eerste opstart',
+		firstBootGroupDesc: 'De groepen die worden uitgevoerd bij de eerste opstart',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync voor alles',
 
+		migrate: 'Migreren',
+		defaultView: 'Standaard',
+		settingsView: 'Instellingen',
+		addons: 'Add-ons',
+
+		groupEverything: 'Alles',
+		groupContent: 'Inhoud',
+		groupSettings: 'Instellingen',
+		groupForms: 'Formulieren',
+		groupMedia: 'Media',
+		groupMembers: 'Leden',
+
 		Report: 'Rapport',
 		Import: 'Importeren',
 		Export: 'Exporteren',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/manifest.ts
@@ -9,6 +9,56 @@ const localizations: Array<UmbExtensionManifest> = [
 		},
 		js: () => import('./files/en-us'),
 	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.dadk',
+		name: 'Danish',
+		weight: 0,
+		meta: {
+			culture: 'da',
+		},
+		js: () => import('./files/da-dk'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.frfr',
+		name: 'French',
+		weight: 0,
+		meta: {
+			culture: 'fr',
+		},
+		js: () => import('./files/fr-fr'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.eses',
+		name: 'Spanish',
+		weight: 0,
+		meta: {
+			culture: 'es',
+		},
+		js: () => import('./files/es-es'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.dede',
+		name: 'German',
+		weight: 0,
+		meta: {
+			culture: 'de',
+		},
+		js: () => import('./files/de-de'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.nlnl',
+		name: 'Dutch',
+		weight: 0,
+		meta: {
+			culture: 'nl',
+		},
+		js: () => import('./files/nl-nl'),
+	},
 ];
 
 export const manifests: UmbExtensionManifest[] = [...localizations];

--- a/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
@@ -64,7 +64,7 @@ const menuSidebarApp: UmbExtensionManifest = {
 	name: 'uSync section sidebar menu',
 	weight: 150,
 	meta: {
-		label: 'Synchronisation',
+		label: '#uSync_section',
 		menu: menu.alias,
 	},
 	conditions: [

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/components/usync-action-button.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/components/usync-action-button.ts
@@ -42,7 +42,7 @@ export class SyncActionButtonElement extends UmbLitElement {
 				<uui-button
 					class="action-button"
 					.disabled=${this.disabled}
-					label=${this.localize.term(`uSync_${this.button?.label}`)}
+					label=${this.localize.termOrDefault(`uSync_${this.button?.label}`, this.button?.label ?? '')}
 					color=${<UUIInterfaceColor>this.button?.color}
 					look=${<UUIInterfaceLook>this.button?.look}
 					state=${ifDefined(this.state)}
@@ -63,7 +63,7 @@ export class SyncActionButtonElement extends UmbLitElement {
 		const buttons = this.button?.children.map((item: SyncActionButton) => {
 			return html` <uui-menu-item
 				.disabled=${this.disabled}
-				.label=${this.localize.term(`uSync_${item.label}`)}
+				.label=${this.localize.termOrDefault(`uSync_${item.label}`, item.label)}
 				@click-label=${() => this.#onClick(item)}></uui-menu-item>`;
 		});
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/dialogs/import-modal.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/dialogs/import-modal.element.ts
@@ -29,7 +29,7 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 
 	render() {
 		return html`
-			<umb-body-layout .headline=${this.localize.term('uSync_importHeader')}>
+			<umb-body-layout .headline=${this.localize.termOrDefault('uSync_importHeader', 'Import from file')}>
 				${this.renderForm()} ${this.renderResult()}
 			</umb-body-layout>
 		`;
@@ -38,7 +38,7 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 	renderForm() {
 		if (this.result !== undefined) return;
 
-		return html` ${this.localize.term('uSync_uploadIntro')}
+		return html` ${this.localize.termOrDefault('uSync_uploadIntro', 'Select a zip file containing uSync files that you want to upload')}
 			<usync-file-upload @uploaded=${this.#onUploaded}></usync-file-upload>
 			<div slot="actions">
 				<uui-button
@@ -53,8 +53,8 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 
 		return html`${when(
 				this.result.success,
-				() => html`${this.localize.term('uSync_uploadSuccess')}`,
-				() => html`${this.localize.term('uSync_uploadError')} ${this.result?.errors}`,
+				() => html`${this.localize.termOrDefault('uSync_uploadSuccess', 'The files have been uploaded and extracted to the uSync folder')}`,
+				() => html`${this.localize.termOrDefault('uSync_uploadError', 'There was an error uploading the files')} ${this.result?.errors}`,
 			)}
 			<div slot="actions">
 				<uui-button id="continue" label="Import" @click="${this.#onImport}"></uui-button>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/manifest.ts
@@ -38,7 +38,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/default/default.element.js'),
 		weight: 300,
 		meta: {
-			label: 'Default',
+			label: '#uSync_defaultView',
 			pathname: 'default',
 			icon: 'usync-logo',
 		},
@@ -56,7 +56,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/settings/settings.element.js'),
 		weight: 200,
 		meta: {
-			label: 'Settings',
+			label: '#uSync_settingsView',
 			pathname: 'settings',
 			icon: 'icon-settings',
 		},
@@ -74,7 +74,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/addons/addons.element.js'),
 		weight: 100,
 		meta: {
-			label: 'AddOns',
+			label: '#uSync_addons',
 			pathname: 'addons',
 			icon: 'icon-box',
 		},
@@ -92,7 +92,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/legacy/legacy.element.js'),
 		weight: 150,
 		meta: {
-			label: 'Migrate',
+			label: '#uSync_migrate',
 			pathname: 'legacy',
 			icon: 'icon-arrow-up',
 		},

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
@@ -243,11 +243,11 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 
 		return html`<div class="set-picker">
 			<label for="set-select"
-				>${this.localize.term('USyncSettings_currentHandlerSet')}</label
+				>${this.localize.termOrDefault('USyncSettings_currentHandlerSet', 'Current Set')}</label
 			>
 			<uui-select
 				id="set-select"
-				.label=${this.localize.term('USyncSettings_currentHandlerSet')}
+				.label=${this.localize.termOrDefault('USyncSettings_currentHandlerSet', 'Current Set')}
 				.options=${options}
 				@change=${(e: Event) => {
 					const select = e.target as HTMLSelectElement;
@@ -264,7 +264,7 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 			: html`
 					<div class="legacy-banner">
 						<umb-icon name="icon-alert"></umb-icon>
-						${this.localize.term('uSync_legacyBanner')}
+						${this.localize.termOrDefault('uSync_legacyBanner', 'This site contains files from a previous version of uSync, view the details in the legacy tab.')}
 					</div>
 				`;
 	}
@@ -333,15 +333,15 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 		if (!this._connected) {
 			return html` <uui-box class="banner warning">
 				<uui-icon name="icon-alert"></uui-icon>
-				${this.localize.term('uSync_runningInBackground')}
+				${this.localize.termOrDefault('uSync_runningInBackground', 'uSync is running this process in background, if you navigate away from this page it will continue to run.')}
 				<br />
-				${this.localize.term('uSync_connectionLost')}
+				${this.localize.termOrDefault('uSync_connectionLost', 'the connection to the server has been lost, the process will continue to run in the background but you will not see updates here.')}
 			</uui-box>`;
 		}
 
 		return html`<uui-box class="banner info">
 			<uui-icon name="icon-info"></uui-icon>
-			${this.localize.term('uSync_runningInBackground')}
+			${this.localize.termOrDefault('uSync_runningInBackground', 'uSync is running this process in background, if you navigate away from this page it will continue to run.')}
 		</uui-box>`;
 	}
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/legacy/legacy.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/legacy/legacy.element.ts
@@ -42,12 +42,8 @@ export class SyncLegacyFilesElement extends UmbLitElement {
 
 		const confirmContext = modalContext?.open(this, UMB_CONFIRM_MODAL, {
 			data: {
-				headline: this.localize.term('uSync_legacyCopyTitle', [
-					this._legacy?.latestVersion,
-				]),
-				content: html`${this.localize.term('uSync_legacyCopyContent', [
-					this._legacy?.latestFolder,
-				])}`,
+				headline: this.localize.termOrDefault('uSync_legacyCopyTitle', 'Overwrite files', this._legacy?.latestVersion),
+				content: html`${this.localize.termOrDefault('uSync_legacyCopyContent', 'Are you sure you want to overwrite the contents of the folder with the legacy uSync folder files?', this._legacy?.latestFolder)}`,
 				color: 'danger',
 				confirmLabel: 'Copy',
 			},
@@ -68,8 +64,8 @@ export class SyncLegacyFilesElement extends UmbLitElement {
 		const modalContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 		const confirmContext = modalContext?.open(this, UMB_CONFIRM_MODAL, {
 			data: {
-				headline: this.localize.term('uSync_legacyIgnoreTitle'),
-				content: html`${this.localize.term('uSync_legacyIgnoreContent')}`,
+				headline: this.localize.termOrDefault('uSync_legacyIgnoreTitle', 'Ignore legacy files'),
+				content: html`${this.localize.termOrDefault('uSync_legacyIgnoreContent', 'Are you sure you want to ignore the files in the legacy uSync folder?')}`,
 				color: 'danger',
 				confirmLabel: 'Ignore',
 			},

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
@@ -49,105 +49,107 @@ export class USyncSettingsViewElement extends UmbElementMixin(LitElement) {
 			<umb-body-layout>
 				<div class="usync-settings-layout">
 					<div>
-						<uui-box headline=${this.localize.term('USyncSettings_settings')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_settings', 'uSync Settings')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_processingMode')}
-								.description=${this.localize.term('USyncSettings_processingModeDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_processingMode', 'Processing Mode')}
+								.description=${this.localize.termOrDefault('USyncSettings_processingModeDesc', 'How the uSync process runs, either in the background or interactively (Normal)')}
 								.value=${this.settings?.processingMode}></usync-setting-item>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_importAtStartup')}
-								.description=${this.localize.term('USyncSettings_importAtStartupDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_importAtStartup', 'Import at startup')}
+								.description=${this.localize.termOrDefault('USyncSettings_importAtStartupDesc', 'Run an import of files from the disk when Umbraco starts')}
 								.value=${this.settings?.importAtStartup}></usync-setting-item>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_exportAtStartup')}
-								.description=${this.localize.term('USyncSettings_exportAtStartupDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_exportAtStartup', 'Export at startup')}
+								.description=${this.localize.termOrDefault('USyncSettings_exportAtStartupDesc', 'Export the Umbraco settings when the site starts up')}
 								.value=${this.settings?.exportAtStartup}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_exportOnSave')}
-								.description=${this.localize.term('USyncSettings_exportOnSaveDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_exportOnSave', 'Export on save')}
+								.description=${this.localize.termOrDefault('USyncSettings_exportOnSaveDesc', 'Generate uSync files when items are saved')}
 								.value=${this.settings?.exportOnSave}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_uiEnabledGroups')}
-								.description=${this.localize.term('USyncSettings_uiEnabledGroupsDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_uiEnabledGroups', 'UI Enabled groups')}
+								.description=${this.localize.termOrDefault('USyncSettings_uiEnabledGroupsDesc', 'Handler groups that can be seen/used on the dashboard')}
 								.value=${this.settings?.uiEnabledGroups}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_failOnMissingParent')}
-								.description=${this.localize.term(
+								.name=${this.localize.termOrDefault('USyncSettings_failOnMissingParent', 'Fail on missing parent')}
+								.description=${this.localize.termOrDefault(
 									'USyncSettings_failOnMissingParentDesc',
+									'Fail on missing parent',
 								)}
 								.value=${this.settings?.failOnMissingParent}></usync-setting-item>
 						</uui-box>
 
-						<uui-box headline=${this.localize.term('USyncSettings_filesAndFolders')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_filesAndFolders', 'File and folders')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_rootSite')}
-								.description=${this.localize.term('USyncSettings_rootSiteDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_rootSite', 'Root Site')}
+								.description=${this.localize.termOrDefault('USyncSettings_rootSiteDesc', 'Is this site a root for other sites.')}
 								.value=${this.settings?.isRootSite}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_rootLocked')}
-								.description=${this.localize.term('USyncSettings_rootLockedDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_rootLocked', 'Root Locked')}
+								.description=${this.localize.termOrDefault('USyncSettings_rootLockedDesc', 'Are changes for items that are from the root site locked?')}
 								.value=${this.settings?.lockRoot}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_folders')}
-								.description=${this.localize.term('USyncSettings_foldersDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_folders', 'Folders')}
+								.description=${this.localize.termOrDefault('USyncSettings_foldersDesc', 'Folders uSync will look for files, (items are normally saved into last folder in the list)')}
 								.value=${this.settings?.folders}></usync-setting-item>
 						</uui-box>
 					</div>
 
 					<div>
-						<uui-box headline=${this.localize.term('USyncSettings_handlerDefaults')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_handlerDefaults', 'Handler defaults')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_handlerSet')}
-								.description=${this.localize.term('USyncSettings_handlerSetDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_handlerSet', 'Default handler set')}
+								.description=${this.localize.termOrDefault('USyncSettings_handlerSetDesc', 'The default handler set to use for the site')}
 								.value=${this.settings?.defaultSet}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_flatStructure')}
-								.description=${this.localize.term('USyncSettings_flatStructureDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_flatStructure', 'Flat structure')}
+								.description=${this.localize.termOrDefault('USyncSettings_flatStructureDesc', 'All items of a type are stored in a flat folder structure')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.useFlatStructure}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_guidNames')}
-								.description=${this.localize.term('USyncSettings_guidNamesDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_guidNames', 'Use guids for filenames')}
+								.description=${this.localize.termOrDefault('USyncSettings_guidNamesDesc', 'Use the GUID of an item as the filename')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.guidNames}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_handlerGroups')}
-								.description=${this.localize.term('USyncSettings_handlerGroupsDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_handlerGroups', 'Handler groups')}
+								.description=${this.localize.termOrDefault('USyncSettings_handlerGroupsDesc', 'Groups to limit handler set to')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.group}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_failOnMissingParent')}
-								.description=${this.localize.term(
+								.name=${this.localize.termOrDefault('USyncSettings_failOnMissingParent', 'Fail on missing parent')}
+								.description=${this.localize.termOrDefault(
 									'USyncSettings_failOnMissingParentDesc',
+									'Fail on missing parent',
 								)}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.failOnMissingParent}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_disabledHandlers')}
-								.description=${this.localize.term('USyncSettings_disabledHandlersDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_disabledHandlers', 'Disabled Handlers')}
+								.description=${this.localize.termOrDefault('USyncSettings_disabledHandlersDesc', 'Handlers explicitly disabled for this handler set')}
 								.value=${this.handlerSettings?.disabledHandlers}></usync-setting-item>
 						</uui-box>
-						<uui-box headline=${this.localize.term('USyncSettings_bootSettings')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_bootSettings', 'First boot settings')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_firstBoot')}
-								.description=${this.localize.term('USyncSettings_firstBootDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_firstBoot', 'Import on First boot')}
+								.description=${this.localize.termOrDefault('USyncSettings_firstBootDesc', 'Run the import process on first boot of the site')}
 								.value=${this.settings?.importOnFirstBoot}></usync-setting-item>
 							${when(
 								this.settings?.importOnFirstBoot,
 								() =>
 									html` <usync-setting-item
-										.name=${this.localize.term('USyncSettings_firstBootGroup')}
-										.description=${this.localize.term('USyncSettings_firstBootGroupDesc')}
+										.name=${this.localize.termOrDefault('USyncSettings_firstBootGroup', 'First boot groups')}
+										.description=${this.localize.termOrDefault('USyncSettings_firstBootGroupDesc', 'The groups to run on first boot')}
 										.value=${this.settings?.firstBootGroup}></usync-setting-item>`,
 							)}
 						</uui-box>


### PR DESCRIPTION
## Summary

- Replace all uSync-owned `localize.term()` calls with `localize.termOrDefault()`, supplying the English text as a fallback so the UI renders correctly before the localization system has fully loaded
- Umbraco core keys (e.g. `general_close`) are left as plain `localize.term()` calls since those are guaranteed by every Umbraco installation
- Add full translations for Danish, French, Spanish, German, and Dutch covering all `uSync_` and `USyncSettings_` keys
- Register all five new locales in the lang manifest

## New translation files
- `da-dk.ts` — Danish
- `fr-fr.ts` — French
- `es-es.ts` — Spanish
- `de-de.ts` — German
- `nl-nl.ts` — Dutch

## Test plan
- [ ] Verify UI renders correctly in English with no localization loaded
- [ ] Switch Umbraco backoffice language to each of the five new locales and confirm strings appear translated
- [ ] Confirm `general_close` and other Umbraco core keys still resolve correctly