### PR TITLE
Consolidate object conversions onto TryGetValueAs (JsonElement pre-check)

### DIFF
--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -93,7 +93,7 @@ public static class HandlerSettingsExtensions
     {
         if (settings.Settings != null && settings.Settings.TryGetValue(key, out var value) && value is not null)
         {
-            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+            if (value.TryGetValueAs<TResult>(out var result) && result is not null)
                 return result;
         }
 

--- a/uSync.Core/Extensions/ConversionExtensions.cs
+++ b/uSync.Core/Extensions/ConversionExtensions.cs
@@ -4,7 +4,7 @@ internal static class ConversionExtensions
     public static TObject? GetValueAs<TObject>(this object value)
     {
         if (value == null) return default;
-        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
+        return value.TryGetValueAs<TObject>(out var result) ? result : default;
     }
 
     public static Guid ConvertToGuid(this int value)

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -430,6 +430,38 @@ public static class JsonTextExtensions
         return true;
     }
 
+    /// <summary>
+    ///  Convert a value to the requested runtime type.
+    /// </summary>
+    /// <remarks>
+    ///  Non-generic companion to the generic TryGetValueAs for callers that only
+    ///  have a runtime Type. Same JsonElement pre-check.
+    /// </remarks>
+    public static bool TryGetValueAs(this object? value, Type targetType, [MaybeNullWhen(false)] out object result)
+    {
+        result = default;
+        if (value is null) return false;
+
+        if (value is JsonElement element && targetType != typeof(string))
+        {
+            try
+            {
+                result = element.Deserialize(targetType, _defaultOptions);
+                if (result is not null) return true;
+            }
+            catch
+            {
+                // not something STJ could convert directly - fall back to TryConvertTo below.
+            }
+        }
+
+        var attempt = value.TryConvertTo(targetType);
+        if (attempt.Success is false || attempt.Result is null) return false;
+
+        result = attempt.Result;
+        return true;
+    }
+
     #endregion
 
     #region property getters 
@@ -491,8 +523,7 @@ public static class JsonTextExtensions
         if (obj.TryGetPropertyValue(propertyName, out var value) is false || value is null)
             return defaultValue;
 
-        var attempt = value.TryConvertTo<TResult>();
-        return attempt.ResultOr(defaultValue);
+        return value.TryGetValueAs<TResult>(out var result) ? result : defaultValue;
     }
 
     public static bool TryGetPropertyAsArray(this JsonObject jsonObject, string propertyName, [MaybeNullWhen(false)] out JsonArray result)

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -390,34 +390,27 @@ public static class JsonTextExtensions
     public static string SerializeJsonString(this object value, bool indent = true)
         => value is null ? string.Empty : JsonSerializer.Serialize(value, indent ? _defaultOptions : _flatOptions);
 
-    private static bool TryGetValueAs<TObject>(this object value, [MaybeNullWhen(false)] out TObject result)
-    {
-        result = default;
-        if (value == null) return false;
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt is false || attempt.Result is null) return attempt;
-        result = attempt.Result;
-        return true;
-    }
-
     /// <summary>
-    ///  Convert a value to the requested type, pre-empting the first-chance
-    ///  InvalidCastException that Umbraco's TryConvertTo throws when converting
-    ///  a JsonElement to a value type (see uSync.Complete issue #304).
+    ///  Convert a value to the requested type.
     /// </summary>
     /// <remarks>
-    ///  Settings/config values often arrive as JsonElement (bound from appsettings.json).
-    ///  Asking Umbraco's TryConvertTo to turn one into e.g. a bool throws (and swallows)
-    ///  an InvalidCastException every call - harmless, but noisy and slow when a debugger
-    ///  is attached. Doing the JsonElement conversion with System.Text.Json first means the
-    ///  common path never throws; anything STJ can't handle still falls back to TryConvertTo.
+    ///  Pre-empts the first-chance InvalidCastException that Umbraco's TryConvertTo
+    ///  throws when converting a JsonElement to a value type (see uSync.Complete
+    ///  issue #304). Settings/config values often arrive as JsonElement (bound from
+    ///  appsettings.json); doing that conversion with System.Text.Json first means the
+    ///  common path never throws. String conversions (which TryConvertTo already
+    ///  handles cleanly) and anything STJ can't handle still fall back to TryConvertTo.
     /// </remarks>
