### PR TITLE
Add missing XML comments to clear CS1591 build warnings

### DIFF
--- a/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
+++ b/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
@@ -24,6 +24,9 @@ public class SyncFolderIntegrityChecks : HealthCheck
     private readonly ISyncConfigService? _configService;
     private readonly ISyncFileService? _fileService;
 
+    /// <summary>
+    ///  Constructor
+    /// </summary>
     public SyncFolderIntegrityChecks() { }
 
     /// <summary>

--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
@@ -77,6 +77,7 @@ public class ContentHandler : PublishableContentHandlerBase<IContent>, ISyncHand
     protected override Task<bool> HasChildrenAsync(IContent item)
         => Task.FromResult(_contentService.HasChildren(item.Id));
 
+    /// <inheritdoc />
     protected override IEnumerable<IEntity> GetRootItems()
         => _contentService.GetRootContent();
 

--- a/uSync.BackOffice/SyncHandlers/Handlers/ElementHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ElementHandler.cs
@@ -36,6 +36,9 @@ using static Umbraco.Cms.Core.Constants.HttpContext;
 
 namespace uSync.BackOffice.SyncHandlers.Handlers;
 
+/// <summary>
+///  Handler to manage the syncing of Element (library) items.
+/// </summary>
 [SyncHandler(
     alias: uSyncConstants.Handlers.ElementHandler,
     name: "Library", folder: "Element",
@@ -59,8 +62,12 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
     private readonly IList<ISyncTracker<EntityContainer>> _treeTrackers;
     private readonly ISyncEntityContainerSerializer<EntityContainer> _containerSerializer;
 
+    /// <inheritdoc />
     public override string Group => uSyncConstants.Groups.Content;
 
+    /// <summary>
+    ///  Constructor
+    /// </summary>
     public ElementHandler(
         ILogger<ContentHandlerBase<IElement>> logger,
         IEntityService entityService,
@@ -92,6 +99,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
     protected override Task<bool> HasChildrenAsync(IElement item)
         => Task.FromResult(false);
 
+    /// <inheritdoc />
     protected override IEnumerable<IEntity> GetRootItems()
     {
         var rootElements = entityService.GetRootEntities(UmbracoObjectTypes.Element);
@@ -115,6 +123,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
         return await ExportContainer(container, folders, config);
     }
 
+    /// <inheritdoc />
     public override async Task<IEnumerable<uSyncAction>> ExportContainer(IEntity item, string[] folders, HandlerSettings config)
     {
         if (item is null)
@@ -209,6 +218,9 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
         return attempt;
     }
 
+    /// <summary>
+    ///  Serialize a container (folder) into its XML representation.
+    /// </summary>
     protected async Task<SyncAttempt<XElement>> SerializeContainerAsync(EntityContainer item, SyncSerializerOptions options)
         => await _containerSerializer.SerializeAsync(item, options);
 
@@ -228,6 +240,9 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
     private string GetContainerEntityPath(EntityContainer item, bool GuidNames, bool isFlat)
         => GuidNames ? GetContainerKey(item).ToString() : GetContainerName(item).ToAppSafeFileName();
 
+    /// <summary>
+    ///  Check for a filename clash when writing a container to a flat folder, appending a short key to avoid it.
+    /// </summary>
     virtual protected async Task<string> CheckAndFixContainerFileClashAsync(string path, EntityContainer item)
     {
         if (syncFileService.FileExists(path))
@@ -296,6 +311,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
         }
     }
 
+    /// <inheritdoc />
     protected override async Task<uSyncAction> DeserializeItemToAction(XElement node, string filename, SyncSerializerOptions serializerOptions)
     {
         if (NodeIsContainer(node))
@@ -324,6 +340,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
         return action;
     }
 
+    /// <inheritdoc />
     protected override async Task<IEnumerable<uSyncChange>> GetChangesAsync(XElement node, XElement currentNode, SyncSerializerOptions options)
     {
         if (NodeIsContainer(node) is false)
@@ -332,6 +349,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
             return await itemFactory.GetChangesAsync<EntityContainer>(node, currentNode, options);
     }
 
+    /// <inheritdoc />
     protected override async Task<SyncChangeInfo> IsItemCurrentAsync(XElement node, SyncSerializerOptions options)
     {
         if (NodeIsContainer(node) is false)

--- a/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
@@ -21,12 +21,21 @@ using uSync.Core.Extensions;
 
 namespace uSync.BackOffice.SyncHandlers.Handlers;
 
+/// <summary>
+///  Base handler for content types that can be published (documents, elements, etc).
+/// </summary>
 public abstract class PublishableContentHandlerBase<TObject>
     : ContentHandlerBase<TObject>
     where TObject : class, IPublishableContentBase
 {
+    /// <summary>
+    ///  The Umbraco object type used for containers (folders) for this handler.
+    /// </summary>
     protected UmbracoObjectTypes ContainerType => UmbracoObjectTypes.Document;
 
+    /// <summary>
+    ///  Constructor
+    /// </summary>
     protected PublishableContentHandlerBase(
         ILogger<ContentHandlerBase<TObject>> logger,
         IEntityService entityService,
@@ -39,6 +48,9 @@ public abstract class PublishableContentHandlerBase<TObject>
         : base(logger, entityService, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfigService, syncItemFactory)
     { }
 
+    /// <summary>
+    ///  Get the root level items for this handler (items with no parent).
+    /// </summary>
     protected abstract IEnumerable<IEntity> GetRootItems();
 
     /// <summary>
@@ -69,6 +81,9 @@ public abstract class PublishableContentHandlerBase<TObject>
     }
 
 
+    /// <summary>
+    ///  Export a single item in response to a notification, cleaning up any orphaned files afterwards.
+    /// </summary>
     protected async Task ProcessItem(EnumerableObjectNotification<TObject> notification, TObject item, string[] handlerFolders)
     {
         try

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -518,6 +518,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
     }
 
+    /// <summary>
+    ///  Deserialize an item from a node and return the resulting <see cref="uSyncAction"/>.
+    /// </summary>
     protected virtual async Task<uSyncAction> DeserializeItemToAction(XElement node, string filename, SyncSerializerOptions serializerOptions)
     {
         // get the item.
@@ -1423,6 +1426,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     }
 
 
+    /// <summary>
+    ///  Calculate the collection of changes between the incoming node and the current node.
+    /// </summary>
     protected virtual async Task<IEnumerable<uSyncChange>> GetChangesAsync(XElement node, XElement currentNode, SyncSerializerOptions options)
         => await itemFactory.GetChangesAsync<TObject>(node, currentNode, options);
 
@@ -1955,6 +1961,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     protected async Task<SyncAttempt<TObject>> DeserializeItemSecondPassAsync(TObject item, XElement node, SyncSerializerOptions options)
         => await serializer.DeserializeSecondPassAsync(item, node, options);
 
+    /// <summary>
+    ///  Work out if the item represented by the node is current (matches what is already in Umbraco).
+    /// </summary>
     protected virtual async Task<SyncChangeInfo> IsItemCurrentAsync(XElement node, SyncSerializerOptions options)
     {
         var change = new SyncChangeInfo
@@ -1985,9 +1994,19 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         return null;
     }
 
+    /// <summary>
+    ///  Holds the result of an item comparison - the type of change and the current serialized node.
+    /// </summary>
     protected class SyncChangeInfo
     {
+        /// <summary>
+        ///  The type of change detected for the item.
+        /// </summary>
         public ChangeType Change { get; set; }
+
+        /// <summary>
+        ///  The serialized node representing the item as it currently is in Umbraco.
+        /// </summary>
         public XElement? CurrentNode { get; set; }
     }
 
@@ -2012,6 +2031,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
     #endregion
 
+    /// <summary>
+    ///  Get a display name for an item, using the file path where available, otherwise the node alias.
+    /// </summary>
     protected string GetNameFromFileOrNode(string filename, XElement node)
     {
         if (string.IsNullOrWhiteSpace(filename) is true) return node.GetAlias();


### PR DESCRIPTION
## What

Adds XML documentation to publicly visible members in **uSync.BackOffice** that were producing `CS1591` (*Missing XML comment for publicly visible type or member*) warnings during the build.

## Why

The build was emitting 48 `CS1591` warnings (24 unique members). This clears all of them so the documentation-generation warnings no longer add noise to the build output.

## How

- Used `<inheritdoc />` for members that override an already-documented base member.
- Wrote `<summary>` docs for base/virtual/abstract members and types that had nothing to inherit from.

### Files touched
- `SyncHandlers/SyncHandlerRoot.cs` — base virtual members (`DeserializeItemToAction`, `GetChangesAsync`, `IsItemCurrentAsync`, `GetNameFromFileOrNode`) and the nested `SyncChangeInfo` class + properties.
- `SyncHandlers/Handlers/PublishableContentHandlerBase.cs` — class, `ContainerType`, constructor, `GetRootItems`, `ProcessItem`.
- `SyncHandlers/Handlers/ElementHandler.cs` — class, constructor, and members (mix of `<inheritdoc />` and summaries).
- `SyncHandlers/Handlers/ContentHandler.cs` — `GetRootItems` (`<inheritdoc />`).
- `HealthChecks/SyncFolderIntegrityChecks.cs` — parameterless constructor.

## Notes for reviewers

- No behavioural changes — documentation only.
- `CS1591` count confirmed at **0** after a clean `Release` rebuild (`Build succeeded`).
- Unrelated `CS0618` (obsolete API usage) and one `CS8632` warning remain and were intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)