### PR TITLE
Avoid some unneeded dictionary operations

### DIFF
--- a/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
@@ -118,8 +118,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
             extensions.Add("Umb.Tiptap.Block");
         }
         
-        if (configuration.ContainsKey("toolbar"))
-            configuration.Remove("toolbar");
+        configuration.Remove("toolbar");
 
         configuration["toolbar"] = new List<List<List<string>>> { new() { newToolbar } };
         
@@ -128,7 +127,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return configuration;
     }
 
-    private bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
+    private static bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
     {
         toolBarList = new List<string>();
         if (toolbar is null) return false;
@@ -146,7 +145,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return true;
     }
 
-    private string? MapToolbarItem(string item)
+    private static string? MapToolbarItem(string item)
     {
         return item switch
         {

--- a/uSync.Core/Extensions/DictionaryExtensions.cs
+++ b/uSync.Core/Extensions/DictionaryExtensions.cs
@@ -15,22 +15,20 @@ internal static class DictionaryExtensions
     {
         if (usernames == null || id == null) return "unknown";
 
-        usernames[id.Value] = usernames.ContainsKey(id.Value)
-            ? usernames[id.Value]
-            : findMethod(id.Value)?.Email ?? "unknown";
+        if (usernames.TryGetValue(id.Value, out string? username))
+            return username;
 
-        return usernames[id.Value];
+        return usernames[id.Value] = findMethod(id.Value)?.Email ?? "unknown";
     }
 
     public static int GetEmails(this Dictionary<string, int> emails, string email, Func<string, IUser> findMethod)
     {
         if (emails == null || string.IsNullOrEmpty(email)) return -1;
 
-        emails[email] = emails.TryGetValue(email, out int value)
-            ? value
-            : findMethod(email)?.Id ?? -1;
+        if (emails.TryGetValue(email, out int value))
+            return value;
 
-        return emails[email];
+        return emails[email] = findMethod(email)?.Id ?? -1;
     }
 
     // This method converts an object to a dictionary of string, object
@@ -40,7 +38,7 @@ internal static class DictionaryExtensions
         var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         // Create a dictionary and populate it with the property names and values
-        var dictionary = new Dictionary<string, object?>();
+        Dictionary<string, object?> dictionary = new(properties.Length);
         foreach (var property in properties)
         {
             dictionary.Add(property.Name, property.GetValue(obj));
@@ -60,7 +58,7 @@ internal static class DictionaryExtensions
         {
             var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            var dictionary = new Dictionary<string, object?>();
+            Dictionary<string, object?> dictionary = new(properties.Length);
             foreach (var property in properties)
             {
                 dictionary.Add(property.Name, property.GetValue(obj));
@@ -87,8 +85,7 @@ internal static class DictionaryExtensions
         {
             foreach (var kvp in dictionary)
             {
-                if (mergedDictionary.ContainsKey(kvp.Key) is true) continue;
-                mergedDictionary.Add(kvp.Key, kvp.Value);
+                mergedDictionary.TryAdd(kvp.Key, kvp.Value);
             }
         }
 
@@ -111,6 +108,6 @@ internal static class DictionaryExtensions
             return s.ToLowerInvariant();
         }
 
-        return char.ToLowerInvariant(s[0]) + s.Substring(1);
+        return $"{char.ToLowerInvariant(s[0])}{s.AsSpan(1)}";
     }
 }

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -86,9 +86,9 @@ public class MediaPicker3Mapper : SyncValueMapperBase, ISyncMapper
 
     private static Guid GetGuidValue(JsonObject obj, string key)
     {
-        if (obj != null && obj.ContainsKey(key))
+        if (obj != null && obj.TryGetPropertyValue(key, out JsonNode? node))
         {
-            if (obj[key]?.ToString().TryGetValueAs<Guid>(out var guid) is true)
+            if (node?.ToString().TryGetValueAs<Guid>(out var guid) is true)
                 return guid;
         }
 

--- a/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
+++ b/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
@@ -160,8 +160,7 @@ internal abstract class SyncConfigMergerBase
                 // targetObject[property.Key] = JsonValue.Create(_inheritedValue);
 
                 // inherited is implicit.
-                if (targetObject.ContainsKey(property.Key)) 
-                    targetObject.Remove(property.Key);
+                targetObject.Remove(property.Key);
             }
         }
 
@@ -206,9 +205,9 @@ internal abstract class SyncConfigMergerBase
         for (int i = 0; i < targetArray.Count; i++)
         {
             if (targetArray[i] is not JsonObject targetObject) continue;
-            if (targetObject.ContainsKey(removeProperty) is false) continue;
+            if (targetObject.TryGetPropertyValue(removeProperty, out JsonNode? removal) is false) continue;
 
-            if (targetObject[removeProperty]!.ToString().StartsWith(_removedLabel) is true)
+            if (removal!.ToString().StartsWith(_removedLabel) is true)
             {
                 // we can't remove it while iterating, so add to a list. 
                 removals.Add(i);

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1419,7 +1419,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
     public bool TabClashesWithExisting(TObject item, string alias, PropertyGroupType tabType)
     {
         EnsureAllTabsCacheLoaded(item);
-        return _allTabs?.ContainsKey(alias) is true && _allTabs?[alias] != tabType;
+        return _allTabs?.TryGetValue(alias, out PropertyGroupType aliasTab) is true && aliasTab != tabType;
     }
 
     public void EnsureAllTabsCacheLoaded(TObject item)

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -189,8 +189,7 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
             var headerValue = header.ValueOrDefault(string.Empty);
 
             if (headerKey == string.Empty) continue;
-            if (newHeaders.ContainsKey(headerKey)) continue; // stop duplicates.
-            newHeaders.Add(headerKey, headerValue);
+            newHeaders.TryAdd(headerKey, headerValue); // stop duplicates.
         }
 
         var existingOrderedEvents = item.Headers.OrderBy(x => x.Key).ToDictionary();


### PR DESCRIPTION
Every lookup & write requires the creation of a hashkey and lookup in the buckets, so reduce that as much as possible