### PR TITLE
Perf: scope handler runtime-cache per operation (#5) + skip clean-up scan on flat+guid (#3)

### DIFF
--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -264,75 +264,79 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     public async Task<IEnumerable<uSyncAction>> ImportAllAsync(string[] folders, HandlerSettings config, uSyncImportOptions options)
     {
         var cacheKey = PrepCaches();
-        runtimeCache.ClearByKey(cacheKey);
-
-        options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
-
-        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
-
-        options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
-
-        // create the update list with items.count space. this is the max size we need this list. 
-        List<uSyncAction> actions = new(items.Count);
-        List<ImportedItem<TObject>> updates = new(items.Count);
-        List<string> cleanMarkers = [];
-
-        int count = 0;
-        int total = items.Count;
-
-        options.Callbacks?.SetRange?.Invoke(count, total);
-
-        foreach (var item in items)
+        try
         {
-            count++;
+            options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
 
+            var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
 
-            var result = await ImportElementAsync(item.Node, item.FileName, config, options);
-            foreach (var attempt in result)
+            options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
+
+            // create the update list with items.count space. this is the max size we need this list.
+            List<uSyncAction> actions = new(items.Count);
+            List<ImportedItem<TObject>> updates = new(items.Count);
+            List<string> cleanMarkers = [];
+
+            int count = 0;
+            int total = items.Count;
+
+            options.Callbacks?.SetRange?.Invoke(count, total);
+
+            foreach (var item in items)
             {
-                if (attempt.Success)
+                count++;
+
+
+                var result = await ImportElementAsync(item.Node, item.FileName, config, options);
+                foreach (var attempt in result)
                 {
-                    if (attempt.Change == ChangeType.Clean)
+                    if (attempt.Success)
                     {
-                        cleanMarkers.Add(item.Path);
+                        if (attempt.Change == ChangeType.Clean)
+                        {
+                            cleanMarkers.Add(item.Path);
+                        }
+                        else if (attempt.Item is not null && attempt.Item is TObject update)
+                        {
+                            updates.Add(new ImportedItem<TObject>(item.Node, update));
+                        }
                     }
-                    else if (attempt.Item is not null && attempt.Item is TObject update)
-                    {
-                        updates.Add(new ImportedItem<TObject>(item.Node, update));
-                    }
+
+                    if (attempt.Change != ChangeType.Clean)
+                        actions.Add(attempt);
+                }
+            }
+
+            // clean up memory we didn't use in the update list.
+            updates.TrimExcess();
+
+            // bulk save?
+            if (updates.Count > 0)
+            {
+                if (options.Flags.HasFlag(SerializerFlags.DoNotSave))
+                {
+                    await serializer.SaveAsync(updates.Select(x => x.Item));
                 }
 
-                if (attempt.Change != ChangeType.Clean)
-                    actions.Add(attempt);
+                await PerformSecondPassImportsAsync(updates, actions, config, options.Callbacks?.Update);
             }
-        }
 
-        // clean up memory we didn't use in the update list. 
-        updates.TrimExcess();
-
-        // bulk save?
-        if (updates.Count > 0)
-        {
-            if (options.Flags.HasFlag(SerializerFlags.DoNotSave))
+            if (actions.All(x => x.Success) && cleanMarkers.Count > 0)
             {
-                await serializer.SaveAsync(updates.Select(x => x.Item));
+                await PerformImportCleanAsync(cleanMarkers, actions, config, options.Callbacks?.Update);
             }
 
-            await PerformSecondPassImportsAsync(updates, actions, config, options.Callbacks?.Update);
-        }
+            options.Callbacks?.Update?.Invoke("Done", 3, 3);
 
-        if (actions.All(x => x.Success) && cleanMarkers.Count > 0)
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("ImportAll: {count} items imported", actions.Count);
+
+            return actions;
+        }
+        finally
         {
-            await PerformImportCleanAsync(cleanMarkers, actions, config, options.Callbacks?.Update);
+            CleanCaches(cacheKey);
         }
-
-        CleanCaches(cacheKey);
-        options.Callbacks?.Update?.Invoke("Done", 3, 3);
-
-        if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("ImportAll: {count} items imported", actions.Count);
-
-        return actions;
     }
 
     /// <summary>
@@ -809,7 +813,19 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// Export all items to a give folder on the disk
     /// </summary>
     virtual public async Task<IEnumerable<uSyncAction>> ExportAllAsync(string[] folders, HandlerSettings settings, SyncUpdateCallback? callback)