-    public static bool TryConvertPreChecked<TObject>(this object? value, [MaybeNullWhen(false)] out TObject result)
+    public static bool TryGetValueAs<TObject>(this object? value, [MaybeNullWhen(false)] out TObject result)
     {
         result = default;
         if (value is null) return false;
 
-        if (value is JsonElement element)
+        // Umbraco's TryConvertTo turns a JsonElement into a string cleanly, but throws
+        // (and swallows) an InvalidCastException for JsonElement -> value type. Do the
+        // value-type conversion with System.Text.Json first to avoid that noise; string
+        // and anything STJ can't handle fall through to TryConvertTo below.
+        if (value is JsonElement element && typeof(TObject) != typeof(string))
         {
             try
             {

--- a/uSync.Core/Extensions/ListExtensions.cs
+++ b/uSync.Core/Extensions/ListExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.Core;
 
 public static class ListExtensions
@@ -40,10 +42,9 @@ public static class ListExtensions
         foreach (var item in items)
         {
             if (string.IsNullOrWhiteSpace(item)) continue;
-            var attempt = item.TryConvertTo<T>();
-            if (attempt.Success && attempt.Result is not null)
+            if (item.TryGetValueAs<T>(out var result))
             {
-                yield return attempt.Result;
+                yield return result;
             }
         }
     }

--- a/uSync.Core/Extensions/ObjectPropertyExtensions.cs
+++ b/uSync.Core/Extensions/ObjectPropertyExtensions.cs
@@ -75,11 +75,6 @@ public static class ObjectPropertyExtensions
         var value = info.GetValue(property);
         if (value == null) return defaultValue;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result ?? defaultValue;
-
-        return defaultValue;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : defaultValue;
     }
 }

--- a/uSync.Core/Extensions/XElementExtensions.cs
+++ b/uSync.Core/Extensions/XElementExtensions.cs
@@ -5,6 +5,8 @@ using System.Xml.Linq;
 
 using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.Core;
 
 public static class XElementExtensions
@@ -138,11 +140,7 @@ public static class XElementExtensions
         var value = node.ValueOrDefault(string.Empty);
         if (value == string.Empty) return defaultValue;
 
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt)
-            return attempt.Result ?? defaultValue;
-
-        return defaultValue;
+        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
 
 
@@ -209,8 +207,7 @@ public static class XElementExtensions
     {
         if (node is null) return;
 
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success)
+        if (value.TryGetValueAs<string>(out var stringValue))
         {
             var element = node.Element(name);
             if (element is null)
@@ -219,7 +216,7 @@ public static class XElementExtensions
                 node.Add(element);
             }
 
-            element.Value = attempt.Result ?? string.Empty;
+            element.Value = stringValue ?? string.Empty;
         }
     }
 
@@ -289,11 +286,7 @@ public static class XElementExtensions
         var value = attribute.ValueOrDefault(string.Empty);
         if (value == string.Empty) return defaultValue;
 
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt)
-            return attempt.Result ?? defaultValue;
-
-        return defaultValue;
+        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
     #endregion
 

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -88,9 +88,8 @@ public class MediaPicker3Mapper : SyncValueMapperBase, ISyncMapper
     {
         if (obj != null && obj.ContainsKey(key))
         {
-            var attempt = obj[key]?.ToString().TryConvertTo<Guid>();
-            if (attempt?.Success is true)
-                return attempt?.Result ?? Guid.Empty;
+            if (obj[key]?.ToString().TryGetValueAs<Guid>(out var guid) is true)
+                return guid;
         }
 
         return Guid.Empty;

--- a/uSync.Core/Mapping/Mappers/MemberGroupPickerManager.cs
+++ b/uSync.Core/Mapping/Mappers/MemberGroupPickerManager.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 using uSync.Core.Dependency;
+using uSync.Core.Extensions;
 using uSync.Core.Serialization;
 
 using static Umbraco.Cms.Core.Constants;
@@ -30,11 +31,10 @@ public class MemberGroupPickerMapper : SyncValueMapperBase, ISyncMapper
     /// </summary>
     public override async Task<string?> GetExportValueAsync(object value, string editorAlias)
     {
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success is false || attempt.Result is null)
+        if (value.TryGetValueAs<string>(out var stringValue) is false)
             return await base.GetExportValueAsync(value, editorAlias);
 
-        var values = attempt.Result.ToDelimitedList().ConvertItems<int>();
+        var values = stringValue.ToDelimitedList().ConvertItems<int>();
 
         var groups = new List<string>();
 
@@ -86,11 +86,10 @@ public class MemberGroupPickerMapper : SyncValueMapperBase, ISyncMapper
             return Enumerable.Empty<uSyncDependency>();
 
         // get the int value and load the group
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success is false || attempt.Result is null) 
+        if (value.TryGetValueAs<string>(out var stringValue) is false)
             return await base.GetDependenciesAsync(value, editorAlias, flags);
 
-        var values = attempt.Result.ToDelimitedList().ConvertItems<int>();
+        var values = stringValue.ToDelimitedList().ConvertItems<int>();
 
         var dependencies = new List<uSyncDependency>();
 

