### PR TITLE
Add opt-in import state cache (CacheImportState, default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ History is backfilled from the v18 release history starting at `v18.0.0`.
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in import state cache — `uSync:Settings:CacheImportState` (default `false`).**
+  uSync decides whether an item has changed by loading it from Umbraco, serializing
+  the whole thing, and comparing hashes — for every item, every run. That means an
+  import where nothing has changed costs roughly as much as a full export, which on
+  sites with thousands of files is the entire run time.
+
+  With this on, uSync remembers the hash of each file it has confirmed matches, and
+  skips those items on the next run without a database lookup or a re-serialize.
+  Import cost goes from `O(all items)` of database and serialization work to
+  `O(changed items)`.
+
+  It only ever remembers a file where the full check actually ran and said "no
+  change", or that uSync has just exported (so the file was written from the
+  database and the two match by construction). It never assumes that because an
+  import succeeded the two sides now agree. **The practical effect is that the first
+  run after turning it on is no faster than before — the benefit arrives on the
+  second run.** An export warms it too.
+
+  The cache lives in the site's temp folder (`{LocalTempPath}/uSync/cache/`), never
+  in the uSync folder, and is thrown away whenever the database, the uSync version,
+  or the handler settings change. Items are forgotten when Umbraco says they have
+  been saved, deleted, moved or published; changing a doc type, data type, template,
+  language or container clears the whole cache, because those get embedded in other
+  items' xml. A force import always ignores it.
+
+  What it cannot see is a database change made by something that raises no Umbraco
+  notification — raw SQL, for example — hence the default of off. **Read
+  [`docs/perf/state-cache.md`](docs/perf/state-cache.md) before enabling it**, in
+  particular the limitations section, and the note for anyone writing a custom
+  serializer that embeds data from another item.
+
+  Implemented entirely through uSync's existing per-item notifications, so nothing
+  in the import, report or serialization path changed.
+
+- **Extender API:** the cancelable per-item notifications
+  (`uSyncImportingItemNotification`, `uSyncReportingItemNotification`, and anything
+  else deriving from `CancelableuSyncItemNotification<T>`) gain an optional
+  `Message`, used instead of uSync's generic "change stopped by delegate event" when
+  you set it. The import and report ones also gain `Force`, so a subscriber that
+  short-cuts the check because it believes nothing has changed can stand down when
+  the user has asked for a forced import.
+
 ### Changed
 
 - **Handler settings now inherit from `HandlerDefaults`.** When a handler has its

--- a/docs/perf/state-cache.md
+++ b/docs/perf/state-cache.md
@@ -1,0 +1,195 @@
+# The import state cache (`CacheImportState`)
+
+**Setting:** `uSync:Settings:CacheImportState` — **default `false`**
+
+An opt-in cache that lets a repeat import or report skip items it has already confirmed match
+Umbraco, without a database lookup or a re-serialize.
+
+---
+
+## 1. The problem it solves
+
+uSync works out whether an item has changed by loading it from Umbraco, serializing the whole
+thing, and comparing hashes:
+
+[`SyncSerializerRoot.DeserializeAsync`](../../uSync.Core/Serialization/SyncSerializerRoot.cs)
+calls `IsCurrentAsync` for **every** item, and
+[`IsCurrentAsync`](../../uSync.Core/Serialization/SyncSerializerRoot.cs) does:
+
+```
+FindItemAsync(node)          // database lookup
+  -> SerializeAsync(item)    // full re-serialize of the Umbraco item
+  -> CleanseNode() x2        // (some serializers deep-clone here)
+  -> two hashes              // one per side
+```
+
+The report path pays the same cost through
+[`SyncHandlerRoot.IsItemCurrentAsync`](../../uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs).
+
+The consequence is that an import where **nothing has changed** costs roughly as much as a full
+export. Reading the files is not the bottleneck — that is already parallelised in
+[`SyncFileService.GetFolderItemsAsync`](../../uSync.BackOffice/Services/SyncFileService.cs) — the
+per-item work afterwards is. On a site with thousands of content and dictionary files that per-item
+work is the whole run time.
+
+With the cache on, an item we have already confirmed costs one hash of an `XElement` we have
+already parsed. Import cost goes from `O(all items)` of database and serialization work to
+`O(changed items)`.
+
+## 2. How it hooks in
+
+Through notifications, not by changing the import pipeline. uSync already fires a cancelable
+notification per item on both the import and report paths — the report one exists for exactly this
+purpose ("this lets us intercept a report and shortcut the checking (sometimes)"). So the whole
+feature sits off to one side:
+
+| Notification | What we do |
+|---|---|
+| `uSyncImportingItemNotification` / `uSyncReportingItemNotification` | cancel the item if we already know the file matches |
+| `uSyncImportedItemNotification` / `uSyncReportedItemNotification` | record the file's hash **if the answer was `NoChange`** |
+| `uSyncExportedItemNotification` | record the file's hash — we just wrote it from the database |
+| `uSync*Starting` / `uSync*Completed` | load / save the cache file |
+
+Nothing in `SyncSerializerRoot`, no serializer, and none of the handler import or report methods
+changed. The feature is two classes
+([`SyncStateCacheManager`](../../uSync.BackOffice/Cache/SyncStateCacheManager.cs),
+[`SyncStateCacheInvalidator`](../../uSync.BackOffice/Cache/SyncStateCacheInvalidator.cs)) plus the
+cache itself ([`SyncStateCache`](../../uSync.BackOffice/Cache/SyncStateCache.cs)) and one setting.
+
+### Only confirmed matches are recorded
+
+An entry is written in exactly two situations:
+
+1. the full expensive check ran and returned `NoChange`, or
+2. we have just exported the item, so the file was written from the database and the two sides
+   match by construction.
+
+We deliberately **do not** record after a successful update or create. It is tempting to assume
+the two sides now agree, but they do not always: some items do not round-trip exactly, which is
+what uSync's *"XML is different - but properties may not have changed"* message is telling you.
+Recording those would silence a real difference for good. Instead they are checked again next
+time — honest, and self-correcting.
+
+The cost of that choice is that **the first run after turning the cache on is no faster than
+before.** The benefit arrives on the second run. An export also warms it, so an
+export-then-report cycle is warm already.
+
+## 3. What invalidates it
+
+`SyncStateCacheInvalidator` listens to Umbraco. There are three levels, and picking the right one
+is the whole game:
+
+| Level | When | Why |
+|---|---|---|
+| the item | saved, deleted, published, unpublished | only that item's own xml changed |
+| the whole item type | moved, or moved to the recycle bin | a move rewrites the `Path` of every descendant, and paths are part of the serialized xml |
+| **everything** | doc type, media type, member type, data type, template, language, or container saved/deleted/moved/renamed | these get embedded in *other* items' xml, so changing one silently changes items whose own rows never moved |
+
+That last row is the important one. A content item's xml carries its doc type alias, template
+alias, parent key and path; a dictionary item's carries its languages. So renaming a doc type
+changes what every item using it serializes to, without touching those items or raising any
+notification for them. There is no cheap way to work out which items are affected, and these
+changes are rare, so we throw the whole cache away. The policy lives in one place —
+`SyncStateCache`'s shared-item-types set — so it applies however the invalidation arrives.
+
+Invalidation runs whether or not the setting is currently on. Otherwise turning the cache off,
+editing things, and turning it back on would leave it confidently wrong.
+
+The whole cache is also discarded when we cannot prove it still applies — see the identity
+section below.
+
+### Nothing pauses invalidation during uSync's own import
+
+There is no `IsPaused` check in the invalidator, and that is deliberate. During an import, an item
+uSync writes is invalidated and then simply not re-recorded (we only record confirmed `NoChange`
+results), so invalidating is harmless — and it also catches items Umbraco saves as a *side effect*
+of something we imported, which a paused check would miss.
+
+## 4. Where it lives
+
+`{IHostingEnvironment.LocalTempPath}/uSync/cache/state-{identity}.json`
+
+**Never in the uSync folder.** The cache describes this site's database, not the source of truth,
+so it must not travel between environments, get committed, or show up in a diff. (Same precedent
+as [uSync.History](../../uSync.History/uSyncHistoryNotificationHandler.cs), which writes to
+`LocalTempPath` too.)
+
+### The identity
+
+The file name and its contents both carry an identity hash. On load, a mismatch means the file is
+discarded entirely. It is built from:
+
+- **a database stamp** — a GUID we create once and keep in Umbraco's key/value table under
+  `uSync.StateCache.Id` (the same pattern as
+  [`SyncTrackerService`](../../uSync.BackOffice/Tracker/SyncTrackerService.cs)). Costs one
+  key/value read per run, and catches a database restore, a database swap, or pointing the site at
+  a different database. If we cannot read it, the cache is not used at all.
+- **the uSync version** — a new version may serialize differently.
+- **a fingerprint of the settings that affect serialization** — folders, root folder, folder mode,
+  default extension, default set, and the default handler set's settings. Changing a handler
+  setting changes the shape of the exported xml, so the recorded hashes stop meaning anything.
+
+### The journal
+
+Removing an entry from memory does nothing about the copy of it in the file on disk — and the file
+is what the next restart trusts. But writing a whole manifest on every editor save would be far
+too much.
+
+So invalidations append a line to `state-{identity}.invalid` (a few bytes), and the journal is
+replayed on load and folded back in whenever a fresh manifest is written. Both halves happen under
+one lock, so an invalidation can never slip in between "manifest written" and "journal cleared"
+and be lost.
+
+## 5. What it cannot see
+
+Read this section before turning it on. **With the cache on, uSync's change detection stops being
+self-verifying and starts trusting its own bookkeeping.**
+
+1. **A database change made by something that raises no Umbraco notification.** Raw SQL, a
+   row-level restore, or an edit made by a differently configured instance. The database stamp
+   catches a whole-database swap; it cannot catch a targeted edit. This is the accepted residual
+   risk, and the reason the default is off.
+2. **A cross-item dependency we have not thought of.** The known ones are handled (see section 3),
+   but any serializer that pulls data in from another item is a new hole. **If you write a custom
+   serializer that embeds data from a different item, that item's type needs adding to
+   `SyncStateCache`'s shared-item-types set.**
+3. **The report is no longer an independent check.** Report and import share one cache so they can
+   never disagree with each other — but that means a wrong entry hides the item from the report
+   too. A **force import** is the way to get a guaranteed full check; it bypasses the cache
+   entirely.
+4. **Dictionary items whose file key differs from the database key.** Dictionary items are matched
+   by alias and uSync deliberately ignores the key when comparing them, but the cache files entries
+   under the key in the file. If those two differ, an invalidation for the database item will not
+   find the entry. Narrow, but real.
+5. **Multiple handler sets with different serialization settings** run against the same folders.
+   The identity fingerprint covers the default set only, so entries recorded under one set could be
+   consulted under another. Leave the cache off if you do this.
+6. **`LocalTempPath` is not guaranteed to survive.** Azure App Service recycles it, a container
+   restart loses it, and on scale-out each instance has its own. All of those degrade to "slow
+   first run", which is safe — but on some hosting the cache may rarely be warm and the feature
+   will quietly do very little. Measure before promising anything.
+
+Every one of these fails towards a *stale skip* at worst, and the cache is cleared by the next
+relevant save. But a stale skip means an item that should have imported did not.
+
+## 6. Operating it
+
+- **Turn it on:** `"CacheImportState": true` under `uSync:Settings`. No restart needed — the
+  setting is read at runtime.
+- **Turn it off:** set it back to `false`. Behaviour and timings return to exactly what they were.
+- **Clear it:** delete `{LocalTempPath}/uSync/cache/`, or run a force import (which ignores the
+  cache for that run). Changing any handler setting also discards it.
+- **See what it is doing:** at `Information` level, uSync logs `loaded {count} known items` on load
+  and `state cache skipped {skipped} of {total} items` at the end of a run. If `skipped` is 0 on a
+  second identical run, something is invalidating more than you expect.
+
+## 7. Deliberately not done
+
+**`UpdateDate` verification.** Storing each item's `UpdateDate` alongside the hash and validating
+it against a single `IEntityService.GetAll(objectType)` query per handler would give existence plus
+a timestamp for every item in one query, at no per-item cost. That would close limitation 1 above
+for real Umbraco node types (not dictionary items, languages, domains or webhooks, which are not
+in `umbracoNode`).
+
+This is the obvious hardening step if notification-based invalidation proves too leaky in practice.
+The manifest format has a version field so the extra data can be added without a migration.

