### PR TITLE
Replace obsolete ITemplate.MasterTemplateAlias with LayoutTemplateAlias

### DIFF
--- a/uSync.AutoTemplates/TemplateWatcher.cs
+++ b/uSync.AutoTemplates/TemplateWatcher.cs
@@ -191,7 +191,7 @@ public partial class TemplateWatcher : IRegisteredObject
 
                 if (template != null)
                 {
-                    var currentMaster = string.IsNullOrWhiteSpace(template.MasterTemplateAlias) ? "null" : template.MasterTemplateAlias;
+                    var currentMaster = string.IsNullOrWhiteSpace(template.LayoutTemplateAlias) ? "null" : template.LayoutTemplateAlias;
                     if (fileMasterAlias != currentMaster)
                     {
                         // template.SetMasterTemplate(GetMasterTemplate(fileMasterAlias));

--- a/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs
@@ -84,7 +84,7 @@ public class TemplateHandler : SyncHandlerLevelBase<ITemplate>, ISyncHandler, IS
 
                 // top level, lets check they aren't secretly lower down.
                 var templateContent = await GetTemplateContentAsync(item.Alias);
-                var masterAlias = _templateContentParserService.MasterTemplateAlias(templateContent);
+                var masterAlias = _templateContentParserService.LayoutTemplateAlias(templateContent);
                 if (string.IsNullOrWhiteSpace(masterAlias) || masterAlias == item.Alias || masterAlias.InvariantEquals("null"))
                 {
                     results.Add(item);

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -306,7 +306,7 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
         var node = this.InitializeBaseNode(item, item.Alias, await this.CalculateLevelAsync(item));
 
         node.Add(new XElement("Name", item.Name));
-        node.Add(new XElement("Parent", item.MasterTemplateAlias));
+        node.Add(new XElement("Parent", item.LayoutTemplateAlias));
 
         if (options.GetSetting(uSyncConstants.Conventions.IncludeContent, false))
         {
@@ -322,14 +322,14 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
 
     private async Task<int> CalculateLevelAsync(ITemplate item)
     {
-        if (item.MasterTemplateAlias.IsNullOrWhiteSpace()) return 1;
+        if (item.LayoutTemplateAlias.IsNullOrWhiteSpace()) return 1;
 
         int level = 1;
         var current = item;
-        while (!string.IsNullOrWhiteSpace(current.MasterTemplateAlias) && level < 20)
+        while (!string.IsNullOrWhiteSpace(current.LayoutTemplateAlias) && level < 20)
         {
             level++;
-            var parent = await FindItemAsync(current.MasterTemplateAlias);
+            var parent = await FindItemAsync(current.LayoutTemplateAlias);
             if (parent == null) return level;
 
             current = parent;


### PR DESCRIPTION
## What

Replaces all uses of `ITemplate.MasterTemplateAlias` / `ITemplateContentParserService.MasterTemplateAlias(...)` with their non-obsolete equivalent, `LayoutTemplateAlias`.

## Why

Both members are marked obsolete in Umbraco 18 (`CS0618`), scheduled for removal in Umbraco 20, and were producing build warnings.

## How

Confirmed via the decompiled `Umbraco.Cms.Core` source that `MasterTemplateAlias` is a pure rename — a default-interface-member / property that simply forwards to `LayoutTemplateAlias` with identical type, nullability, and semantics. All uses here were read-only (getters / method calls), so the swap is a direct drop-in replacement.

### Files touched
- `uSync.Core/Serialization/Serializers/TemplateSerializer.cs` — `item.MasterTemplateAlias` → `item.LayoutTemplateAlias` (export, level calculation, parent lookup).
- `uSync.BackOffice/SyncHandlers/Handlers/TemplateHandler.cs` — `_templateContentParserService.MasterTemplateAlias(...)` → `.LayoutTemplateAlias(...)`.
- `uSync.AutoTemplates/TemplateWatcher.cs` — `template.MasterTemplateAlias` → `template.LayoutTemplateAlias`.

## Notes for reviewers

- No behavioural changes — build succeeds and the `MasterTemplateAlias` `CS0618` warnings are gone.
- Two unrelated `CS0618` warnings remain (`HtmlLocalLinkParser` legacy methods in `SyncLocalLinkProcessor.cs`, and `ISyncActionService.UnpackImportFromStream` in `uSyncManagementService.cs`) — intentionally out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)