### PR TITLE
Optimisations for list lookups in import and reportings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ History is backfilled from the v18 release history starting at `v18.0.0`.
   `uSync.Core.Json.JsonXElementConverter` is obsolete for the same reason
   (use `Jumoo.Json.Converters.JsonXElementConverter`).
 
+- **Removed three O(n²) lookups from import.** All of them only showed up on
+  large syncs, and none of them change what is imported:
+  - the duplicate key check when merging folders, and the "keys to keep" check
+    when deleting missing items during a clean, are now set lookups rather than
+    a scan of a list per item.
+  - second pass imports (content, media) now index the action list once, instead
+    of scanning it — and building two interpolated strings per comparison — for
+    every item. With 10,000 two pass items that was tens of millions of string
+    allocations.
+
+  > Actions updated by a second pass are now updated in place, so they keep
+  > their original position in the results list. Previously each one was removed
+  > and re-added, which moved it to the end of the handler's list. Only the
+  > display/reporting order is affected.
+
+  **Extender API:** `List<uSyncAction>.CreateActionIndex()` and the matching
+  `UpdateActions(index, key, handlerAlias, attempt)` overload are new. The
+  existing `UpdateActions(key, handlerAlias, attempt)` is unchanged, including
+  its move-to-the-end behaviour.
+
 ### Fixed
 
 - `HandlerSettings.Clone()` no longer drops the `CreateClean` and

--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -78,9 +78,30 @@ public static class uSyncActionExtensions
     /// </summary>
     public static bool TryFindAction(this IEnumerable<uSyncAction> actions, Guid key, string handlerAlias, out uSyncAction action)
     {
-        action = actions.FirstOrDefault(x => $"{x.Key}_{x.HandlerAlias}" == $"{key}_{handlerAlias}", new uSyncAction { Key = Guid.Empty });
+        action = actions.FirstOrDefault(x => x.Key == key && MatchesAlias(x.HandlerAlias, handlerAlias), new uSyncAction { Key = Guid.Empty });
         return action.Key != Guid.Empty;
     }
+
+    /// <summary>
+    ///  index the actions in a list by key and handler alias, so they can be found without scanning the list.
+    /// </summary>
+    /// <remarks>
+    ///  the values are the positions of the actions in the list, so anything using the index has to
+    ///  update the actions in place - if items are added, removed, or reordered the index is stale.
+    /// </remarks>
+    public static Dictionary<(Guid key, string handlerAlias), int> CreateActionIndex(this List<uSyncAction> actions)
+    {
+        var index = new Dictionary<(Guid, string), int>(actions.Count);
+        for (var n = 0; n < actions.Count; n++)
+        {
+            // first one wins, so we find the same action as TryFindAction would.
+            _ = index.TryAdd((actions[n].Key, actions[n].HandlerAlias ?? string.Empty), n);
+        }
+        return index;
+    }
+
+    private static bool MatchesAlias(string? actionAlias, string? handlerAlias)
+        => (actionAlias ?? string.Empty) == (handlerAlias ?? string.Empty);
 
     /// <summary>
     /// merge two lists of actions together, removing duplicates
@@ -112,19 +133,47 @@ public static class uSyncActionExtensions
         if (actions.TryFindAction(key, handlerAlias, out var action))
         {
             actions.Remove(action);
-            action.Message += attempt.Message;
-            action.Details = [.. action.Details ?? [], .. attempt.Details ?? []];
-
-            action.Success = attempt.Success;
-
-            if (attempt.Success is false)
-            {
-                action.Message = "Failed: " + action.Message;
-                action.Exception = attempt.Exception;
-                action.Change = Core.ChangeType.Fail;
-            }
-            actions.Add(action);
+            actions.Add(ApplyAttempt(action, attempt));
         }