--- a/uSync.BackOffice.Targets/appsettings-schema.usync.json
+++ b/uSync.BackOffice.Targets/appsettings-schema.usync.json
@@ -159,6 +159,11 @@
           "description": "Should folder keys be cached (for speed)",
           "default": true
         },
+        "CacheImportState": {
+          "type": "boolean",
+          "description": "Cache the results of the \"no change\" checks between runs, so repeat imports can skip\nunchanged items without a database lookup or a re-serialize.",
+          "default": false
+        },
         "ShowVersionCheckWarning": {
           "type": "boolean",
           "description": "Show a version check warning to the user if the folder version is less than the version expected by uSync.",

--- a/uSync.BackOffice/Cache/ISyncStateCache.cs
+++ b/uSync.BackOffice/Cache/ISyncStateCache.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace uSync.BackOffice.Cache;
+
+/// <summary>
+///  remembers which uSync files we have already confirmed match what is in Umbraco,
+///  so repeat imports and reports can skip those items without going near the database.
+/// </summary>
+/// <remarks>
+///  <para>
+///   working out if an item has changed normally means loading it from Umbraco, serializing
+///   the whole thing, and comparing hashes. that is the bulk of the cost of an import where
+///   nothing has actually changed. this cache lets us answer the same question with a single
+///   hash of the file we have already loaded.
+///  </para>
+///  <para>
+///   we only ever record a file we have positively confirmed as matching - either the full
+///   check ran and said "no change", or we have just written the file out ourselves during an
+///   export. we never assume that because an import succeeded the two sides now agree.
+///  </para>
+///  <para>
+///   the cache is a performance aid, not a source of truth. everything about it is designed to
+///   fail towards doing the real work: it is off by default, a force import ignores it, and it
+///   is discarded wholesale whenever we cannot prove it still applies.
+///  </para>
+/// </remarks>
+public interface ISyncStateCache
+{
+    /// <summary>
+    ///  is the cache turned on (uSync:Settings:CacheImportState)
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    ///  how many items we currently think we know about.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    ///  have we already confirmed that this exact file content matches what is in Umbraco?
+    /// </summary>
+    /// <remarks>
+    ///  false whenever we are not sure - including when the cache is off, the node is an
+    ///  action (delete/rename/clean) marker, or anything at all goes wrong.
+    /// </remarks>
+    Task<bool> IsKnownCurrentAsync(XElement node);
+
+    /// <summary>
+    ///  record that this exact file content is known to match what is in Umbraco.
+    /// </summary>
+    Task RecordAsync(XElement node);
+
+    /// <summary>
+    ///  forget what we knew about a single item.
+    /// </summary>
+    /// <remarks>
+    ///  item types whose contents get embedded in other items (doc types, templates, languages
+    ///  and so on) escalate to <see cref="InvalidateAllAsync"/> - renaming a doc type changes
+    ///  the serialized xml of every item that uses it, without touching their rows.
+    /// </remarks>
+    Task InvalidateAsync(string itemType, Guid key);
+
+    /// <summary>
+    ///  forget everything we knew about one type of item.
+    /// </summary>
+    /// <remarks>
+    ///  used for moves - moving a node rewrites the path of everything beneath it, so
+    ///  invalidating just the moved item is not enough.
+    /// </remarks>
+    Task InvalidateTypeAsync(string itemType);
+
+    /// <summary>
+    ///  forget everything.
+    /// </summary>
+    Task InvalidateAllAsync();
+
+    /// <summary>
+    ///  load the cache from disk (called once, on first use).
+    /// </summary>
+    Task LoadAsync();
+
+    /// <summary>
+    ///  write the cache back to disk, if anything has changed since we loaded it.
+    /// </summary>
+    Task PersistAsync();
+}

--- a/uSync.BackOffice/Cache/SyncStateCache.cs
+++ b/uSync.BackOffice/Cache/SyncStateCache.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
+
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.Core;
+using uSync.Core.Extensions;
+
+namespace uSync.BackOffice.Cache;
+
+/// <inheritdoc/>
+/// <remarks>
+///  <para>
+///   the cache is a flat map of "item type + key" to "the hash of the file we last confirmed
+///   matched". it lives in the site's temp folder - never in the uSync folder, because it
+///   describes this site's database, not the source of truth, and should never travel between
+///   environments.
+///  </para>
+///  <para>
+///   the file name and contents both carry an identity - a stamp we keep in Umbraco's key/value
+///   table, the uSync version, and a fingerprint of the settings that affect serialization. if
+///   any of those change we cannot prove the cache still applies, so we throw it away.
+///  </para>
+///  <para>
+///   invalidations are appended to a small journal file as they happen, and the journal is
+///   replayed when we load. without that, an item saved between two uSync runs (or between a
+///   run and a restart) could still be sitting in the manifest, and we would wrongly skip it.
+///  </para>
+/// </remarks>
+internal class SyncStateCache : ISyncStateCache
+{
+    /// <summary>
+    ///  key we store our database stamp under, so we can tell if we are looking at the
+    ///  same database that wrote the cache.
+    /// </summary>
+    private const string _databaseStampKey = "uSync.StateCache.Id";
+
+    /// <summary>
+    ///  bump this if the shape of the file changes, so old files are discarded.
+    /// </summary>
+    private const int _formatVersion = 1;
+
+    private const string _cacheFolder = "uSync/cache";
+
+    /// <summary>
+    ///  item types whose contents get embedded in *other* items when those are serialized.
+    /// </summary>
+    /// <remarks>
+    ///  a content item's xml carries its doc type alias, template alias and path; a dictionary
+    ///  item's carries its languages. so renaming a doc type changes the serialized xml of every
+    ///  item that uses it, while leaving those items' own rows (and notifications) untouched.
+    ///  there is no cheap way to work out which items are affected, and these changes are rare,
+    ///  so we throw the whole cache away instead.
+    /// </remarks>
+    private static readonly HashSet<string> _sharedItemTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        Core.uSyncConstants.Serialization.ContentType,
+        Core.uSyncConstants.Serialization.MediaType,
+        Core.uSyncConstants.Serialization.MemberType,
+        Core.uSyncConstants.Serialization.DataType,
+        Core.uSyncConstants.Serialization.Template,
+        Core.uSyncConstants.Serialization.Language,
+        Core.uSyncConstants.Serialization.ElementContainer,
+    };
+
+    private readonly ILogger<SyncStateCache> _logger;
+    private readonly ISyncConfigService _configService;
+    private readonly ISyncFileService _fileService;
+    private readonly IHostingEnvironment _hostingEnvironment;
+    private readonly IKeyValueService _keyValueService;
+
+    private readonly ConcurrentDictionary<string, string> _entries = new(StringComparer.Ordinal);
+
+    private readonly SemaphoreSlim _loadLock = new(1, 1);
+
+    /// <summary>
+    ///  held while anything changes what we have on disk - invalidations appending to the
+    ///  journal, and persist writing the manifest and clearing the journal.
+    /// </summary>
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    private bool _loaded;
+    private bool _usable = true;
+    private bool _dirty;
+    private bool _manifestOnDisk;
+
+    private string? _identity;
+    private string? _manifestFile;
+    private string? _journalFile;
+
+    public SyncStateCache(
+        ILogger<SyncStateCache> logger,
+        ISyncConfigService configService,
+        ISyncFileService fileService,
+        IHostingEnvironment hostingEnvironment,
+        IKeyValueService keyValueService)
+    {
+        _logger = logger;
+        _configService = configService;
+        _fileService = fileService;
+        _hostingEnvironment = hostingEnvironment;
+        _keyValueService = keyValueService;
+    }
+
+    /// <inheritdoc/>
+    public bool IsEnabled => _configService.Settings.CacheImportState;
+
+    /// <inheritdoc/>
+    public int Count => _entries.Count;
+
+    #region Lookup and record
+
+    /// <inheritdoc/>
+    public async Task<bool> IsKnownCurrentAsync(XElement node)
+    {
+        if (IsEnabled is false) return false;
+
+        var entryKey = GetEntryKey(node);
+        if (entryKey is null) return false;
+
+        await EnsureLoadedAsync();
+        if (_usable is false) return false;
+
+        if (_entries.TryGetValue(entryKey, out var known) is false) return false;
+
+        var hash = await MakeSafeHashAsync(node);
+        return hash is not null && string.Equals(hash, known, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public async Task RecordAsync(XElement node)
+    {
+        if (IsEnabled is false) return;
+
+        var entryKey = GetEntryKey(node);
+        if (entryKey is null) return;
+
+        await EnsureLoadedAsync();
+        if (_usable is false) return;
+
+        var hash = await MakeSafeHashAsync(node);
+        if (hash is null) return;
+
+        _entries[entryKey] = hash;
+        _dirty = true;
+    }
+
+    /// <summary>
+    ///  the key we file an item under - scoped by type, because different types can share a key
+    ///  (this is the same scheme <see cref="ISyncFileService.VerifyFolderAsync"/> uses to spot
+    ///  clashes).
+    /// </summary>
+    /// <returns>null if this node is not something we can safely cache</returns>
+    private static string? GetEntryKey(XElement? node)
+    {
+        if (node is null) return null;
+
+        // action files (delete/rename/clean markers) are never cached. whether they are
+        // "current" depends on whether the item still exists, and they are filed under the
+        // 'Empty' node name, so an invalidation for the real item would never reach them.
+        if (node.IsEmptyItem()) return null;
+
+        var key = node.GetKey();
+        if (key == Guid.Empty) return null;
+
+        return GetEntryKey(node.Name.LocalName, key);
+    }
+
+    private static string GetEntryKey(string itemType, Guid key)
+        => $"{itemType}_{key}";
+
+    private async Task<string?> MakeSafeHashAsync(XElement node)
+    {
+        try
+        {
+            return await node.MakePlatformSafeHashAsync();
+        }
+        catch (Exception ex)
+        {
+            // a cache is never worth failing an import over.
+            _logger.LogWarning(ex, "uSync state cache: could not hash a node, treating it as changed");
+            return null;
+        }
+    }
+
+    #endregion
+
+    #region Invalidation
+
+    /// <inheritdoc/>
+    public async Task InvalidateAsync(string itemType, Guid key)
+    {
+        if (string.IsNullOrWhiteSpace(itemType) || key == Guid.Empty) return;
+
+        // see _sharedItemTypes - these change how other items serialize, so a single key
+        // is not enough.
+        if (_sharedItemTypes.Contains(itemType))
+        {
+            await InvalidateAllAsync();
+            return;
+        }
+
+        if (await PrepareForInvalidationAsync() is false) return;
+
+        var entryKey = GetEntryKey(itemType, key);
+        await ApplyInvalidationAsync(entryKey, () => _entries.TryRemove(entryKey, out _));
+    }
+
+    /// <inheritdoc/>
+    public async Task InvalidateTypeAsync(string itemType)
+    {
+        if (string.IsNullOrWhiteSpace(itemType)) return;
+
+        if (_sharedItemTypes.Contains(itemType))
+        {
+            await InvalidateAllAsync();
+            return;
+        }
+
+        if (await PrepareForInvalidationAsync() is false) return;
+
+        await ApplyInvalidationAsync($"#{itemType}", () => RemoveByType(itemType));
+    }
+
+    /// <inheritdoc/>
+    public async Task InvalidateAllAsync()
+    {
+        if (await PrepareForInvalidationAsync() is false) return;
+
+        await ApplyInvalidationAsync("*", _entries.Clear);
+    }
+
+    /// <summary>
+    ///  make sure we are in a position to invalidate anything.
+    /// </summary>
+    /// <remarks>
+    ///  we have to load before we can invalidate. clearing an entry from memory does nothing
+    ///  about the copy of it sitting in the file on disk - and the file is what we will trust
+    ///  after the next restart. so an item saved before uSync has run even once still has to
+    ///  reach the journal.
+    ///
+    ///  note this happens whether or not the setting is on: if someone turns the cache off,
+    ///  edits things, and turns it back on, the file must not still be claiming those items
+    ///  are unchanged.
+    /// </remarks>
+    private async Task<bool> PrepareForInvalidationAsync()
+    {
+        await EnsureLoadedAsync();
+        return _usable;
+    }
+
+    private void RemoveByType(string itemType)
+    {
+        var prefix = $"{itemType}_";
+        foreach (var key in _entries.Keys.Where(x => x.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+        {
+            _entries.TryRemove(key, out _);
+        }
+    }
+
+    /// <summary>
+    ///  drop the entries from memory and note the invalidation on disk, so it survives a restart.
+    /// </summary>
+    /// <remarks>
+    ///  writing the whole manifest on every editor save would be far too much, so instead we
+    ///  append a line to a journal (a few bytes) and fold it back in the next time we write a
+    ///  fresh manifest.
+    ///
+    ///  both halves happen under the write lock, and <see cref="PersistAsync"/> takes the same
+    ///  lock, so an invalidation can never slip in between "manifest written" and "journal
+    ///  cleared" and be lost.
+    /// </remarks>
+    private async Task ApplyInvalidationAsync(string line, Action removeFromMemory)
+    {
+        await _writeLock.WaitAsync();
+        try
+        {
+            removeFromMemory();
+
+            // so the next persist rewrites the manifest without these entries, and the
+            // journal can be cleared rather than growing forever.
+            _dirty = true;
+
+            // nothing on disk to correct means nothing to journal - the normal state for
+            // anyone who has never turned the cache on.
+            if (_journalFile is null || _manifestOnDisk is false) return;
+
+            // deliberately not going through ISyncFileService: it has no append, and this
+            // is a few bytes into a temp file that we own.
+            await File.AppendAllTextAsync(_journalFile, line + Environment.NewLine);
+        }
+        catch (Exception ex)
+        {
+            // if we cannot journal, we cannot promise the file on disk is right after a
+            // restart - so stop trusting it.
+            _logger.LogWarning(ex, "uSync state cache: could not record an invalidation, no longer using the cache");
+            _usable = false;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private void ApplyJournalLine(string line)
+    {
+        line = line.Trim();
+        if (line.Length == 0) return;
+
+        if (line == "*")
+        {
+            _entries.Clear();
+        }
+        else if (line[0] == '#')
+        {
+            RemoveByType(line[1..]);
+        }
+        else
+        {
+            _entries.TryRemove(line, out _);
+        }
+    }
+
+    #endregion
+
+    #region Load and persist
+
+    private async Task EnsureLoadedAsync()
+    {
+        if (_loaded) return;
+        await LoadAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task LoadAsync()
+    {
+        await _loadLock.WaitAsync();
+        try
+        {
+            if (_loaded) return;
+
+            // mark as loaded first: whatever happens below, we only try this once, and every
+            // failure path leaves us with an empty cache (which just means "check everything").
+            _loaded = true;
+
+            _identity = CalculateIdentity();
+            if (_identity is null)
+            {
+                _usable = false;
+                return;
+            }
+
+            var folder = _fileService.GetAbsPath(Path.Combine(_hostingEnvironment.LocalTempPath, _cacheFolder));
+            _manifestFile = Path.Combine(folder, $"state-{_identity}.json");
+            _journalFile = Path.Combine(folder, $"state-{_identity}.invalid");
+
+            if (_fileService.FileExists(_manifestFile) is false)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("uSync state cache: no cache file yet, starting empty");
+                return;
+            }
+
+            _manifestOnDisk = true;
+
+            var content = await _fileService.LoadContentAsync(_manifestFile);
+            if (content.TryDeserialize<SyncStateCacheFile>(out var manifest) is false || manifest is null)
+            {
+                // dirty, so the next run replaces the unreadable file rather than rejecting
+                // it again on every restart.
+                _dirty = true;
+                _logger.LogWarning("uSync state cache: could not read the cache file, starting empty");
+                return;
+            }
+
+            if (manifest.FormatVersion != _formatVersion ||
+                string.Equals(manifest.Identity, _identity, StringComparison.Ordinal) is false)
+            {
+                // shouldn't happen (the identity is in the file name) but if someone copies a
+                // file around, this is what catches it.
+                _dirty = true;
+                _logger.LogInformation("uSync state cache: cache file no longer applies to this site, starting empty");
+                return;
+            }
+
+            foreach (var entry in manifest.Entries)
+            {
+                _entries[entry.Key] = entry.Value;
+            }
+
+            await ReplayJournalAsync();
+
+            if (_logger.IsEnabled(LogLevel.Information))
+                _logger.LogInformation("uSync state cache: loaded {count} known items", _entries.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "uSync state cache: failed to load, everything will be checked normally");
+            _entries.Clear();
+            _usable = false;
+        }
+        finally
+        {
+            _loadLock.Release();
+        }
+    }
+
+    private async Task ReplayJournalAsync()
+    {
+        if (_journalFile is null || _fileService.FileExists(_journalFile) is false) return;
+
+        var journal = await _fileService.LoadContentAsync(_journalFile);
+        var lines = journal.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            ApplyJournalLine(line);
+        }
+
+        if (lines.Length > 0)
+        {
+            // anything the journal removed needs to come out of the file too.
+            _dirty = true;
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("uSync state cache: replayed {count} invalidations", lines.Length);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task PersistAsync()
+    {
+        // note: we persist even when the setting is off, because a run may have folded
+        // invalidations out of the file, and losing those is the one thing that would make
+        // the cache lie to us later.
+        if (_loaded is false || _usable is false || _dirty is false) return;
+        if (_manifestFile is null || _identity is null) return;
+
+        // the whole write happens under the same lock invalidations use, so one cannot land
+        // between "manifest written" and "journal cleared" and be thrown away.
+        await _writeLock.WaitAsync();
+        try
+        {
+            var manifest = new SyncStateCacheFile
+            {
+                FormatVersion = _formatVersion,
+                Identity = _identity,
+                SavedAt = DateTime.UtcNow,
+                Entries = _entries.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal),
+            };
+
+            _fileService.CreateFoldersForFile(_manifestFile);
+            await _fileService.SaveFileAsync(_manifestFile, manifest.SerializeJsonString(false));
+            _manifestOnDisk = true;
+
+            // the manifest now includes everything the journal was telling us.
+            if (_journalFile is not null && _fileService.FileExists(_journalFile))
+                _fileService.DeleteFile(_journalFile);
+
+            _dirty = false;
+
+            CleanUpOldCacheFiles();
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("uSync state cache: saved {count} known items", _entries.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "uSync state cache: failed to save");
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    ///  remove cache files for identities that no longer apply (e.g. after a settings change).
+    /// </summary>
+    private void CleanUpOldCacheFiles()
+    {
+        if (_manifestFile is null) return;
+
+        try
+        {
+            var folder = Path.GetDirectoryName(_manifestFile);
+            if (string.IsNullOrEmpty(folder)) return;
+
+            foreach (var file in _fileService.GetFiles(folder, "state-*.*"))
+            {
+                if (_fileService.PathMatches(file, _manifestFile)) continue;
+
+                // never our own journal - an invalidation may have re-created it.
+                if (_journalFile is not null && _fileService.PathMatches(file, _journalFile)) continue;
+
+                _fileService.DeleteFile(file);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "uSync state cache: could not tidy up old cache files");
+        }
+    }
+
+    #endregion
+
+    #region Identity
+
+    /// <summary>
+    ///  work out whether the cache we have on disk still describes this site.
+    /// </summary>
+    /// <returns>null if we cannot tell, in which case the cache is not used at all</returns>
+    private string? CalculateIdentity()
+    {
+        try
+        {
+            var databaseStamp = GetDatabaseStamp();
+            if (databaseStamp is null) return null;
+
+            return HashString($"db={databaseStamp}\n{BuildSettingsFingerprint()}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "uSync state cache: could not work out the cache identity");
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///  describe everything that could change what uSync writes out, so that a change to any of
+    ///  it means the hashes we recorded stop meaning anything.
+    /// </summary>
+    /// <remarks>
+    ///  built by hand rather than by serializing the settings, because this has to produce the
+    ///  same string on every start of the same site. dictionaries bound from configuration
+    ///  enumerate in whatever order the configuration provider hands them over, and if that
+    ///  wobbled the identity would change on restart and the cache would silently never survive
+    ///  one. hence the explicit ordering.
+    ///
+    ///  erring towards including too much: a setting listed here that turns out not to affect
+    ///  the xml just means the cache is discarded more often than it needs to be, which is
+    ///  slow. a setting missing from here means the cache could be wrong, which is worse.
+    /// </remarks>
+    private string BuildSettingsFingerprint()
+    {
+        var settings = _configService.Settings;
+        var set = _configService.GetDefaultSetSettings();
+
+        var parts = new List<string>
+        {
+            $"version={uSync.Version}",
+            $"root={settings.RootFolder}",
+            $"folders={string.Join('|', _configService.GetFolders())}",
+            $"extension={settings.DefaultExtension}",
+            $"foldermode={settings.FolderMode}",
+            $"production={settings.ProductionFolder}",
+            $"set={settings.DefaultSet}",
+            $"disabled={string.Join('|', set.DisabledHandlers.OrderBy(x => x, StringComparer.OrdinalIgnoreCase))}",
+            $"defaults={Describe(set.HandlerDefaults)}",
+        };
+
+        foreach (var handler in set.Handlers.OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            parts.Add($"handler:{handler.Key}={Describe(handler.Value)}");
+        }
+
+        return string.Join('\n', parts);
+    }
+
+    private static string Describe(HandlerSettings? handler)
+    {
+        if (handler is null) return string.Empty;
+
+        var extra = handler.Settings is null
+            ? string.Empty
+            : string.Join(',', handler.Settings
+                .OrderBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(x => $"{x.Key}={x.Value}"));
+
+        return string.Join('/', [
+            handler.Enabled.ToString(),
+            string.Join('+', handler.Actions.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+            handler.UseFlatStructure.ToString(),
+            handler.GuidNames.ToString(),
+            handler.CreateClean.ToString(),
+            handler.FullFileOnDifference.ToString(),
+            handler.Group,
+            $"[{extra}]"
+        ]);
+    }
+
+    /// <summary>
+    ///  a value we keep in the database, so that restoring or pointing at a different database
+    ///  invalidates everything we thought we knew.
+    /// </summary>
+    private string? GetDatabaseStamp()
+    {
+        try
+        {
+            var stamp = _keyValueService.GetValue(_databaseStampKey);
+            if (string.IsNullOrWhiteSpace(stamp) is false) return stamp;
+
+            stamp = Guid.NewGuid().ToString();
+            _keyValueService.SetValue(_databaseStampKey, stamp);
+            return stamp;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "uSync state cache: could not read the database stamp");
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///  same approach as the xml hashing - we want the same answer on every machine, so
+    ///  not GetHashCode.
+    /// </summary>
+    private static string HashString(string value)
+    {
+        using HashAlgorithm hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA1.Create() : MD5.Create();
+        return Convert.ToHexStringLower(hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(value)));
+    }
+
+    #endregion
+
+    /// <summary>
+    ///  on disk shape of the cache.
+    /// </summary>
+    internal class SyncStateCacheFile
+    {
+        public int FormatVersion { get; set; }
+        public string Identity { get; set; } = string.Empty;
+        public DateTime SavedAt { get; set; }
+        public Dictionary<string, string> Entries { get; set; } = [];
+    }
+}

--- a/uSync.BackOffice/Cache/SyncStateCacheInvalidator.cs
+++ b/uSync.BackOffice/Cache/SyncStateCacheInvalidator.cs
@@ -1,0 +1,305 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Notifications;
+
+using uSync.Core;
+
+namespace uSync.BackOffice.Cache;
+
+/// <summary>
+///  listens to Umbraco and forgets anything the state cache can no longer vouch for.
+/// </summary>
+/// <remarks>
+///  <para>
+///   this is what stops the cache going stale: as soon as Umbraco tells us an item has been
+///   saved, deleted, moved or published, we stop claiming to know anything about it. all of it
+///   happens whether or not the cache is currently switched on, because otherwise turning it
+///   off, editing things, and turning it back on would leave the cache confidently wrong.
+///  </para>
+///  <para>
+///   three levels of forgetting, and picking the right one is the whole game:
+///   <list type="bullet">
+///    <item><b>the item</b> - a save or publish only changes that item's own xml.</item>
+///    <item><b>every item of that type</b> - a move rewrites the path of everything underneath
+///          it, and paths are part of the serialized xml.</item>
+///    <item><b>everything</b> - doc types, data types, templates and languages all get embedded
+///          in other items' xml, so changing one silently changes items whose own rows never
+///          moved. handled inside the cache itself (see SyncStateCache's shared item types), so
+///          it applies however the invalidation arrives.</item>
+///   </list>
+///  </para>
+///  <para>
+///   note there is no check for uSync being paused here. during uSync's own import, an item we
+///   write is invalidated and then simply not re-recorded (we only record confirmed "no change"
+///   results), so invalidating is both harmless and the safer default - it also catches items
+///   Umbraco saves as a side effect of something we imported.
+///  </para>
+/// </remarks>
+internal class SyncStateCacheInvalidator :
+
+    // content, media and elements - the high volume types, invalidated one item at a time.
+    INotificationAsyncHandler<ContentSavedNotification>,
+    INotificationAsyncHandler<ContentDeletedNotification>,
+    INotificationAsyncHandler<ContentPublishedNotification>,
+    INotificationAsyncHandler<ContentUnpublishedNotification>,
+    INotificationAsyncHandler<ContentSavedBlueprintNotification>,
+    INotificationAsyncHandler<ContentDeletedBlueprintNotification>,
+    INotificationAsyncHandler<MediaSavedNotification>,
+    INotificationAsyncHandler<MediaDeletedNotification>,
+    INotificationAsyncHandler<ElementSavedNotification>,
+    INotificationAsyncHandler<ElementDeletedNotification>,
+    INotificationAsyncHandler<ElementPublishedNotification>,
+    INotificationAsyncHandler<ElementUnpublishedNotification>,
+    INotificationAsyncHandler<DictionaryItemSavedNotification>,
+    INotificationAsyncHandler<DictionaryItemDeletedNotification>,
+
+    // moves change the path of every descendant, so the whole type has to go.
+    INotificationAsyncHandler<ContentMovedNotification>,
+    INotificationAsyncHandler<ContentMovedToRecycleBinNotification>,
+    INotificationAsyncHandler<MediaMovedNotification>,
+    INotificationAsyncHandler<MediaMovedToRecycleBinNotification>,
+    INotificationAsyncHandler<ElementMovedNotification>,
+    INotificationAsyncHandler<ElementMovedToRecycleBinNotification>,
+
+    // low volume types - not worth the per-item bookkeeping, so we drop the type.
+    INotificationAsyncHandler<DomainSavedNotification>,
+    INotificationAsyncHandler<DomainDeletedNotification>,
+    INotificationAsyncHandler<RelationTypeSavedNotification>,
+    INotificationAsyncHandler<RelationTypeDeletedNotification>,
+    INotificationAsyncHandler<WebhookSavedNotification>,
+    INotificationAsyncHandler<WebhookDeletedNotification>,
+
+    // types that get embedded in other items - these all end up clearing everything.
+    INotificationAsyncHandler<ContentTypeSavedNotification>,
+    INotificationAsyncHandler<ContentTypeDeletedNotification>,
+    INotificationAsyncHandler<ContentTypeMovedNotification>,
+    INotificationAsyncHandler<MediaTypeSavedNotification>,
+    INotificationAsyncHandler<MediaTypeDeletedNotification>,
+    INotificationAsyncHandler<MediaTypeMovedNotification>,
+    INotificationAsyncHandler<MemberTypeSavedNotification>,
+    INotificationAsyncHandler<MemberTypeDeletedNotification>,
+    INotificationAsyncHandler<MemberTypeMovedNotification>,
+    INotificationAsyncHandler<DataTypeSavedNotification>,
+    INotificationAsyncHandler<DataTypeDeletedNotification>,
+    INotificationAsyncHandler<DataTypeMovedNotification>,
+    INotificationAsyncHandler<TemplateSavedNotification>,
+    INotificationAsyncHandler<TemplateDeletedNotification>,
+    INotificationAsyncHandler<LanguageSavedNotification>,
+    INotificationAsyncHandler<LanguageDeletedNotification>,
+    INotificationAsyncHandler<EntityContainerSavedNotification>,
+    INotificationAsyncHandler<EntityContainerRenamedNotification>
+{
+    private readonly ISyncStateCache _stateCache;
+
+    public SyncStateCacheInvalidator(ISyncStateCache stateCache)
+    {
+        _stateCache = stateCache;
+    }
+
+    #region Content
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentSavedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, n.SavedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentDeletedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, n.DeletedEntities);
+
+    /// <inheritdoc/>
+    /// <remarks>publishing does not always fire a save, so it needs handling separately.</remarks>
+    public Task HandleAsync(ContentPublishedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, n.PublishedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentUnpublishedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, n.UnpublishedEntities);
+
+    /// <inheritdoc/>
+    /// <remarks>blueprints are serialized as content, so they share the same entry keys.</remarks>
+    public Task HandleAsync(ContentSavedBlueprintNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, [n.SavedBlueprint]);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentDeletedBlueprintNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Content, n.DeletedBlueprints);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentMovedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Content);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentMovedToRecycleBinNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Content);
+
+    #endregion
+
+    #region Media
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaSavedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Media, n.SavedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaDeletedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Media, n.DeletedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaMovedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Media);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaMovedToRecycleBinNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Media);
+
+    #endregion
+
+    #region Elements
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementSavedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Element, n.SavedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementDeletedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Element, n.DeletedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementPublishedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Element, n.PublishedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementUnpublishedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Element, n.UnpublishedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementMovedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Element);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ElementMovedToRecycleBinNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Element);
+
+    #endregion
+
+    #region Dictionary
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DictionaryItemSavedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Dictionary, n.SavedEntities);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DictionaryItemDeletedNotification n, CancellationToken c)
+        => InvalidateAsync(Core.uSyncConstants.Serialization.Dictionary, n.DeletedEntities);
+
+    #endregion
+
+    #region Low volume types (drop the whole type, there is nothing to gain by being precise)
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DomainSavedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Domain);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DomainDeletedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Domain);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(RelationTypeSavedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.RelationType);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(RelationTypeDeletedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.RelationType);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(WebhookSavedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Webhook);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(WebhookDeletedNotification n, CancellationToken c)
+        => _stateCache.InvalidateTypeAsync(Core.uSyncConstants.Serialization.Webhook);
+
+    #endregion
+
+    #region Types that change how other items serialize
+
+    // all of these route through Invalidate with an item type the cache treats as shared,
+    // which clears everything. keeping them as normal invalidations (rather than calling
+    // InvalidateAll here) means the policy lives in one place.
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentTypeSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentTypeDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(ContentTypeMovedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaTypeSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaTypeDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MediaTypeMovedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MemberTypeSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MemberTypeDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(MemberTypeMovedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DataTypeSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DataTypeDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(DataTypeMovedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(TemplateSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(TemplateDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(LanguageSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(LanguageDeletedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    /// <remarks>a container is a folder - renaming one changes the path of everything in it.</remarks>
+    public Task HandleAsync(EntityContainerSavedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(EntityContainerRenamedNotification n, CancellationToken c) => InvalidateEverythingAsync();
+
+    private Task InvalidateEverythingAsync()
+        => _stateCache.InvalidateAllAsync();
+
+    #endregion
+
+    private async Task InvalidateAsync(string itemType, IEnumerable<IEntity> items)
+    {
+        if (items is null) return;
+
+        foreach (var item in items.Where(x => x is not null))
+        {
+            await _stateCache.InvalidateAsync(itemType, item.Key);
+        }
+    }
+}

--- a/uSync.BackOffice/Cache/SyncStateCacheManager.cs
+++ b/uSync.BackOffice/Cache/SyncStateCacheManager.cs
@@ -1,0 +1,185 @@
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+using Microsoft.Extensions.Logging;
+
+using Umbraco.Cms.Core.Events;
+
+using uSync.Core;
+
+namespace uSync.BackOffice.Cache;
+
+/// <summary>
+///  plugs the state cache into uSync's own import, report and export notifications.
+/// </summary>
+/// <remarks>
+///  <para>
+///   deliberately done through notifications rather than by changing the import pipeline. uSync
+///   already fires a cancelable notification per item on both the import and report paths - the
+///   report one exists for exactly this reason ("this lets us intercept a report and shortcut
+///   the checking") - so the whole feature can hang off the side without touching how items are
+///   deserialized or compared.
+///  </para>
+///  <para>
+///   the three things we do:
+///   <list type="bullet">
+///    <item>before an item is checked, cancel it if we already know the file matches</item>
+///    <item>after an item is checked, remember it if the answer was "no change"</item>
+///    <item>after an item is exported, remember it - we just wrote the file from the database,
+///          so the two sides match by construction</item>
+///   </list>
+///  </para>
+/// </remarks>
+internal class SyncStateCacheManager :
+    INotificationAsyncHandler<uSyncImportStartingNotification>,
+    INotificationAsyncHandler<uSyncReportStartingNotification>,
+    INotificationAsyncHandler<uSyncExportStartingNotification>,
+    INotificationAsyncHandler<uSyncImportCompletedNotification>,
+    INotificationAsyncHandler<uSyncReportCompletedNotification>,
+    INotificationAsyncHandler<uSyncExportCompletedNotification>,
+    INotificationAsyncHandler<uSyncImportingItemNotification>,
+    INotificationAsyncHandler<uSyncReportingItemNotification>,
+    INotificationAsyncHandler<uSyncImportedItemNotification>,
+    INotificationAsyncHandler<uSyncReportedItemNotification>,
+    INotificationAsyncHandler<uSyncExportedItemNotification>
+{
+    private readonly ISyncStateCache _stateCache;
+    private readonly ILogger<SyncStateCacheManager> _logger;
+
+    private int _checked;
+    private int _skipped;
+
+    public SyncStateCacheManager(
+        ISyncStateCache stateCache,
+        ILogger<SyncStateCacheManager> logger)
+    {
+        _stateCache = stateCache;
+        _logger = logger;
+    }
+
+    #region Run start and end
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncImportStartingNotification notification, CancellationToken c) => StartRunAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncReportStartingNotification notification, CancellationToken c) => StartRunAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncExportStartingNotification notification, CancellationToken c) => StartRunAsync();
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncImportCompletedNotification notification, CancellationToken c) => EndRunAsync("Import");
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncReportCompletedNotification notification, CancellationToken c) => EndRunAsync("Report");
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncExportCompletedNotification notification, CancellationToken c) => EndRunAsync("Export");
+
+    private async Task StartRunAsync()
+    {
+        Interlocked.Exchange(ref _checked, 0);
+        Interlocked.Exchange(ref _skipped, 0);
+
+        if (_stateCache.IsEnabled is false) return;
+        await _stateCache.LoadAsync();
+    }
+
+    private async Task EndRunAsync(string operation)
+    {
+        // persist runs even when the setting is off - a run can fold invalidations out of the
+        // cache file, and those are the one thing we must not lose.
+        await _stateCache.PersistAsync();
+
+        var skipped = Volatile.Read(ref _skipped);
+        if (skipped > 0 && _logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "uSync {operation}: state cache skipped {skipped} of {total} items (no database lookup or serialize needed)",
+                operation, skipped, Volatile.Read(ref _checked));
+        }
+    }
+
+    #endregion
+
+    #region Skipping items we already know about
+
+    /// <inheritdoc/>
+    public async Task HandleAsync(uSyncImportingItemNotification notification, CancellationToken c)
+    {
+        if (notification.Force) return;
+        if (await IsKnownCurrentAsync(notification.Item) is false) return;
+
+        notification.Cancel = true;
+        notification.Message = "No change (from the state cache)";
+    }
+
+    /// <inheritdoc/>
+    public async Task HandleAsync(uSyncReportingItemNotification notification, CancellationToken c)
+    {
+        if (notification.Force) return;
+        if (await IsKnownCurrentAsync(notification.Item) is false) return;
+
+        notification.Cancel = true;
+        notification.Message = "No change (from the state cache)";
+    }
+
+    private async Task<bool> IsKnownCurrentAsync(XElement? node)
+    {
+        if (_stateCache.IsEnabled is false || node is null) return false;
+
+        Interlocked.Increment(ref _checked);
+
+        if (await _stateCache.IsKnownCurrentAsync(node) is false) return false;
+
+        Interlocked.Increment(ref _skipped);
+        return true;
+    }
+
+    #endregion
+
+    #region Learning which items match
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncImportedItemNotification notification, CancellationToken c)
+        => RecordIfUnchangedAsync(notification);
+
+    /// <inheritdoc/>
+    public Task HandleAsync(uSyncReportedItemNotification notification, CancellationToken c)
+        => RecordIfUnchangedAsync(notification);
+
+    /// <summary>
+    ///  remember the file only when the full check ran and told us it matches.
+    /// </summary>
+    /// <remarks>
+    ///  specifically *not* recording after a successful update or create. it is tempting to
+    ///  assume the two sides now agree, but they do not always: some items don't round-trip
+    ///  exactly, which is what uSync's "xml is different - but properties may not have changed"
+    ///  message is telling you. recording those would silence a real difference for good.
+    ///  instead they get checked again next time, which is both honest and self-correcting.
+    /// </remarks>
+    private async Task RecordIfUnchangedAsync(uSyncItemNotification<XElement> notification)
+    {
+        if (_stateCache.IsEnabled is false) return;
+        if (notification.Change != ChangeType.NoChange) return;
+        if (notification.Item is null) return;
+
+        await _stateCache.RecordAsync(notification.Item);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    ///  an export has just written this xml to disk straight from the database, so the file and
+    ///  the database agree by construction. this is what makes an export a way to warm the cache
+    ///  up without a slow first import.
+    /// </remarks>
+    public async Task HandleAsync(uSyncExportedItemNotification notification, CancellationToken c)
+    {
+        if (_stateCache.IsEnabled is false || notification.Item is null) return;
+        await _stateCache.RecordAsync(notification.Item);
+    }
+
+    #endregion
+}

--- a/uSync.BackOffice/Configuration/uSyncSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncSettings.cs
@@ -146,6 +146,32 @@ public class uSyncSettings
 
 
     /// <summary>
+    /// Cache the results of the "no change" checks between runs, so repeat imports can skip
+    /// unchanged items without a database lookup or a re-serialize.
+    /// </summary>
+    /// <remarks>
+    ///  uSync works out if an item has changed by loading the item from Umbraco, serializing it,
+    ///  and comparing the hash to the file. that means an import where nothing has changed costs
+    ///  about as much as a full export. with this on, uSync remembers the file hashes it has
+    ///  already confirmed as matching, and skips those items entirely.
+    ///
+    ///  the cache only ever remembers items where the full check actually ran and said
+    ///  "no change" (or that we have just exported), so the fast path is only taken for items
+    ///  we have positively checked. that also means the first run after turning this on is no
+    ///  faster than before - the benefit arrives on the second run.
+    ///
+    ///  the cache lives in the site's temp folder, never in the uSync folder, and is thrown
+    ///  away when the database, the uSync version, or the handler settings change. items are
+    ///  removed from it when Umbraco tells us they have been saved, deleted, moved or published.
+    ///  a force import always ignores it.
+    ///
+    ///  what it cannot see is a change made to the database by something that raises no Umbraco
+    ///  notification (raw SQL, for example) - hence the default of off.
+    /// </remarks>
+    [DefaultValue(false)]
+    public bool CacheImportState { get; set; } = false;
+
+    /// <summary>
     /// Show a version check warning to the user if the folder version is less than the version expected by uSync.
     /// </summary>
     [DefaultValue(true)]

--- a/uSync.BackOffice/Notifications/uSyncNotifications/CancelableuSyncItemNotification.cs
+++ b/uSync.BackOffice/Notifications/uSyncNotifications/CancelableuSyncItemNotification.cs
@@ -27,4 +27,13 @@ public class CancelableuSyncItemNotification<TObject> : uSyncItemNotification<TO
     ///  Cancel the current process
     /// </summary>
     public bool Cancel { get; set; }
+
+    /// <summary>
+    ///  Why the process was cancelled, shown to the user against the item.
+    /// </summary>
+    /// <remarks>
+    ///  optional - if you cancel without setting this, uSync reports its generic
+    ///  "change stopped by delegate event" message.
+    /// </remarks>
+    public string? Message { get; set; }
 }

