### PR TITLE
Optimise XElementExtensions value conversion and hashing

### DIFF
--- a/uSync.Core/Extensions/XElementExtensions.cs
+++ b/uSync.Core/Extensions/XElementExtensions.cs
@@ -138,7 +138,37 @@ public static class XElementExtensions
     public static TObject ValueOrDefault<TObject>([AllowNull] this XElement? node, TObject defaultValue)
     {
         var value = node.ValueOrDefault(string.Empty);
-        if (value == string.Empty) return defaultValue;
+        if (value.Length == 0) return defaultValue;
+
+        return value.ConvertOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    ///  Convert a non-empty string value to the requested type.
+    /// </summary>
+    /// <remarks>
+    ///  These getters are called for (almost) every attribute of every node during a
+    ///  report/import. The handful of value types actually used have direct, allocation
+    ///  free parsers that are much cheaper than routing through Umbraco's reflection based
+    ///  TryConvertTo. The typeof(TObject) == typeof(...) comparisons are folded to
+    ///  constants by the JIT per generic instantiation, so the branches have no runtime
+    ///  cost. Anything not matched falls through to TryGetValueAs.
+    /// </remarks>
+    private static TObject ConvertOrDefault<TObject>(this string value, TObject defaultValue)
+    {
+        if (typeof(TObject) == typeof(int))
+            return int.TryParse(value, out var i) ? (TObject)(object)i : defaultValue;
+
+        if (typeof(TObject) == typeof(Guid))
+            return Guid.TryParse(value, out var g) ? (TObject)(object)g : defaultValue;
+
+        if (typeof(TObject) == typeof(bool))
+            return bool.TryParse(value, out var b) ? (TObject)(object)b : defaultValue;
+
+        if (typeof(TObject).IsEnum)
+            return Enum.TryParse(typeof(TObject), value, true, out var e) && e is TObject enumValue
+                ? enumValue
+                : defaultValue;
 
         return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
@@ -284,9 +314,9 @@ public static class XElementExtensions
     public static TObject ValueOrDefault<TObject>([AllowNull] this XAttribute attribute, TObject defaultValue)
     {
         var value = attribute.ValueOrDefault(string.Empty);
-        if (value == string.Empty) return defaultValue;
+        if (value.Length == 0) return defaultValue;
 
-        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
+        return value.ConvertOrDefault(defaultValue);
     }
     #endregion
 
@@ -307,17 +337,17 @@ public static class XElementExtensions
     /// </remarks>
     public static async Task<string> MakePlatformSafeHashAsync(this XElement node)
     {
-        using (MemoryStream stream = new MemoryStream())
-        {
-            await node.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
-            stream.Seek(0, SeekOrigin.Begin);
+        using HashAlgorithm hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA1.Create() : MD5.Create();
 
-            using (HashAlgorithm hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA1.Create() : MD5.Create())
-            {
-                var hash = await hashAlgorithm.ComputeHashAsync(stream);
-                return Convert.ToHexStringLower(hash);
-            }
+        // stream the xml straight into the hash instead of buffering the whole
+        // serialized document into a MemoryStream first. CryptoStream feeds each
+        // written block to the algorithm as it arrives, so nothing is held in memory.
+        using (var cryptoStream = new CryptoStream(Stream.Null, hashAlgorithm, CryptoStreamMode.Write))
+        {
+            await node.SaveAsync(cryptoStream, SaveOptions.None, CancellationToken.None);
         }
+
+        return Convert.ToHexStringLower(hashAlgorithm.Hash!);
     }
 
 }


### PR DESCRIPTION
## What

Two hot-path optimisations in `XElementExtensions`, the value-getter helpers used throughout report/import.

### 1. `ValueOrDefault<TObject>` fast paths
The generic `ValueOrDefault<TObject>` (both the `XElement` and `XAttribute` overloads) previously routed every conversion through Umbraco's reflection-based `TryConvertTo`. In practice the only `TObject`s used are `int`, `Guid`, `bool` and the `SyncActionType` enum — all of which have direct, allocation-free parsers.

A shared `ConvertOrDefault<TObject>` helper now handles those with `int.TryParse` / `Guid.TryParse` / `bool.TryParse` / `Enum.TryParse`, falling back to `TryGetValueAs` for anything else. The `typeof(TObject) == typeof(...)` comparisons are JIT-folded to constants per generic instantiation, so there's no branching cost at runtime.

These getters (`GetLevel`, `GetKey`, `GetParentKey`, `GetItemSortOrder`, `GetEmptyAction`, `IsBlueprint`, …) run for almost every attribute of every node, so avoiding the reflection + swallowed-exception overhead adds up across a large sync.

### 2. `MakePlatformSafeHashAsync` streaming
Previously the whole serialised XML document was buffered into a growing `MemoryStream` before hashing. It now streams the XML straight through a `CryptoStream`, feeding each block to the hash algorithm as it's written — nothing is held in memory. The hashed byte sequence is identical (same `SaveAsync` call/options), so hashes remain stable across platforms.

## Testing
- `dotnet build uSync.Core` — succeeds (only pre-existing package/obsolete warnings).
- Full `uSync.Tests` suite: **137 passed, 0 failed**, including the `TryGetValueAs` tests that exercise the conversion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)