-        => await ExportAllAsync(default, folders, settings, callback);
+    {
+        // scope the runtime cache (e.g. child-item lookups) to this export run, so the
+        // cache keys stay stable across async thread hops and are cleared when we're done.
+        var cacheKey = BeginCacheScope();
+        try
+        {
+            return await ExportAllAsync(default, folders, settings, callback);
+        }
+        finally
+        {
+            EndCacheScope(cacheKey);
+        }
+    }
 
 
     /// <summary>
@@ -1066,28 +1082,33 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         List<uSyncAction> actions = [];
 
         var cacheKey = PrepCaches();
-
-        callback?.Invoke("Calculating order", 1, 3);
-
-        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(callback));
-        var options = new uSyncImportOptions();
-
-        int count = 0;
-
-        foreach (var item in items)
+        try
         {
-            count++;
-            callback?.Invoke(Path.GetFileNameWithoutExtension(item.Path), count, items.Count);
-            actions.AddRange(await ReportElementAsync(item.Node, item.FileName, config, options));
+            callback?.Invoke("Calculating order", 1, 3);
+
+            var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(callback));
+            var options = new uSyncImportOptions();
+
+            int count = 0;
+
+            foreach (var item in items)
+            {
+                count++;
+                callback?.Invoke(Path.GetFileNameWithoutExtension(item.Path), count, items.Count);
+                actions.AddRange(await ReportElementAsync(item.Node, item.FileName, config, options));
+            }
+
+            callback?.Invoke("Validating Report", 2, 3);
+            var validationActions = await ReportMissingParentsAsync([.. actions]);
+            actions.AddRange(ReportDeleteCheck(uSyncConfig.GetWorkingFolder(), validationActions));
+
+            callback?.Invoke($"Done ({this.ItemType})", 3, 3);
+            return actions;
         }
-
-        callback?.Invoke("Validating Report", 2, 3);
-        var validationActions = await ReportMissingParentsAsync([.. actions]);
-        actions.AddRange(ReportDeleteCheck(uSyncConfig.GetWorkingFolder(), validationActions));
-
-        CleanCaches(cacheKey);
-        callback?.Invoke($"Done ({this.ItemType})", 3, 3);
-        return actions;
+        finally
+        {
+            CleanCaches(cacheKey);
+        }
     }
 
     /// <summary>