--- a/uSync.BackOffice/Notifications/uSyncNotifications/uSyncImportingItemNotification.cs
+++ b/uSync.BackOffice/Notifications/uSyncNotifications/uSyncImportingItemNotification.cs
@@ -21,4 +21,14 @@ public class uSyncImportingItemNotification : CancelableuSyncItemNotification<XE
     public uSyncImportingItemNotification(XElement item, ISyncHandler handler)
         : base(item, handler) { }
 
+    /// <summary>
+    ///  is this a forced import (the user has asked for the item to be imported
+    ///  regardless of whether anything appears to have changed).
+    /// </summary>
+    /// <remarks>
+    ///  anything short-cutting the import because it believes nothing has changed
+    ///  should stand down when this is set - a forced import is how someone gets a
+    ///  guaranteed, full import.
+    /// </remarks>
+    public bool Force { get; set; }
 }

--- a/uSync.BackOffice/Notifications/uSyncNotifications/uSyncReportingItemNotification.cs
+++ b/uSync.BackOffice/Notifications/uSyncNotifications/uSyncReportingItemNotification.cs
@@ -10,4 +10,9 @@ public class uSyncReportingItemNotification : CancelableuSyncItemNotification<XE
     /// <inheritdoc/>
     public uSyncReportingItemNotification(XElement item)
         : base(item) { }