+    }
+
+    /// <summary>
+    ///  update any existing action with the details from the attempt, using an index to find it.
+    /// </summary>
+    /// <remarks>
+    ///  the action is updated in place, so the index built by <see cref="CreateActionIndex(List{uSyncAction})"/>
+    ///  stays valid for the rest of the run.
+    /// </remarks>
+    public static void UpdateActions<TObject>(this List<uSyncAction> actions, Dictionary<(Guid key, string handlerAlias), int> index, Guid key, string handlerAlias, SyncAttempt<TObject> attempt)
+    {
+        if (key == Guid.Empty) return;
+
+        // if it's not an error, and has a no message and blank details, its not worth updating,
+        // so we skip the lookup and update (worth it as the list may have 10000's of items)
+        if (attempt.Success == true
+            && string.IsNullOrWhiteSpace(attempt.Message) is true
+            && attempt.Details?.Count() == 0) return;
+
+        if (index.TryGetValue((key, handlerAlias ?? string.Empty), out var position) is false) return;
+
+        actions[position] = ApplyAttempt(actions[position], attempt);
+    }
+
+    private static uSyncAction ApplyAttempt<TObject>(uSyncAction action, SyncAttempt<TObject> attempt)
+    {
+        action.Message += attempt.Message;
+        action.Details = [.. action.Details ?? [], .. attempt.Details ?? []];
+
+        action.Success = attempt.Success;
+
+        if (attempt.Success is false)
+        {
+            action.Message = "Failed: " + action.Message;
+            action.Exception = attempt.Exception;
+            action.Change = Core.ChangeType.Fail;
+        }
+
+        return action;
     }
 
     /// <summary>

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -469,18 +469,18 @@ internal class SyncFileService : ISyncFileService
 
             var items = await GetFolderItemsAsync(absPath, extension);
 
