### PR TITLE
18.1.0 RC Build with Jumoo.Json

### DIFF
--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "18.0.3",
+	"version": "18.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "18.0.3",
+			"version": "18.1.0",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.97.1",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "18.0.3",
+	"version": "18.1.0",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "18.0.3",
+  "version": "18.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "18.0.3",
+      "version": "18.1.0",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.99.0",
         "@jumoo/usync": "^18.0.0",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "18.0.3",
+  "version": "18.1.0",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",


### PR DESCRIPTION
Release candidate using the Jumoo.Json Library for all those System.Text.Json helpers. 

We already use the Jumoo.Json library in uSync.Complete and Translation Manager, and uSync had its own version of all these files, moving to the library, allows us to get the benfits of the shared and optimised code, across all projects.