+
+    /// <summary>
+    ///  is this a forced report (nothing should short-cut the checking).
+    /// </summary>
+    public bool Force { get; set; }
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -487,11 +487,17 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             return [uSyncAction.SetAction(true, node.GetAlias(), message: "Change blocked (based on configuration)")];
         }
 
-        if (await _mutexService.FireItemStartingEventAsync(new uSyncImportingItemNotification(node, (ISyncHandler)this)))
+        var importingNotification = new uSyncImportingItemNotification(node, (ISyncHandler)this)
+        {
+            Force = options.Flags.HasFlag(SerializerFlags.Force)
+        };
+
+        if (await _mutexService.FireItemStartingEventAsync(importingNotification))
         {
             // blocked
             return [uSyncActionHelper<TObject>
-                .ReportAction(ChangeType.NoChange, node.GetAlias(), node.GetPath(), GetNameFromFileOrNode(filename, node), node.GetKey(), this.Alias, "Change stopped by delegate event")];
+                .ReportAction(ChangeType.NoChange, node.GetAlias(), node.GetPath(), GetNameFromFileOrNode(filename, node), node.GetKey(), this.Alias,
+                    importingNotification.Message ?? "Change stopped by delegate event")];
         }
 
         try
@@ -1327,11 +1333,16 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             //  starting reporting notification
             //  this lets us intercept a report and 
             //  shortcut the checking (sometimes).
