### PR TITLE
Perf: stream item keys for clean operations instead of full XML parse

### DIFF
--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -137,6 +137,16 @@ public interface ISyncFileService
     Task<XElement> LoadXElementAsync(string file);
 
     /// <summary>
+    ///  load just the item key (the Key attribute on the root element) from a file.
+    /// </summary>
+    /// <remarks>
+    ///  This streams the file and stops at the root element, so we don't pay the cost
+    ///  of parsing the whole document when all we need is the key (e.g. when working out
+    ///  which items live in a folder for a 'clean' operation).
+    /// </remarks>
+    Task<Guid> LoadKeyFromFileAsync(string file);
+
+    /// <summary>
     ///  merge all the files in the given folders into a single xml node, that can be bulk imported
     /// </summary>
     Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string fileName, string extension);

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -211,6 +211,51 @@ internal class SyncFileService : ISyncFileService
         }
     }
 
+    private static readonly XmlReaderSettings _keyReaderSettings = new()
+    {
+        CheckCharacters = false,
+        Async = true,
+        IgnoreWhitespace = true,
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+        DtdProcessing = DtdProcessing.Prohibit,
+    };
+
+    /// <inheritdoc/>
+    public async Task<Guid> LoadKeyFromFileAsync(string file)
+    {
+        EnsureFileExists(file);
+
+        try
+        {
+            using (var stream = OpenRead(file))
+            {
+                if (stream is null)
+                    throw new FileNotFoundException($"Cannot create stream for {file}");
+
+                using (var reader = XmlReader.Create(stream, _keyReaderSettings.Clone()))
+                {
+                    // move to the first (root) element and read its Key attribute,
+                    // we don't need to read any further into the document.
+                    while (await reader.ReadAsync())
+                    {
+                        if (reader.NodeType != XmlNodeType.Element) continue;
+
+                        var key = reader.GetAttribute(global::uSync.Core.uSyncConstants.Xml.Key);
+                        return Guid.TryParse(key, out var guid) ? guid : Guid.Empty;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Error while reading key from {file} {message}", file, ex.Message);
+            throw new Exception($"Error while reading key from {file}", ex);
+        }
+
+        return Guid.Empty;
+    }
+
     /// <inheritdoc/>
     public async Task SaveFileAsync(string filename, Stream stream)
     {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -99,9 +99,11 @@ public abstract class SyncHandlerBase<TObject>
 
     private async Task<Guid?> GetCleanParentKeyAsync(string cleanFile)
     {
-        var node = await syncFileService.LoadXElementAsync(cleanFile);
-        if (node.GetKey() == Guid.Empty) return Guid.Empty;
-        return (await GetCleanParentAsync(cleanFile))?.Key;
+        // stream the key rather than parsing the whole file, and reuse it for the
+        // parent lookup so we don't read the clean file a second time.
+        var key = await syncFileService.LoadKeyFromFileAsync(cleanFile);
+        if (key == Guid.Empty) return Guid.Empty;
+        return (await GetFromServiceAsync(key))?.Key;
     }
 
     /// <summary>

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -697,8 +697,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         foreach (var file in files)
         {
-            var node = await syncFileService.LoadXElementAsync(file);
-            var key = node.GetKey();
+            // we only need the key here, so stream it rather than parsing the whole file.
+            var key = await syncFileService.LoadKeyFromFileAsync(file);
             if (key != Guid.Empty)
             {
                 keySet.Add(key);
@@ -719,8 +719,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// </summary>
     protected async Task<TObject?> GetCleanParentAsync(string file)
     {
-        var node = await syncFileService.LoadXElementAsync(file);
-        var key = node.GetKey();
+        // we only need the key to find the parent, so stream it rather than parsing the whole file.
+        var key = await syncFileService.LoadKeyFromFileAsync(file);
         if (key == Guid.Empty) return default;
         return await GetFromServiceAsync(key);
     }


### PR DESCRIPTION
## What

The `clean` import path needs only the **Key** attribute for every item in a folder, but was fully parsing each `.config` file (`XElement.LoadAsync` with `PreserveWhitespace`) just to read it. On large content/media trees this is effectively a **second full file-IO + XML-parse pass** over the folder during any import that contains clean markers.

This is items **#2 and #4** from the performance review (redundant full re-parse pass in `GetFolderKeysAsync`, and reading a whole document to extract a single attribute).

## Changes

- Add `ISyncFileService.LoadKeyFromFileAsync(string file)` — streams the file with an `XmlReader`, reads the `Key` attribute off the root element and **stops**. No DOM allocation, no reading the rest of the document.
- Wire it into the clean path:
  - `SyncHandlerRoot.GetFolderKeysAsync` — the per-folder key scan (reads *every* file in the folder, recursively when not flat).
  - `SyncHandlerRoot.GetCleanParentAsync`.
  - `SyncHandlerBase.GetCleanParentKeyAsync` — additionally reuses the streamed key for the parent lookup instead of loading the clean file **twice**.

## Why it's safe / behaviour-preserving

- The root `Key` attribute is present on both normal item nodes and `uSyncEmpty` (delete/rename/clean) nodes, so streaming the root element returns the same value `node.GetKey()` did.
- Files whose root has no `Key` (e.g. plural `<Content**s**>` wrappers) still yield `Guid.Empty` and are skipped — same as before.
- Read errors still **throw**, so a corrupt file aborts the clean (no keys → no deletes) exactly as today, preserving the "super defensive about deletes" contract.

## Testing

- `dotnet build` clean.
- Full `uSync.Tests` suite: **137 passed, 0 failed**.

## Notes / follow-ups

- `SyncFileService.VerifyFolderAsync` (health-check path) also full-parses to read root name + key, but it needs additional node data and is a cold, one-off path — deliberately left out to keep this change focused.
- Deliberately **not** deriving folder keys from the already-merged in-memory nodes: the merged set is de-duplicated and excludes delete/rename markers, so it is not a safe substitute for the defensive on-disk key scan. Streaming keeps the on-disk scan authoritative while removing the parse cost.
- Next up per the review discussion: #3 (skip full-tree `CleanUpAsync` on flat+GUID saves) and #5 (child-items cache keyed by thread id). #1 (batched content/media save) deferred pending deeper testing of Umbraco batch-save behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)