@@ -1577,6 +1598,13 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     ///  </remarks>
     protected virtual async Task CleanUpAsync(TObject item, string newFile, string folder)
     {
+        // when using a flat folder structure with guid file names, an item's file is always
+        // "{key}.{ext}" in the same folder - it never changes name or location - so there can
+        // never be a stale duplicate file to clean up. Skip the (recursive) folder scan, which
+        // otherwise runs on every save/move/delete. (Content/Media make the same check earlier.)
+        if (DefaultConfig.UseFlatStructure && DefaultConfig.GuidNames)
+            return;
+
         var physicalFile = syncFileService.GetAbsPath(newFile);
 
         var files = syncFileService.GetFiles(folder, $"*.{this.uSyncConfig.Settings.DefaultExtension}");
@@ -1969,32 +1997,70 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
 
     /// <summary>
-    ///  get the key for any caches we might call (thread based cache value)
+    ///  per-operation cache scope id.
+    /// </summary>
+    /// <remarks>
+    ///  this flows with the async operation (via AsyncLocal) so the runtime-cache keys
+    ///  stay stable even when a continuation resumes on a different thread. Previously the
+    ///  key was based on the managed thread id, which could change mid-operation across an
+    ///  await - defeating the cache (misses) and leaving orphaned entries in the shared
+    ///  runtime cache that the end-of-operation cleanup (running on another thread) missed.
+    ///
+    ///  when no operation scope is active (ad-hoc lookups) we fall back to the managed
+    ///  thread id, preserving the previous behavior for those callers.
+    /// </remarks>
+    private readonly AsyncLocal<string?> _cacheScope = new();
+
+    /// <summary>
+    ///  get the key for any caches we might call (scoped to the current operation)
     /// </summary>
     /// <returns></returns>
     protected string GetCacheKeyBase()
-        => $"keyCache_{this.Alias}_{Environment.CurrentManagedThreadId}";
+        => $"keyCache_{this.Alias}_{_cacheScope.Value ?? $"t{Environment.CurrentManagedThreadId}"}";
 
     private string PrepCaches()
     {
         if (this.serializer is ISyncCachedSerializer cachedSerializer)
             cachedSerializer.InitializeCache();
 
-        // make sure the runtime cache is clean.
-        var key = GetCacheKeyBase();
-
-        // this also clears the folder cache - as its a starts with call.
-        runtimeCache.ClearByKey(key);
-        return key;
+        return BeginCacheScope();
     }
 
     private void CleanCaches(string cacheKey)
     {
-        runtimeCache.ClearByKey(cacheKey);
+        EndCacheScope(cacheKey);
 
         if (this.serializer is ISyncCachedSerializer cachedSerializer)
             cachedSerializer.DisposeCache();
+    }
 
+    /// <summary>
+    ///  begin a runtime-cache scope for a single logical operation (import/report/export).
+    /// </summary>
+    /// <remarks>
+    ///  the scope id flows with the async operation (see <see cref="_cacheScope"/>) so the
+    ///  cache keys stay stable across await/thread hops, and the entries can be reliably
+    ///  cleared when the operation finishes.
+    /// </remarks>
+    /// <returns>the base cache key for the scope.</returns>
+    private string BeginCacheScope()
+    {
+        _cacheScope.Value = Guid.NewGuid().ToString("N");
+
+        // this also clears the folder cache - as its a 'starts with' call.
+        var key = GetCacheKeyBase();
+        runtimeCache.ClearByKey(key);
+        return key;
+    }
+
+    /// <summary>
+    ///  end the runtime-cache scope started by <see cref="BeginCacheScope"/>, clearing the
+    ///  entries cached during the operation.
+    /// </summary>
+    private void EndCacheScope(string cacheKey)
+    {
+        runtimeCache.ClearByKey(cacheKey);
+        _cacheScope.Value = null;
     }
 
     #region roots notifications 


### PR DESCRIPTION
Follow-up to #989. Implements items **#3** and **#5** from the performance review. (#1 batched save is still parked for its own deeper investigation.)

---

## #5 — runtime-cache scope keyed by managed thread id

`GetCacheKeyBase()` built its runtime-cache key from `Environment.CurrentManagedThreadId`:

```csharp
=> $"keyCache_{this.Alias}_{Environment.CurrentManagedThreadId}";
```

This backs the per-folder key cache (`GetFolderKeysAsync`) and the child-item cache (`GetChildItemsAsync`). Because it uses the OS thread id, across an `await` a continuation can resume on a **different** thread, so mid-operation the key changes:

- **Cache misses** — subsequent lookups compute a different key and re-hit `entityService` instead of the cache.
- **Leaks** — the end-of-operation cleanup (`CleanCaches`) runs on whatever thread it lands on and clears *that* thread's key prefix, so entries created under other thread ids are never evicted from the **shared, app-wide** runtime cache.

### Fix
Replace the thread id with an `AsyncLocal<string>` scope id that flows with the async operation (stable across thread hops):

- `PrepCaches`/`CleanCaches` (import + report) now begin/end a scope via `BeginCacheScope`/`EndCacheScope`.
- Top-level `ExportAllAsync` establishes its own scope (its child-item lookups were previously thread-keyed too).
- `ImportAllAsync` and `ReportAsync` run the cleanup in a **`finally`**, so entries are released even on exception.
- Callers with **no active scope** (paged import/report, ad-hoc tree/dependency lookups) fall back to the thread id — behaviour there is unchanged, so the paged `PreCacheFolderKeysAsync` optimisation is untouched.

The cache key captured at `BeginCacheScope` is reused for the clear, so cleanup targets the right entries regardless of which thread `finally` runs on.

## #3 — skip the CleanUp folder scan for flat + guid-name setups

On every save/move/delete (ExportOnSave), `SyncHandlerRoot.CleanUpAsync` recursively reads the whole handler folder tree, parsing each file, to find duplicate files to mark as renames. With a **flat** structure and **guid** file names an item's file is always `{key}.{ext}` in the same folder — it never changes name or location — so there is never anything to clean.

`ContentHandlerBase` (Content/Media, the big trees) already short-circuits this exact case. This PR adds the same early return to the **base** handler so the settings / level / container handlers (doctypes, datatypes, templates, dictionary, domains, languages, webhooks) also skip the scan when configured flat+guid.

---

## Safety / behaviour

- No public API or interface changes.
- Unscoped call paths keep the previous thread-id behaviour (explicit fallback), so paged import/report and tree/dependency lookups are unaffected.
- The flat+guid skip mirrors a trade-off already made in `ContentHandlerBase` (a full export still reconciles any stale files from a config change).

## Testing

- `dotnet build` clean.
- `uSync.Tests`: **137 passed, 0 failed**.

## Follow-ups (noted, not in this PR)

- The paged `ImportPartialAsync`/`ReportPartialAsync` flows still use the thread-id fallback; giving them an explicit operation scope would need a small `ISyncHandler` surface addition.
- #1 (batched content/media save) remains deferred pending Umbraco batch-save testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)