--- a/uSync.Core/Mapping/SyncValueMapperBase.cs
+++ b/uSync.Core/Mapping/SyncValueMapperBase.cs
@@ -115,7 +115,7 @@ public abstract class SyncValueMapperBase
     protected static TObject? GetValueAs<TObject>(object value)
     {
         if (value == null) return default;
-        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
+        return value.TryGetValueAs<TObject>(out var result) ? result : default;
     }
 }
 

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -706,8 +706,8 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         if (current != null && newValue != null && current.GetType() != newValue.GetType())
         {
             var currentType = current.GetType();
-            var attempt = newValue.TryConvertTo(currentType);
-            if (attempt.Success) return !current.Equals(attempt.Result);
+            if (newValue.TryGetValueAs(currentType, out var converted))
+                return !current.Equals(converted);
         }
 
         return true;

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -727,19 +727,18 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         if (propertyInfo != null)
         {
             var value = node.Element(propertyName).ValueOrDefault(string.Empty);
-            var attempt = value.TryConvertTo<TValue>();
-            if (attempt.Success)
+            if (value.TryGetValueAs<TValue>(out var converted))
             {
                 var current = ContentTypeBaseSerializer<TObject>.GetPropertyAs<TValue>(propertyInfo, property);
 
-                if (current == null || !current.Equals(attempt.Result))
+                if (current == null || !current.Equals(converted))
                 {
-                    propertyInfo.SetValue(property, attempt.Result);
+                    propertyInfo.SetValue(property, converted);
 
                     return uSyncChange.Update($"property/{propertyName}",
                         propertyName,
                         current.ToNonBlankValue(),
-                        attempt.Result?.ToString());
+                        converted?.ToString());
                 }
             }
         }
@@ -754,12 +753,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         var value = info.GetValue(property);
         if (value == null) return default;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result;
-
-        return default;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : default;
     }
 
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -153,17 +153,15 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         {
             var value = propertyInfo.GetValue(property);
 
-            var attempt = value.TryConvertTo<TValue>();
-            if (attempt.Success)
+            // TryGetValueAs treats a null conversion result as failure, so fall back
+            // to an empty element - the property still gets recorded in the xml.
+            if (value.TryGetValueAs<TValue>(out var converted))
             {
-                if (attempt.Result != null)
-                {
-                    node.Add(new XElement(propertyName, attempt.Result));
-                }
-                else
-                {
-                    node.Add(new XElement(propertyName, string.Empty));
-                }
+                node.Add(new XElement(propertyName, converted));
+            }
+            else
+            {
+                node.Add(new XElement(propertyName, string.Empty));
             }
         }
     }

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -409,15 +409,14 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
                 var current = GetPropertyAs<string>(property, historyCleanup);
                 if (element.Value != current)
                 {
-                    // now set it. 
-                    var updatedValue = element.Value.TryConvertTo(property.PropertyType);
-                    if (updatedValue.Success)
+                    // now set it.
+                    if (element.Value.TryGetValueAs(property.PropertyType, out var updatedValue))
                     {
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.LogDebug("Saving HistoryCleanup Value: {name} {value}", element.Name.LocalName, updatedValue.Result);
+                            logger.LogDebug("Saving HistoryCleanup Value: {name} {value}", element.Name.LocalName, updatedValue);
 
-                        changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current.ToNonBlankValue(), updatedValue.Result, $"{_historyCleanupName}/{element.Name.LocalName}");
-                        property.SetValue(historyCleanup, updatedValue.Result);
+                        changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current.ToNonBlankValue(), updatedValue, $"{_historyCleanupName}/{element.Name.LocalName}");
+                        property.SetValue(historyCleanup, updatedValue);
                     }
                 }
             }
@@ -451,11 +450,6 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
         var value = info.GetValue(property);
         if (value is null) return default;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result;
-
-        return default;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : default;
     }
 }

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -167,8 +167,7 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
 
         var result = property.GetValue(item);
 
