### PR TITLE
Update changelog for build warning cleanup and UnpackStreamAsync API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ History is backfilled from the v18 release history starting at `v18.0.0`.
   > inherited values instead. Review any set that mixes `HandlerDefaults` with
   > per-handler blocks.
 
+- **Extender API:** `ISyncManagementService` gains `UnpackStreamAsync(Stream)`.
+  The synchronous `UnpackStream(Stream)` is now obsolete (removed in v19). (#1005)
+
+- Cleared the remaining build warnings left over from the Umbraco 18 upgrade:
+  replaced `ITemplate.MasterTemplateAlias` usage with `LayoutTemplateAlias`,
+  and inlined the legacy `{localLink:x}` parsing that Umbraco is removing in
+  v18 into uSync's own code, since uSync still needs to detect un-migrated
+  links. No behavioural changes. (#1002, #1003, #1004)
+
 ### Fixed
 
 - `HandlerSettings.Clone()` no longer drops the `CreateClean` and


### PR DESCRIPTION
## What

Adds two entries to `CHANGELOG.md` under `[Unreleased] → Changed`, covering the four PRs merged in this session's build-warning cleanup pass.

## Why

The changelog wasn't updated as part of #1002-#1005, and per the repo convention (see the existing `ExportContainer` entry) extender-facing API changes should be recorded there.

## What's recorded

- **Extender API:** `ISyncManagementService.UnpackStreamAsync(Stream)` added; `UnpackStream(Stream)` obsoleted (removed in v19). (#1005)
- A combined note on the `MasterTemplateAlias` → `LayoutTemplateAlias` swap and inlining the legacy `{localLink:x}` parsing that Umbraco is removing in v18, explicitly flagged as no behavioural change. (#1002, #1003, #1004)

## Notes for reviewers

- Docs-only change, no code touched.
- Deliberately didn't give the XML-doc-comment addition (also part of #1002) its own line — it's purely internal and not user-facing behaviour, so it's folded into the same bullet as the warning fix it shipped alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)