-            if (await _mutexService.FireItemStartingEventAsync(new uSyncReportingItemNotification(node)))
+            var reportingNotification = new uSyncReportingItemNotification(node)
+            {
+                Force = options.Flags.HasFlag(SerializerFlags.Force)
+            };
+
+            if (await _mutexService.FireItemStartingEventAsync(reportingNotification))
             {
                 return [uSyncActionHelper<TObject>
                     .ReportAction(ChangeType.NoChange, node.GetAlias(), node.GetPath(), GetNameFromFileOrNode(filename, node), node.GetKey(), this.Alias,
-                        "Change stopped by delegate event")];
+                        reportingNotification.Message ?? "Change stopped by delegate event")];
             }
 
             var actions = new List<uSyncAction>();

--- a/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
+++ b/uSync.BackOffice/uSyncBackOfficeBuilderExtensions.cs
@@ -83,6 +83,12 @@ public static class uSyncBackOfficeBuilderExtensions
         builder.Services.AddSingleton<ISyncService, SyncService>();
         builder.Services.AddSingleton<CacheLifecycleManager>();
 
+        // remembers which files we have already confirmed match Umbraco, so repeat runs can
+        // skip them (uSync:Settings:CacheImportState - off by default).
+        builder.Services.AddSingleton<ISyncStateCache, SyncStateCache>();
+        builder.Services.AddSingleton<SyncStateCacheManager>();
+        builder.Services.AddSingleton<SyncStateCacheInvalidator>();
+
         // first boot should happen before any other bits of uSync export on a blank site. 
         builder.AdduSyncFirstBoot();
 
