### PR TITLE
Inline legacy local link parsing to drop obsolete HtmlLocalLinkParser API

### DIFF
--- a/uSync.Core/Versions/18.0/SyncLocalLinkProcessor.cs
+++ b/uSync.Core/Versions/18.0/SyncLocalLinkProcessor.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Templates;
 
 namespace uSync.Core.Versions._18._0;
 
@@ -18,19 +19,27 @@ public interface ISyncTypedLocalLinkProcessor
     public Func<object?, Func<object?, bool>, Func<string, string>, bool> Process { get; }
 }
 
-
-public class SyncLocalLinkProcessor
+/// <summary>
+///  Finds and replaces the legacy {localLink:x} syntax within values, mapping ids/UDIs to keys.
+/// </summary>
+/// <remarks>
+///  Umbraco's own <c>HtmlLocalLinkParser.FindLegacyLocalLinkIds</c> (and its <c>LocalLinkTag</c> model)
+///  are obsolete and scheduled for removal in Umbraco 18, but uSync still needs to detect these
+///  legacy (un-migrated) links when mapping content, so the parsing logic lives here instead.
+/// </remarks>
+public partial class SyncLocalLinkProcessor
 {
-    private readonly HtmlLocalLinkParser _localLinkParser;
+    // copied from Umbraco.Cms.Core.Templates.HtmlLocalLinkParser.LocalLinkPattern
+    [GeneratedRegex(@"href=['""](?<locallink>\/?(?:\{|\%7B)localLink:(?<guid>[a-zA-Z0-9-://]+)(?:\}|\%7D))", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace, "en-GB")]
+    private static partial Regex LegacyLocalLinkPattern();
+
     private readonly IIdKeyMap _idKeyMap;
     private readonly IEnumerable<ISyncTypedLocalLinkProcessor> _localLinkProcessors;
 
     public SyncLocalLinkProcessor(
-        HtmlLocalLinkParser localLinkParser,
         IIdKeyMap idKeyMap,
         IEnumerable<ISyncTypedLocalLinkProcessor> localLinkProcessors)
     {
-        _localLinkParser = localLinkParser;
         _idKeyMap = idKeyMap;
         _localLinkProcessors = localLinkProcessors;
     }
@@ -49,9 +58,9 @@ public class SyncLocalLinkProcessor
     public string ProcessStringValue(string input)
     {
         // find all legacy tags
-        var tags = _localLinkParser.FindLegacyLocalLinkIds(input).ToList();
+        var tags = FindLegacyLocalLinkIds(input).ToList();
 
-        foreach (HtmlLocalLinkParser.LocalLinkTag tag in tags)
+        foreach (LocalLinkTag tag in tags)
         {
             string newTagHref;
             if (tag.Udi is not null)
@@ -101,4 +110,49 @@ public class SyncLocalLinkProcessor
         return null;
     }
 
+    // copied from Umbraco.Cms.Core.Templates.HtmlLocalLinkParser.FindLegacyLocalLinkIds
+    private static IEnumerable<LocalLinkTag> FindLegacyLocalLinkIds(string text)
+    {
+        MatchCollection tags = LegacyLocalLinkPattern().Matches(text);
+        foreach (Match tag in tags)
+        {
+            if (tag.Groups.Count <= 0)
+            {
+                continue;
+            }
+
+            var id = tag.Groups["guid"].Value;
+
+            // The id could be an int or a UDI
+            if (UdiParser.TryParse(id, out Udi? udi))
+            {
+                if (udi is GuidUdi guidUdi)
+                {
+                    yield return new LocalLinkTag(null, guidUdi, tag.Groups["locallink"].Value);
+                }
+            }
+
+            if (int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intId))
+            {
+                yield return new LocalLinkTag(intId, null, tag.Groups["locallink"].Value);
+            }
+        }
+    }
+
+    // copied from Umbraco.Cms.Core.Templates.HtmlLocalLinkParser.LocalLinkTag
+    private sealed class LocalLinkTag
+    {
+        public LocalLinkTag(int? intId, GuidUdi? udi, string tagHref)
+        {
+            IntId = intId;
+            Udi = udi;
+            TagHref = tagHref;
+        }
+
+        public int? IntId { get; }
+
+        public GuidUdi? Udi { get; }
+
+        public string TagHref { get; }
+    }
 }


### PR DESCRIPTION
## What

`SyncLocalLinkProcessor` no longer depends on `HtmlLocalLinkParser.FindLegacyLocalLinkIds` / `HtmlLocalLinkParser.LocalLinkTag`. The parsing logic for legacy (un-migrated) `{localLink:x}` references now lives directly in `SyncLocalLinkProcessor`.

## Why

Those two members are marked `[Obsolete]` (`CS0618`) in Umbraco 18 and scheduled for removal, but uSync still needs this legacy-detection behaviour when mapping RTE content that hasn't been migrated to the new `<a type="..." href="{localLink:guid}">` format. Since Umbraco intends to remove the API outright (not just rename it, unlike `MasterTemplateAlias`), the only forward-compatible fix is to own the logic ourselves rather than call the soon-to-be-removed method.

## How

Copied directly from Umbraco 18's `Umbraco.Cms.Core.Templates.HtmlLocalLinkParser` (checked out locally at `D:\Source\Umbraco\v18\Umbraco-CMS-v18`):
- The `LocalLinkPattern` regex, now a private `[GeneratedRegex]` on `SyncLocalLinkProcessor` (which is now `partial` to support the source generator).
- The `FindLegacyLocalLinkIds` method body, unchanged apart from being private/static and returning uSync's own local `LocalLinkTag` model instead of Umbraco's obsolete one.
- A private `LocalLinkTag` class carrying `IntId`, `Udi`, and `TagHref` — the same shape as Umbraco's, minus the unused `Culture` property (`SyncLocalLinkProcessor` never read it).

Since `HtmlLocalLinkParser` was only ever used for this one obsolete method, it's been dropped from the constructor entirely rather than kept unused. Confirmed the only two call sites (`uSyncCoreBuilderExtensions.cs` DI registration and `RTEMapper.cs`'s use of `ProcessStringValue`) are unaffected by the constructor change.

## Notes for reviewers

- No behavioural changes — regex and parsing logic is a byte-for-byte copy of Umbraco's own implementation.
- Full solution builds with 0 errors; the `HtmlLocalLinkParser`-related `CS0618` warnings are gone.
- All 148 existing tests pass (`dotnet test uSync.Tests`).
- One unrelated `CS0618` warning remains (`ISyncActionService.UnpackImportFromStream` in `uSyncManagementService.cs`) — intentionally out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)