### PR TITLE
Restore backoffice guard and content paging fixes dropped in v17->v18 merge

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
@@ -81,6 +81,35 @@ public class ContentHandler : PublishableContentHandlerBase<IContent>, ISyncHand
     protected override IEnumerable<IEntity> GetRootItems()
         => _contentService.GetRootContent();
 
+    /// <inheritdoc />
+    protected override async Task<IEnumerable<IEntity>> GetChildItemsAsync(IEntity? parent)
+    {
+        if (parent != null)
+        {
+            var items = new List<IContent>();
+            const int pageSize = 5000;
+            var page = 0;
+            var total = long.MaxValue;
+            while (page * pageSize < total)
+            {
+                items.AddRange(_contentService.GetPagedChildren(
+                    id: parent.Id,
+                    pageIndex: page++,
+                    pageSize: pageSize,
+                    totalRecords: out total,
+                    propertyAliases: null,
+                    filter: null,
+                    ordering: null,
+                    loadTemplates: true));
+            }
+            return items;
+        }
+        else
+        {
+            return await Task.FromResult(GetRootItems());
+        }
+    }
+
      /// <summary>
     ///  Handle the publish events for content
     /// </summary>

--- a/uSync.BackOffice/uSyncBackOfficeComposer.cs
+++ b/uSync.BackOffice/uSyncBackOfficeComposer.cs
@@ -18,10 +18,9 @@ public class uSyncBackOfficeComposer : IComposer
     /// <inheritdoc/>
     public void Compose(IUmbracoBuilder builder)
     {
-        // uSync core will actually run when their is no back office loaded.
-        //if (builder.IsUmbracoBackOfficeEnabled() is false)
-        //    return;
-
-        builder.AdduSync();
+        if (builder.IsUmbracoBackOfficeEnabled() is true)
+        {
+            builder.AdduSync();
+        }
     }
 }


### PR DESCRIPTION
## Summary

An audit comparing `v17/main` against `v18/main` found that the squash-merge in #992 ("Merge v17/main into v18/main (2026-07-11)") successfully ported the large majority of v17's work (perf fixes, localization, blueprint path/parent resolution, image mapper split, clean-folder fix, all frontend changes) — but two fixes didn't survive the port:

- **`uSyncBackOfficeComposer.cs`**: the `IsUmbracoBackOfficeEnabled()` guard (originally added in v17 #962) was present but commented out, so uSync now registers itself unconditionally — including on headless/delivery-only servers where it shouldn't run. Restored the guard.
- **`ContentHandler.cs`**: during v18's refactor that centralized paged child-fetching into `PublishableContentHandlerBase`, `ContentHandler` lost the concrete-typed fetching it had in v17 (part of the perf work in v17 #990). The shared base now returns generic `IEntitySlim` for non-root items, which fails `SyncHandlerRoot.ExportAllAsync`'s `is TObject` check and forces an extra `contentService.GetById` call per descendant item during export/import. `MediaHandler` was never affected since it already overrides `GetChildItemsAsync` directly with concrete `IMedia` — `ContentHandler` now mirrors that same pattern using `_contentService.GetPagedChildren`.

Everything else checked out as correctly ported; these are the only two gaps found.

## Notes for reviewers

- Used the explicit 8-parameter `GetPagedChildren` overload (matching v17's original call) rather than the shorter 4-arg form `MediaHandler` uses for `IMediaService`, because `IContentService`'s equivalent short overload is marked `[Obsolete]` in Umbraco 18.0.2 and would otherwise produce a `CS0618` warning.
- No existing test exercises either code path directly (the composer guard or this specific paging call), so there's no new test coverage — these are behavioral/perf fixes, not bug fixes with a repro test.

## Test plan

- [x] `dotnet build uSync.slnx` — 0 warnings, 0 errors
- [x] `dotnet test uSync.Tests/uSync.Tests.csproj` — 148/148 passing
- [ ] Manual/staging verification that a backoffice-disabled site no longer registers uSync, and that exporting a nested content tree no longer issues extra per-item `GetById` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)