@@ -274,6 +280,86 @@ public static class uSyncBackOfficeBuilderExtensions
             AddNotificationAsyncHandler<MediaSavingNotification, CacheLifecycleManager>().
             AddNotificationAsyncHandler<MediaSavedNotification, CacheLifecycleManager>().
             AddNotificationAsyncHandler<MediaDeletedNotification, CacheLifecycleManager>();
+
+        builder.AddStateCacheNotifications();
+    }
+
+    /// <summary>
+    ///  wire up the import state cache (uSync:Settings:CacheImportState).
+    /// </summary>
+    /// <remarks>
+    ///  registered unconditionally, and the setting is checked at runtime, so it can be turned
+    ///  on and off without restarting the site.
+    /// </remarks>
+    private static void AddStateCacheNotifications(this IUmbracoBuilder builder)
+    {
+        // uSync's own run and per-item notifications - this is where items get skipped
+        // and where we learn which files match.
+        builder.
+            AddNotificationAsyncHandler<uSyncImportStartingNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncReportStartingNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncExportStartingNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncImportCompletedNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncReportCompletedNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncExportCompletedNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncImportingItemNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncReportingItemNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncImportedItemNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncReportedItemNotification, SyncStateCacheManager>().
+            AddNotificationAsyncHandler<uSyncExportedItemNotification, SyncStateCacheManager>();
+
+        // Umbraco's notifications - what stops the cache going stale.
+        builder.
+            AddNotificationAsyncHandler<ContentSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentPublishedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentUnpublishedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentSavedBlueprintNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentDeletedBlueprintNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentMovedToRecycleBinNotification, SyncStateCacheInvalidator>().
+
+            AddNotificationAsyncHandler<MediaSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaMovedToRecycleBinNotification, SyncStateCacheInvalidator>().
+
+            AddNotificationAsyncHandler<ElementSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ElementDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ElementPublishedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ElementUnpublishedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ElementMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ElementMovedToRecycleBinNotification, SyncStateCacheInvalidator>().
+
+            AddNotificationAsyncHandler<DictionaryItemSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<DictionaryItemDeletedNotification, SyncStateCacheInvalidator>().
+
+            AddNotificationAsyncHandler<DomainSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<DomainDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<RelationTypeSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<RelationTypeDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<WebhookSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<WebhookDeletedNotification, SyncStateCacheInvalidator>().
+
+            // these all clear the whole cache - they change how other items serialize.
+            AddNotificationAsyncHandler<ContentTypeSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentTypeDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<ContentTypeMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaTypeSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaTypeDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MediaTypeMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MemberTypeSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MemberTypeDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<MemberTypeMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<DataTypeSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<DataTypeDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<DataTypeMovedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<TemplateSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<TemplateDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<LanguageSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<LanguageDeletedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<EntityContainerSavedNotification, SyncStateCacheInvalidator>().
+            AddNotificationAsyncHandler<EntityContainerRenamedNotification, SyncStateCacheInvalidator>();
     }
 
     private static void CreatePolicies(AuthorizationOptions options,

--- a/uSync.Tests/Cache/SyncStateCacheTests.cs
+++ b/uSync.Tests/Cache/SyncStateCacheTests.cs
@@ -1,0 +1,516 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core.Services;
+
+using uSync.BackOffice.Cache;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.Core;
+using uSync.Core.Extensions;
+
+namespace uSync.Tests.Cache;
+
+/// <summary>
+///  tests for the import state cache - the thing that lets a repeat import skip items it has
+///  already confirmed match, without going near the database.
+/// </summary>
+/// <remarks>
+///  these run against a real temp folder rather than a mocked file service, because the bits
+///  most likely to break (does a hash survive being written to disk and read back, does an
+///  invalidation survive a restart) are precisely the bits that involve real files.
+/// </remarks>
+[TestFixture]
+internal class SyncStateCacheTests
+{
+    private string _tempFolder;
+    private uSyncSettings _settings;
+    private uSyncHandlerSetSettings _setSettings;
+    private string _databaseStamp;
+    private ISyncFileService _fileService;
+
+    [SetUp]
+    public void Setup()
+    {
+        _tempFolder = Path.Combine(Path.GetTempPath(), "uSyncStateCacheTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempFolder);
+
+        _settings = new uSyncSettings { CacheImportState = true };
+        _setSettings = new uSyncHandlerSetSettings();
+        _databaseStamp = Guid.NewGuid().ToString();
+
+        var hostEnvironment = new Mock<Microsoft.Extensions.Hosting.IHostEnvironment>();
+        hostEnvironment.SetupGet(x => x.ContentRootPath).Returns(_tempFolder);
+        _fileService = new SyncFileService(NullLogger<SyncFileService>.Instance, hostEnvironment.Object);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_tempFolder)) Directory.Delete(_tempFolder, true);
+        }
+        catch
+        {
+            // a leftover temp folder is not worth failing a test run over.
+        }
+    }
+
+    /// <summary>
+    ///  build a cache pointed at this test's temp folder. call it more than once to simulate
+    ///  a restart - the second instance sees whatever the first one left on disk.
+    /// </summary>
+    private SyncStateCache CreateCache()
+    {
+        var configService = new Mock<ISyncConfigService>();
+        configService.SetupGet(x => x.Settings).Returns(() => _settings);
+        configService.Setup(x => x.GetFolders()).Returns(() => _settings.Folders);
+        configService.Setup(x => x.GetDefaultSetSettings()).Returns(() => _setSettings);
+
+        var hostingEnvironment = new Mock<Umbraco.Cms.Core.Hosting.IHostingEnvironment>();
+        hostingEnvironment.SetupGet(x => x.LocalTempPath).Returns(_tempFolder);
+
+        var keyValueService = new Mock<IKeyValueService>();
+        keyValueService.Setup(x => x.GetValue("uSync.StateCache.Id")).Returns(() => _databaseStamp);
+
+        return new SyncStateCache(
+            NullLogger<SyncStateCache>.Instance,
+            configService.Object,
+            _fileService,
+            hostingEnvironment.Object,
+            keyValueService.Object);
+    }
+
+    private static XElement MakeNode(string itemType, Guid key, string alias, string value = "a value")
+        => XElement.Parse(
+            $"<{itemType} Key=\"{key}\" Alias=\"{alias}\" Level=\"1\">" +
+            $"  <Info><Name>{alias}</Name></Info>" +
+            $"  <Value>{value}</Value>" +
+            $"</{itemType}>");
+
+    private static XElement MakeEmptyNode(Guid key, string alias)
+        => XElement.Parse($"<Empty Key=\"{key}\" Alias=\"{alias}\" Change=\"Delete\" />");
+
+    #region The hash has to survive a round trip through the file system
+
+    // this is the test that matters most. warming the cache on export records the hash of the
+    // node we serialized; the next import hashes the node it loaded back off disk. if those two
+    // hashes do not agree the export warm-up silently does nothing, and nobody would notice
+    // except that imports stay slow.
+    [Test]
+    public async Task Hash_OfSerializedNode_MatchesHashAfterSaveAndReload()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+        var file = Path.Combine(_tempFolder, "round-trip.config");
+
+        var hashBefore = await node.MakePlatformSafeHashAsync();
+
+        await _fileService.SaveXElementAsync(node, file);
+        var reloaded = await _fileService.LoadXElementAsync(file);
+
+        var hashAfter = await reloaded.MakePlatformSafeHashAsync();
+
+        Assert.That(hashAfter, Is.EqualTo(hashBefore));
+    }
+
+    #endregion
+
+    #region Recording and looking up
+
+    [Test]
+    public async Task RecordedItem_IsKnownCurrent()
+    {
+        var cache = CreateCache();
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        await cache.RecordAsync(node);
+
+        Assert.That(await cache.IsKnownCurrentAsync(node), Is.True);
+    }
+
+    [Test]
+    public async Task ChangedFileContent_IsNotKnownCurrent()
+    {
+        var cache = CreateCache();
+        var key = Guid.NewGuid();
+
+        await cache.RecordAsync(MakeNode(uSyncConstants.Serialization.Content, key, "home"));
+
+        var changed = MakeNode(uSyncConstants.Serialization.Content, key, "home", "a different value");
+
+        Assert.That(await cache.IsKnownCurrentAsync(changed), Is.False);
+    }
+
+    [Test]
+    public async Task UnknownItem_IsNotKnownCurrent()
+    {
+        var cache = CreateCache();
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        Assert.That(await cache.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    [Test]
+    public async Task WhenTurnedOff_NothingIsKnownCurrent()
+    {
+        var cache = CreateCache();
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+        await cache.RecordAsync(node);
+
+        _settings.CacheImportState = false;
+
+        var isKnown = await cache.IsKnownCurrentAsync(node);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(cache.IsEnabled, Is.False);
+            Assert.That(isKnown, Is.False);
+        });
+    }
+
+    // delete/rename/clean markers must never be cached: whether they are "current" depends on
+    // whether the item still exists, and they are filed under the 'Empty' node name, so an
+    // invalidation for the real item would never reach them.
+    [Test]
+    public async Task ActionMarkers_AreNeverCached()
+    {
+        var cache = CreateCache();
+        var node = MakeEmptyNode(Guid.NewGuid(), "gone");
+
+        await cache.RecordAsync(node);
+
+        var isKnown = await cache.IsKnownCurrentAsync(node);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(isKnown, Is.False);
+            Assert.That(cache.Count, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task NodeWithNoKey_IsNotCached()
+    {
+        var cache = CreateCache();
+        var node = XElement.Parse("<Content Alias=\"no-key\" />");
+
+        await cache.RecordAsync(node);
+
+        Assert.That(cache.Count, Is.Zero);
+    }
+
+    #endregion
+
+    #region Invalidation
+
+    [Test]
+    public async Task Invalidate_ForgetsThatItemOnly()
+    {
+        var cache = CreateCache();
+        var goneKey = Guid.NewGuid();
+        var stays = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "stays");
+        var goes = MakeNode(uSyncConstants.Serialization.Content, goneKey, "goes");
+
+        await cache.RecordAsync(stays);
+        await cache.RecordAsync(goes);
+
+        await cache.InvalidateAsync(uSyncConstants.Serialization.Content, goneKey);
+
+        var goesIsKnown = await cache.IsKnownCurrentAsync(goes);
+        var staysIsKnown = await cache.IsKnownCurrentAsync(stays);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(goesIsKnown, Is.False);
+            Assert.That(staysIsKnown, Is.True);
+        });
+    }
+
+    // a move rewrites the path of every descendant, and paths are part of the serialized xml,
+    // so a move has to drop the whole type - not just the item that moved.
+    [Test]
+    public async Task InvalidateType_ForgetsThatTypeButLeavesOthers()
+    {
+        var cache = CreateCache();
+        var content = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "page");
+        var media = MakeNode(uSyncConstants.Serialization.Media, Guid.NewGuid(), "image");
+
+        await cache.RecordAsync(content);
+        await cache.RecordAsync(media);
+
+        await cache.InvalidateTypeAsync(uSyncConstants.Serialization.Content);
+
+        var contentIsKnown = await cache.IsKnownCurrentAsync(content);
+        var mediaIsKnown = await cache.IsKnownCurrentAsync(media);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(contentIsKnown, Is.False);
+            Assert.That(mediaIsKnown, Is.True);
+        });
+    }
+
+    // renaming a doc type changes the serialized xml of every item that uses it, while leaving
+    // those items' own rows - and notifications - untouched. so a doc type change has to clear
+    // everything, even though we were only told about one item.
+    [Test]
+    public async Task Invalidate_ForATypeOthersEmbed_ForgetsEverything()
+    {
+        var cache = CreateCache();
+        var content = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "page");
+        var media = MakeNode(uSyncConstants.Serialization.Media, Guid.NewGuid(), "image");
+
+        await cache.RecordAsync(content);
+        await cache.RecordAsync(media);
+
+        await cache.InvalidateAsync(uSyncConstants.Serialization.ContentType, Guid.NewGuid());
+
+        var contentIsKnown = await cache.IsKnownCurrentAsync(content);
+        var mediaIsKnown = await cache.IsKnownCurrentAsync(media);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(contentIsKnown, Is.False);
+            Assert.That(mediaIsKnown, Is.False);
+            Assert.That(cache.Count, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task InvalidateAll_ForgetsEverything()
+    {
+        var cache = CreateCache();
+        await cache.RecordAsync(MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "one"));
+        await cache.RecordAsync(MakeNode(uSyncConstants.Serialization.Media, Guid.NewGuid(), "two"));
+
+        await cache.InvalidateAllAsync();
+
+        Assert.That(cache.Count, Is.Zero);
+    }
+
+    // two different types can legitimately share a key, so entries are filed per type.
+    [Test]
+    public async Task Entries_AreScopedByItemType()
+    {
+        var cache = CreateCache();
+        var sharedKey = Guid.NewGuid();
+        var content = MakeNode(uSyncConstants.Serialization.Content, sharedKey, "page");
+        var media = MakeNode(uSyncConstants.Serialization.Media, sharedKey, "image");
+
+        await cache.RecordAsync(content);
+        await cache.RecordAsync(media);
+
+        await cache.InvalidateAsync(uSyncConstants.Serialization.Content, sharedKey);
+
+        var contentIsKnown = await cache.IsKnownCurrentAsync(content);
+        var mediaIsKnown = await cache.IsKnownCurrentAsync(media);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(contentIsKnown, Is.False);
+            Assert.That(mediaIsKnown, Is.True);
+        });
+    }
+
+    #endregion
+
+    #region Surviving a restart
+
+    [Test]
+    public async Task Entries_SurviveAReload()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.True);
+    }
+
+    // the journal. an item saved after a run has finished is only removed from memory - the
+    // copy in the file on disk is what the next restart trusts, so the invalidation has to be
+    // written down as it happens.
+    [Test]
+    public async Task Invalidation_AfterTheFileIsWritten_SurvivesAReload()
+    {
+        var key = Guid.NewGuid();
+        var node = MakeNode(uSyncConstants.Serialization.Content, key, "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        // ... run finishes, then someone edits the item.
+        await first.InvalidateAsync(uSyncConstants.Serialization.Content, key);
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    [Test]
+    public async Task Invalidation_MadeBeforeAnythingIsLoaded_StillSurvivesAReload()
+    {
+        var key = Guid.NewGuid();
+        var node = MakeNode(uSyncConstants.Serialization.Content, key, "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        // a fresh instance that has not loaded anything yet - which is where a save lands if
+        // uSync has not run since the site started.
+        var second = CreateCache();
+        await second.InvalidateAsync(uSyncConstants.Serialization.Content, key);
+
+        var third = CreateCache();
+        await third.LoadAsync();
+
+        Assert.That(await third.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    [Test]
+    public async Task ChangedSettings_ThrowTheCacheAway()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        // changing a setting changes what uSync writes out, so the hashes we recorded no
+        // longer tell us anything.
+        _settings.RootFolder = "uSync/somewhere-else/";
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        var isKnown = await second.IsKnownCurrentAsync(node);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(isKnown, Is.False);
+            Assert.That(second.Count, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task ChangedHandlerSettings_ThrowTheCacheAway()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        _setSettings.Handlers["contentHandler"] = new HandlerSettings
+        {
+            Settings = new() { ["Cultures"] = "en-gb" }
+        };
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        // handler settings feed into the serializer, so they change the xml we compare against.
+        _setSettings.Handlers["contentHandler"].Settings["Cultures"] = "en-gb,fr-fr";
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    // the identity has to come out the same on every start of the same site. dictionaries bound
+    // from configuration enumerate in whatever order the provider hands them over, so if the
+    // identity depended on that order the cache would silently never survive a restart - and the
+    // only symptom would be "the feature does nothing".
+    [Test]
+    public async Task Identity_IsTheSame_WhenSettingsArriveInADifferentOrder()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        _setSettings.DisabledHandlers = ["zebra", "apple"];
+        _setSettings.Handlers["zebraHandler"] = new HandlerSettings { Settings = new() { ["z"] = "1", ["a"] = "2" } };
+        _setSettings.Handlers["appleHandler"] = new HandlerSettings { Settings = new() { ["m"] = "3" } };
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        // same settings, different insertion order - as a restart could easily produce.
+        _setSettings = new uSyncHandlerSetSettings { DisabledHandlers = ["apple", "zebra"] };
+        _setSettings.Handlers["appleHandler"] = new HandlerSettings { Settings = new() { ["m"] = "3" } };
+        _setSettings.Handlers["zebraHandler"] = new HandlerSettings { Settings = new() { ["a"] = "2", ["z"] = "1" } };
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.True);
+    }
+
+    // restoring or pointing at a different database has to invalidate everything - the cache
+    // describes a database, not the files.
+    [Test]
+    public async Task ADifferentDatabase_ThrowsTheCacheAway()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        _databaseStamp = Guid.NewGuid().ToString();
+
+        var second = CreateCache();
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    // if we cannot get a stamp out of the database we cannot prove the cache applies to it,
+    // so we must not use the cache at all.
+    [Test]
+    public async Task WithNoDatabaseStamp_TheCacheIsNotUsed()
+    {
+        var node = MakeNode(uSyncConstants.Serialization.Content, Guid.NewGuid(), "home");
+
+        var first = CreateCache();
+        await first.RecordAsync(node);
+        await first.PersistAsync();
+
+        var configService = new Mock<ISyncConfigService>();
+        configService.SetupGet(x => x.Settings).Returns(_settings);
+        configService.Setup(x => x.GetFolders()).Returns(_settings.Folders);
+        configService.Setup(x => x.GetDefaultSetSettings()).Returns(_setSettings);
+
+        var hostingEnvironment = new Mock<Umbraco.Cms.Core.Hosting.IHostingEnvironment>();
+        hostingEnvironment.SetupGet(x => x.LocalTempPath).Returns(_tempFolder);
+
+        var throwingKeyValueService = new Mock<IKeyValueService>();
+        throwingKeyValueService.Setup(x => x.GetValue(It.IsAny<string>())).Throws(new InvalidOperationException("no database"));
+
+        var second = new SyncStateCache(
+            NullLogger<SyncStateCache>.Instance,
+            configService.Object,
+            _fileService,
+            hostingEnvironment.Object,
+            throwingKeyValueService.Object);
+
+        await second.LoadAsync();
+
+        Assert.That(await second.IsKnownCurrentAsync(node), Is.False);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Why

Someone passed on an AI analysis of `v18/main` focused on import performance on large sites (thousands of content and dictionary files). Its main finding checks out:

`SyncSerializerRoot.DeserializeAsync` calls `IsCurrentAsync` for **every** item, and `IsCurrentAsync` does a database lookup, a full re-serialize of the Umbraco item, `CleanseNode` on both sides, then two hashes. The report path pays the same through `SyncHandlerRoot.IsItemCurrentAsync`.

So **an import where nothing has changed costs about as much as a full export.** Reading the files is not the bottleneck — that is already nicely parallelised in `GetFolderItemsAsync` — the per-item work afterwards is, and at a few thousand files it is the whole run time.

Two of the analysis's supporting claims are real but smaller than presented, and are **not** addressed here (they are cheap independent fixes, deliberately not entangled with a feature flag):

- `DictionaryItemSerializer.CleanseNode` really does deep-clone via `XElement.Parse(node.ToString())`, for both sides of every comparison, and `GetLevelAsync` walks the parent chain with an uncached service lookup per level.
- The "hash the raw file bytes instead of parsing the XML" idea does **not** save the parse — `GetFolderItemsAsync` has to parse every file anyway for key/level/path. The saving is in skipping the database lookup, the re-serialize and the second hash. So this hashes the in-memory `XElement` we already have.

## What this does

Adds `uSync:Settings:CacheImportState` (**default `false`**). With it on, uSync remembers the hash of each file it has confirmed matches Umbraco, and skips those items on the next run with no database lookup and no serialize. Import cost goes from `O(all items)` of database and serialization work to `O(changed items)`.

### Only confirmed matches are recorded

An entry is written in exactly two cases: the full check ran and returned `NoChange`, or we have just exported the item (so the file was written from the database and the two match by construction).

It deliberately does **not** record after a successful update or create. Tempting, but some items do not round-trip exactly — that is what uSync's *"XML is different - but properties may not have changed"* message is telling you — and recording those would silence a real difference for good.

**Consequence worth being clear about: the first run after enabling is no faster than before. The benefit arrives on the second run.** An export warms it too.

### How it hooks in

Through uSync's existing per-item notifications. The report one already carried a comment saying it exists for precisely this — *"this lets us intercept a report and shortcut the checking (sometimes)"*.

| Notification | What happens |
|---|---|
| `uSyncImportingItemNotification` / `uSyncReportingItemNotification` | cancel the item if we already know the file matches |
| `uSyncImportedItemNotification` / `uSyncReportedItemNotification` | record the hash **if the answer was `NoChange`** |
| `uSyncExportedItemNotification` | record the hash — we just wrote the file from the database |
| `uSync*Starting` / `uSync*Completed` | load / save the cache file |

**`SyncSerializerRoot`, every serializer, and the handler import/report methods are untouched.** No constructor signatures changed either, which would have been source-breaking for uSync.Complete and community handlers/serializers. The only change to the pipeline is 19 lines in `SyncHandlerRoot`, all additive.

### Storage and invalidation

- `{LocalTempPath}/uSync/cache/state-{identity}.json` — **never** in the uSync folder. The cache describes this site's database, not the source of truth, so it must not travel between environments or show up in a diff. (Same precedent as uSync.History.)
- Identity = a GUID stamp kept in Umbraco's key/value table (same pattern as `SyncTrackerService`) + the uSync version + a fingerprint of the settings that affect serialization. Any mismatch and the file is discarded. If the stamp can't be read, the cache isn't used at all.
- `SyncStateCacheInvalidator` listens to Umbraco. Three levels: **the item** (saved/deleted/published), **the whole type** (moved — a move rewrites the path of every descendant), and **everything** (doc type, data type, template, language, container — these get embedded in other items' xml, so changing one silently changes items whose own rows never moved).
- A force import ignores the cache entirely.

## Two decisions reviewers should look at

**No `IsPaused` guard on invalidation.** The original design had one. Working through the ordering, it is both unnecessary and less safe: an item uSync writes gets invalidated and then simply isn't re-recorded (we only record confirmed `NoChange`), and dropping the guard also catches items Umbraco saves as a *side effect* of an import, which a paused check would miss. Reasoning is in the class docs.

**Invalidations are journalled to disk.** This turned out to be load-bearing, not a nicety. Removing an entry from memory does nothing about the copy in the file, and the file is what the next restart trusts — so an item saved between a run and a restart would be wrongly skipped. That is exactly the `ImportAtStartup` case, i.e. a main reason to want this at all. A tiny append per save, folded back in and cleared on the next persist, both halves under one lock so nothing can be lost between "manifest written" and "journal cleared".

Also: the identity fingerprint is built by hand rather than by serializing the settings object, because dictionaries bound from configuration enumerate in provider order. If that wobbled the identity would change on restart and the cache would silently never survive one — the only symptom being "the feature does nothing". There is a regression test for it.

## Limitations (why it's off by default)

Full list in [`docs/perf/state-cache.md`](docs/perf/state-cache.md). The headline: **with the cache on, uSync's change detection stops being self-verifying and starts trusting its own bookkeeping.** It cannot see a database change made by something that raises no Umbraco notification (raw SQL, a row-level restore). The database stamp catches a whole-database swap; it cannot catch a targeted edit.

The pitfall I'd watch hardest is not raw SQL though — it's **cross-item dependencies**. The known ones are handled, but any serializer that pulls data in from another item is a new hole. That's called out in the docs for third-party serializer authors, and the policy lives in one set in `SyncStateCache` so it's a one-line extension.

Also documented: report is no longer an independent check (force import is the way to get a guaranteed full one); dictionary items whose file key differs from the database key; multiple handler sets with differing serialization settings; and `LocalTempPath` not surviving on Azure App Service / containers / scale-out, where the cache may rarely be warm and the feature quietly does little.

## Deliberately not in this PR

**`UpdateDate` verification.** Storing each item's `UpdateDate` and validating against one `IEntityService.GetAll(objectType)` query per handler would give existence plus a timestamp for every item in a single query, at no per-item cost, closing the raw-SQL gap for real Umbraco node types. That's the obvious hardening step if notification-based invalidation proves too leaky; the manifest has a format version so it can be added without a migration.

## Testing

- `dotnet build uSync.slnx` — clean, 0 warnings, 0 errors.
- 197 tests pass, including 20 new ones in `uSync.Tests/Cache/SyncStateCacheTests.cs`. They run against a real temp folder rather than a mocked file service, because the bits most likely to break involve real files. Notably: the hash surviving a save/reload round trip (the whole export warm-up depends on it), identity stability across differing dictionary order, invalidations surviving a reload, and the three invalidation levels.

**Not yet verified against a real site.** The acceptance test still to do: enable it on a site with a few thousand content and dictionary items, run a report twice, and confirm run 2 is dramatically faster and produces an **identical action list** to run 1. Any difference between the two is a bug. Also worth walking through: edit one item (only that item re-checked), rename a doc type (everything re-checked), move a node (descendants re-checked), force import (cache ignored), hand-edit a `.config` (change detected), change a handler setting (cache discarded), and setting the flag back to `false` (timings return to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