-        var attempt = result.TryConvertTo<int>();
-        return attempt.Success ? attempt.Result : 0;
+        return result.TryGetValueAs<int>(out var sortable) ? sortable : 0;
     }
 
     /// <summary>

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -74,7 +74,7 @@ public class SyncSerializerOptions
     {
         if (this.Settings?.TryGetValue(key, out var value) is true && value is not null)
         {
-            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+            if (value.TryGetValueAs<TResult>(out var result) && result is not null)
                 return result;
         }
 

--- a/uSync.Tests/Extensions/TryGetValueAsTests.cs
+++ b/uSync.Tests/Extensions/TryGetValueAsTests.cs
@@ -13,14 +13,14 @@ namespace uSync.Tests.Extensions;
 ///  (uSync.Complete issue #304).
 /// </summary>
 [TestFixture]
-internal class TryConvertPreCheckedTests
+internal class TryGetValueAsTests
 {
     [Test]
     public void JsonElementTrue_ConvertsToBool()
     {
         object value = JsonSerializer.SerializeToElement(true);
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -34,7 +34,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement(false);
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -48,7 +48,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement(42);
 
-        var success = value.TryConvertPreChecked<int>(out var result);
+        var success = value.TryGetValueAs<int>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -63,7 +63,7 @@ internal class TryConvertPreCheckedTests
         var guid = Guid.NewGuid();
         object value = JsonSerializer.SerializeToElement(guid.ToString());
 
-        var success = value.TryConvertPreChecked<Guid>(out var result);
+        var success = value.TryGetValueAs<Guid>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -77,7 +77,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement("hello");
 
-        var success = value.TryConvertPreChecked<string>(out var result);
+        var success = value.TryGetValueAs<string>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -93,7 +93,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = "42";
 
-        var success = value.TryConvertPreChecked<int>(out var result);
+        var success = value.TryGetValueAs<int>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -107,7 +107,7 @@ internal class TryConvertPreCheckedTests
     {
         object? value = null;
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {


### PR DESCRIPTION
Follow-up to #986 (now merged).

## What & why

#986 added a JsonElement pre-check to avoid the swallowed `InvalidCastException` Umbraco's `TryConvertTo` throws on `JsonElement → value type`. This PR consolidates **all** the ad-hoc `object → T` conversions in uSync onto a single method, `TryGetValueAs`, so they consistently get that pre-check. After this PR, `TryConvertTo` is called in exactly one place — inside `TryGetValueAs` itself.

## How it got here

**1. Combine into `TryGetValueAs`.** `JsonTextExtensions` already had a private `TryGetValueAs<T>` with essentially the same shape and a nicer name. Folded the pre-check into it, made it `public`, deleted the interim `TryConvertPreChecked`, and pointed the config/value wrappers at it.

**2. Route the remaining `TryConvertTo` calls through it,** and added a non-generic `Type` overload for the two callers that only have a runtime `Type` (`ContentTypeSerializer` history-cleanup; `ContentSerializerBase` value diff — the latter compares content property values that can be `JsonElement`, so it gets the pre-check too).

**3. Convert the last holdout, `SerializeNewProperty`,** so nothing is left on `TryConvertTo` outside the helper.

Converted sites: `ConversionExtensions`, `SyncValueMapperBase`, `SyncSerializerOptions`, `HandlerSettingsExtensions`, `XElementExtensions` (element/attribute `ValueOrDefault`, `CreateOrSetElement`), `ObjectPropertyExtensions`, `ListExtensions`, `JsonTextExtensions.GetPropertyValueOrDefault`, `MediaPicker3Mapper`, `MemberGroupPickerManager`, `DomainSerializer`, `ContentTypeSerializer`, `ContentTypeBaseSerializer` (incl. `SerializeNewProperty`).

## Two subtleties worth a look

**String targets skip the pre-check.** Umbraco's `TryConvertTo<string>` already turns a `JsonElement` into a string cleanly (via `ToString()`), whereas routing an object/array `JsonElement` through `Deserialize<string>` would *throw* — reintroducing the exact exception we're removing. So `TryGetValueAs` only applies the STJ path to value types (`bool`/`int`/`Guid`/…); `string` and anything STJ can't handle fall back to `TryConvertTo`.

**`SerializeNewProperty` and the empty element.** The old code used the `Attempt<T>` success-vs-null distinction to emit an *empty* `<element>` when conversion succeeded with a null result. `TryGetValueAs` treats null as failure, so the rewrite keeps the empty element in the `else` branch:
```csharp
if (value.TryGetValueAs<TValue>(out var converted))
    node.Add(new XElement(propertyName, converted));
else
    node.Add(new XElement(propertyName, string.Empty));
```
The only theoretical change is that the old hard-fail case (which wrote *nothing*) now writes an empty element — but that branch is effectively unreachable here: reflected value-type properties return boxed defaults rather than null, and `string` already took the empty-element path.

## Behaviour notes
- `TryGetValueAs` treats a null conversion result as failure (`false`). For the converted "…OrDefault"/getter sites this is equivalent — they defaulted on null anyway, and value-type targets have no null case.
- Non-`JsonElement` inputs are unchanged; they still go straight to `TryConvertTo`.

## Tests
137 pass (includes the conversion/cache tests from #986). Both `uSync.Core` and `uSync.BackOffice` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)