-            var localKeys = new List<Guid>();
+            // set, not a list - so the duplicate check doesn't scan every key we have already seen.
+            var localKeys = new HashSet<Guid>();
 
             foreach (var item in items)
             {
                 var itemKey = item.Value.Node.GetKey();
                 if (item.Value.Node.IsEmptyItem() is false)
                 {
-                    if (localKeys.Contains(itemKey))
+                    if (localKeys.Add(itemKey) is false)
                     {
                         throw new Exception($"Duplicate: Item key {itemKey} already exists for {item.Key} - run uSync Health check for more info.");
                     }
-                    localKeys.Add(itemKey);
 
                     if (elements.TryGetValue(item.Key, out var value))
                     {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -136,11 +136,15 @@ public abstract class SyncHandlerBase<TObject>
     {
         var items = (await GetChildItemsAsync(key)).ToArray();
 
+        // keysToKeep is usually a list, so hash it once here, otherwise every item
+        // below does a linear scan of all the keys.
+        HashSet<Guid> keys = keysToKeep as HashSet<Guid> ?? [.. keysToKeep];
+
         if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("DeleteMissingItems: {parentId} Checking {itemCount} items for {keyCount} keys", key, items.Length, keysToKeep.Count());
+            logger.LogDebug("DeleteMissingItems: {parentId} Checking {itemCount} items for {keyCount} keys", key, items.Length, keys.Count);
 
         var actions = new List<uSyncAction>();
-        foreach (var item in items.Where(x => !keysToKeep.Contains(x.Key)))
+        foreach (var item in items.Where(x => !keys.Contains(x.Key)))
         {
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("DeleteMissingItems: Found {item} that is not in file list (Reporting: {reportOnly})", item.Id, reportOnly);

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -541,6 +541,10 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// </summary>
     private async Task PerformSecondPassImportsAsync(List<ImportedItem<TObject>> importedItems, List<uSyncAction> actions, HandlerSettings config, SyncUpdateCallback? callback = null)
     {
+        // index the actions once up front, so each second pass item doesn't have to
+        // scan the whole list to find the action it is updating.
+        var actionIndex = actions.CreateActionIndex();
+
         foreach (var item in importedItems.Select((update, Index) => new { update, Index }))
         {
             var itemKey = item.update.Node.GetKey();
@@ -551,7 +555,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             if (attempt.RequiresSave())
                 await serializer.SaveAsync([attempt.Item!]);
 
-            actions.UpdateActions(itemKey, this.Alias, attempt);
+            actions.UpdateActions(actionIndex, itemKey, this.Alias, attempt);
         }
     }
 

--- a/uSync.Tests/Extensions/ActionIndexTests.cs
+++ b/uSync.Tests/Extensions/ActionIndexTests.cs
@@ -1,0 +1,119 @@
+using NUnit.Framework;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using uSync.BackOffice;
+using uSync.Core;
+using uSync.Core.Models;
+
+namespace uSync.Tests.Extensions;
+
+/// <summary>
+///  tests for the action index used to look up actions during the second pass import.
+/// </summary>
+[TestFixture]
+public class ActionIndexTests
+{
+    private const string _handler = "ContentHandler";
+
+    private static readonly Guid _one = Guid.Parse("{5E37F691-FF91-45DA-9F53-8641FD9FE233}");
+    private static readonly Guid _two = Guid.Parse("{5A35701C-349C-4AAE-BBCE-964B5C196989}");
+    private static readonly Guid _three = Guid.Parse("{C70BE6CF-4923-4E2B-8742-B90FB7BBAFCB}");
+
+    private static List<uSyncAction> GetActions()
+        => new List<uSyncAction>
+        {
+            new uSyncAction { Key = _one, HandlerAlias = _handler, Name = "one", Success = true },
+            new uSyncAction { Key = _two, HandlerAlias = _handler, Name = "two", Success = true },
+            new uSyncAction { Key = _three, HandlerAlias = "OtherHandler", Name = "three", Success = true },
+        };
+
+    [Test]
+    public void IndexFindsActionByKeyAndAlias()
+    {
+        var actions = GetActions();
+        var index = actions.CreateActionIndex();
+
+        Assert.That(index[(_one, _handler)], Is.EqualTo(0));
+        Assert.That(index[(_two, _handler)], Is.EqualTo(1));
+        Assert.That(index.ContainsKey((_two, "OtherHandler")), Is.False);
+    }
+
+    [Test]
+    public void DuplicateKeysIndexTheFirstAction()
+    {
+        var actions = GetActions();
+        actions.Add(new uSyncAction { Key = _one, HandlerAlias = _handler, Name = "one-again" });
+
+        var index = actions.CreateActionIndex();
+
+        Assert.That(index[(_one, _handler)], Is.EqualTo(0));
+    }
+
+    [Test]
+    public void UpdateWithIndexUpdatesActionInPlace()
+    {
+        var actions = GetActions();
+        var index = actions.CreateActionIndex();
+
+        actions.UpdateActions(index, _one, _handler, SyncAttempt<string>.Succeed("one", ChangeType.Import, " updated"));
+
+        Assert.That(actions.Count, Is.EqualTo(3));
+        Assert.That(actions[0].Name, Is.EqualTo("one"));
+        Assert.That(actions[0].Message, Is.EqualTo(" updated"));
+        Assert.That(actions[0].Success, Is.True);
+    }
+
+    [Test]
+    public void UpdateWithIndexMarksFailures()
+    {
+        var actions = GetActions();
+        var index = actions.CreateActionIndex();
+
+        actions.UpdateActions(index, _two, _handler, SyncAttempt<string>.Fail("two", ChangeType.ImportFail, "it broke"));
+
+        Assert.That(actions[1].Success, Is.False);
+        Assert.That(actions[1].Change, Is.EqualTo(ChangeType.Fail));
+        Assert.That(actions[1].Message, Is.EqualTo("Failed: it broke"));
+    }
+
+    [Test]
+    public void UpdateWithIndexIgnoresMissingActions()
+    {
+        var actions = GetActions();
+        var index = actions.CreateActionIndex();
+
+        // right key, wrong handler - nothing should change.
+        actions.UpdateActions(index, _one, "MissingHandler", SyncAttempt<string>.Succeed("one", ChangeType.Import, "updated"));
+
+        Assert.That(actions.Count, Is.EqualTo(3));
+        Assert.That(actions.All(x => string.IsNullOrEmpty(x.Message)), Is.True);
+    }
+
+    [Test]
+    public void UpdateWithIndexSkipsUneventfulAttempts()
+    {
+        var actions = GetActions();
+        var index = actions.CreateActionIndex();
+
+        // success, no message, no details - nothing worth updating.
+        actions.UpdateActions(index, _one, _handler,
+            SyncAttempt<string>.Succeed("one", "item", ChangeType.NoChange, new List<uSyncChange>()));
+
+        Assert.That(actions[0].Details, Is.Null);
+        Assert.That(actions[0].Message, Is.Null);
+    }
+
+    [Test]
+    public void TryFindActionMatchesKeyAndAlias()
+    {
+        var actions = GetActions();
+
+        Assert.That(actions.TryFindAction(_two, _handler, out var action), Is.True);
+        Assert.That(action.Name, Is.EqualTo("two"));
+
+        Assert.That(actions.TryFindAction(_two, "OtherHandler", out _), Is.False);
+    }
+}


### PR DESCRIPTION
 **Removed three O(n²) lookups from import.** All of them only showed up on
  large syncs, and none of them change what is imported:
  - the duplicate key check when merging folders, and the "keys to keep" check
    when deleting missing items during a clean, are now set lookups rather than
    a scan of a list per item.
  - second pass imports (content, media) now index the action list once, instead
    of scanning it — and building two interpolated strings per comparison — for
    every item. With 10,000 two pass items that was tens of millions of string
    allocations.