### PR TITLE
Add async UnpackStreamAsync to ISyncManagementService, obsolete sync UnpackStream

### DIFF
--- a/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncPerformActionController.cs
+++ b/uSync.Backoffice.Management.Api/Controllers/Actions/uSyncPerformActionController.cs
@@ -81,7 +81,7 @@ public class uSyncPerformActionController : uSyncControllerBase
 
         using (var stream = tempFile.OpenReadStream())
         {
-            return Ok(_managementService.UnpackStream(stream));
+            return Ok(await _managementService.UnpackStreamAsync(stream));
         }
     }
 }

--- a/uSync.Backoffice.Management.Api/Services/ISyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/ISyncManagementService.cs
@@ -22,5 +22,9 @@ public interface ISyncManagementService
     Func<SyncActionOptions, uSyncCallbacks, Task<SyncActionResult>> GetHandlerMethodAsync(HandlerActions action);
     Task<SyncFileVersionCheckResult> GetSyncFileInfo();
     Task<PerformActionResponse> PerformActionAsync(PerformActionRequest actionRequest, IUser? user);
-    UploadImportResult UnpackStream(Stream stream);
+
+    [Obsolete("use UnpackStreamAsync will be removed in v19")]
+    UploadImportResult UnpackStream(Stream stream)
+        => UnpackStreamAsync(stream).Result;
+    Task<UploadImportResult> UnpackStreamAsync(Stream stream);
 }

--- a/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
@@ -427,8 +427,8 @@ internal class uSyncManagementService : ISyncManagementService
     /// <summary>
     ///  take a zip file as a stream expand it over the current uSync folder. 
     /// </summary>
-    public UploadImportResult UnpackStream(Stream stream)
-        => _syncActionService.UnpackImportFromStream(stream);
+    public async Task<UploadImportResult> UnpackStreamAsync(Stream stream)
+        => await _syncActionService.UnpackImportFromStreamAsync(stream);
 
     public async Task<SyncFileVersionCheckResult> GetSyncFileInfo()
         => await _syncVersionFileService.GetSyncFileInfo(_configService.GetWorkingFolder());


### PR DESCRIPTION
## What

`ISyncManagementService` gets a new `UnpackStreamAsync(Stream stream)` method. The existing `UnpackStream(Stream stream)` is now `[Obsolete]` with a default implementation that forwards to the async version.

## Why

`uSyncManagementService.UnpackStream` called the obsolete `ISyncActionService.UnpackImportFromStream(Stream)` (`CS0618`, scheduled for removal in v19), producing the last remaining build warning. `ISyncActionService` already exposes the async replacement (`UnpackImportFromStreamAsync`), so the fix is to plumb that all the way up through `ISyncManagementService` and its controller caller, rather than keep calling the obsolete sync member.

## How

Mirrors the pattern `ISyncActionService` already uses for this exact same rename (`UnpackImportFromStream` → `UnpackImportFromStreamAsync`, see `uSync.BackOffice/Services/ISyncActionService.cs:71-78`) and the existing `[Obsolete("... will be removed in vXX")]` convention already used elsewhere in `ISyncManagementService` (`GetActions()`):

- `ISyncManagementService.cs` — added `Task<UploadImportResult> UnpackStreamAsync(Stream stream)`; `UnpackStream` is now `[Obsolete]` with a default body calling `UnpackStreamAsync(stream).Result`.
- `uSyncManagementService.cs` — `UnpackStream` implementation replaced with `UnpackStreamAsync`, which now awaits `_syncActionService.UnpackImportFromStreamAsync(stream)` directly instead of the obsolete sync wrapper.
- `uSyncPerformActionController.cs` — `ProcessUpload` now calls `await _managementService.UnpackStreamAsync(stream)`.

No other call sites reference `UnpackStream`.

## Notes for reviewers

- Full solution builds with 0 errors and 0 `CS0618` warnings (down from the last remaining one). Only a pre-existing, unrelated `CS8632` nullable-annotation warning remains in the test project.
- All 148 existing tests pass.
- Minor style note: `ISyncActionService`'s equivalent default body uses `.GetAwaiter().GetResult()` rather than `.Result` (avoids wrapping exceptions in `AggregateException`) — worth aligning if this ever gets called from a sync context, but since `UnpackStream` has no callers left in-repo it's not a functional concern here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)