### PR TITLE
Only export content/element items once per save-and-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,19 @@ History is backfilled from the v18 release history starting at `v18.0.0`.
 
 ### Fixed
 
+- **Content and Library items are no longer exported twice by one editor
+  action.** Umbraco 18.1 raises the saved notification for a save-and-publish as
+  well as the published one ([umbraco/Umbraco-CMS#23523][u23523]); uSync
+  listens to both, so a single save-and-publish serialized and wrote the item
+  twice, and un-publishing a culture could write it three times. All the
+  notifications for one operation now share a record of which items have been
+  exported, so each item is exported once. Publishing or un-publishing from the
+  tree — which still only raises the publish notification — is unaffected.
+
+  This applies to both the Content and the Library (Element) handlers.
+
+  [u23523]: https://github.com/umbraco/Umbraco-CMS/issues/23523
+
 - `HandlerSettings.Clone()` no longer drops the `CreateClean` and
   `FullFileOnDifference` properties. Handlers that set either value in their own
   block were previously resolved as `false` regardless; they are now honoured.

--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
@@ -114,7 +114,8 @@ public class ContentHandler : PublishableContentHandlerBase<IContent>, ISyncHand
     ///  Handle the publish events for content
     /// </summary>
     /// <remarks>
-    ///  some publication events do not fire the save notification, so we need to handle those here.
+    ///  publishing from the tree does not fire the save notification, so we need to handle it here.
+    ///  a save-and-publish fires both, and ProcessItem de-duplicates the export.
     /// </remarks>
     public async Task HandleAsync(ContentPublishedNotification notification, CancellationToken cancellationToken)
     {
@@ -135,6 +136,7 @@ public class ContentHandler : PublishableContentHandlerBase<IContent>, ISyncHand
     /// </summary>
     /// <remarks>
     ///  un-publish does not fire the save notification, so we need to handle those here.
+    ///  un-publishing a single culture does fire both, and ProcessItem de-duplicates the export.
     /// </remarks>
     public async Task HandleAsync(ContentUnpublishedNotification notification, CancellationToken cancellationToken)
     {

--- a/uSync.BackOffice/SyncHandlers/Handlers/ElementHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ElementHandler.cs
@@ -275,7 +275,8 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
     ///  Handle the publish events for content
     /// </summary>
     /// <remarks>
-    ///  some publication events do not fire the save notification, so we need to handle those here.
+    ///  publishing from the tree does not fire the save notification, so we need to handle it here.
+    ///  a save-and-publish fires both, and ProcessItem de-duplicates the export.
     /// </remarks>
     public async Task HandleAsync(ElementPublishedNotification notification, CancellationToken cancellationToken)
     {
@@ -296,6 +297,7 @@ public class ElementHandler : PublishableContentHandlerBase<IElement>, ISyncHand
     /// </summary>
     /// <remarks>
     ///  un-publish does not fire the save notification, so we need to handle those here.
+    ///  un-publishing a single culture does fire both, and ProcessItem de-duplicates the export.
     /// </remarks>
     public async Task HandleAsync(ElementUnpublishedNotification notification, CancellationToken cancellationToken)
     {

--- a/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
@@ -82,10 +82,43 @@ public abstract class PublishableContentHandlerBase<TObject>
 
 
     /// <summary>
+    ///  Handle the Umbraco saved notification for publishable items.
+    /// </summary>
+    /// <remarks>
+    ///  routed through <see cref="ProcessItem(EnumerableObjectNotification{TObject}, TObject, string[])"/>
+    ///  rather than using the base implementation, so the export is de-duplicated against the
+    ///  published/unpublished notifications raised by the same operation.
+    /// </remarks>
+    public override async Task HandleAsync(SavedNotification<TObject> notification, CancellationToken cancellationToken)
+    {
+        if (!ShouldProcessEvent()) return;
+        if (notification.State.TryGetValue(uSync.EventPausedKey, out var paused) && paused is true)
+            return;
+
+        var handlerFolders = GetDefaultHandlerFolders();
+
+        foreach (var item in notification.SavedEntities)
+        {
+            await ProcessItem(notification, item, handlerFolders);
+        }
+    }
+
+    /// <summary>
     ///  Export a single item in response to a notification, cleaning up any orphaned files afterwards.
     /// </summary>
+    /// <remarks>
+    ///  an item is only exported once per Umbraco operation - see <see cref="ClaimItemForExport(EnumerableObjectNotification{TObject}, TObject)"/>.
+    /// </remarks>
     protected async Task ProcessItem(EnumerableObjectNotification<TObject> notification, TObject item, string[] handlerFolders)
     {
+        if (ClaimItemForExport(notification, item) is false)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Skipping export of {name} - already exported by an earlier notification in this operation", item.Name);
+
+            return;
+        }
+
         try
         {
             var attempts = await ExportAsync(item, handlerFolders, DefaultConfig);
@@ -101,5 +134,42 @@ public abstract class PublishableContentHandlerBase<TObject>
             notification.Messages.Add(new EventMessage("uSync", $"Failed to create export file : {ex.Message}", EventMessageType.Warning));
         }
     }
-  
+
+    /// <summary>
+    ///  Claim an item for export, returning false if it has already been exported in this operation.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   From Umbraco 18.1 a save-and-publish raises the saved notification as well as the
+    ///   published one (umbraco/Umbraco-CMS#23523), and unpublishing a culture raises the saved
+    ///   and unpublished notifications. Without this, one editor action would export the item
+    ///   two or three times.
+    ///  </para>
+    ///  <para>
+    ///   All the notifications for one operation share a single notification state object, so we
+    ///   track the claimed items there. The item is claimed before the export is attempted, so a
+    ///   failed export isn't retried (and re-reported) by the next notification in the operation.
+    ///  </para>
+    ///  <para>
+    ///   The first notification wins. By the time any of them are raised Umbraco has already
+    ///   persisted the item - including its publish state - so the export reflects the finished
+    ///   operation whichever notification triggers it.
+    ///  </para>
+    /// </remarks>
+    internal static bool ClaimItemForExport(EnumerableObjectNotification<TObject> notification, TObject item)
+    {
+        var state = notification.State;
+
+        lock (state)
+        {
+            if (state.TryGetValue(uSync.EventExportedItemsKey, out var value) is false
+                || value is not HashSet<Guid> exported)
+            {
+                exported = [];
+                state[uSync.EventExportedItemsKey] = exported;
+            }
+
+            return exported.Add(item.Key);
+        }
+    }
 }

--- a/uSync.BackOffice/uSyncBackOffice.cs
+++ b/uSync.BackOffice/uSyncBackOffice.cs
@@ -28,6 +28,17 @@ public class uSync
     public const string EventPausedKey = "uSync.PausedKey";
 
     /// <summary>
+    ///  a key we set on notifications, holding the keys of the items already exported
+    ///  during the current Umbraco operation.
+    /// </summary>
+    /// <remarks>
+    ///  a single operation can raise more than one notification for the same item (a
+    ///  save-and-publish raises both the saved and the published notification), and they
+    ///  all share one notification state, so we use it to only export the item once.
+    /// </remarks>
+    public const string EventExportedItemsKey = "uSync.ExportedItems";
+
+    /// <summary>
     ///  the name we use internally for the 'everything' group.
     /// </summary>
     public const string EverythingGroupName = "All";

--- a/uSync.Tests/SyncHandlers/ExportDeduplicationTests.cs
+++ b/uSync.Tests/SyncHandlers/ExportDeduplicationTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Notifications;
+
+using uSync.BackOffice.SyncHandlers.Handlers;
+
+namespace uSync.Tests.SyncHandlers;
+
+/// <summary>
+///  Tests for the export de-duplication used by the publishable content handlers.
+/// </summary>
+/// <remarks>
+///  From Umbraco 18.1 a save-and-publish raises the saved notification as well as the published
+///  one (umbraco/Umbraco-CMS#23523). Both notifications share a single notification state object,
+///  which is what lets us export the item only once per operation.
+/// </remarks>
+[TestFixture]
+public class ExportDeduplicationTests
+{
+    private static IContent MakeContent(Guid key)
+    {
+        var content = new Mock<IContent>();
+        content.SetupGet(x => x.Key).Returns(key);
+        content.SetupGet(x => x.Name).Returns($"item-{key}");
+        return content.Object;
+    }
+
+    /// <summary>
+    ///  build the pair of notifications Umbraco raises for a save-and-publish, sharing one state
+    ///  object the way ContentService does via .WithState(notificationState).
+    /// </summary>
+    private static (ContentSavedNotification Saved, ContentPublishedNotification Published) SaveAndPublishNotifications(IContent item)
+    {
+        var messages = new EventMessages();
+        var state = new Dictionary<string, object>();
+
+        var saved = new ContentSavedNotification(item, messages) { State = state };
+        var published = new ContentPublishedNotification(item, messages) { State = state };
+
+        return (saved, published);
+    }
+
+    [Test]
+    public void Item_Is_Only_Claimed_Once_Across_A_Save_And_Publish()
+    {
+        var item = MakeContent(Guid.NewGuid());
+        var (saved, published) = SaveAndPublishNotifications(item);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                PublishableContentHandlerBase<IContent>.ClaimItemForExport(saved, item), Is.True,
+                "the saved notification arrives first, so it should export the item");
+
+            Assert.That(
+                PublishableContentHandlerBase<IContent>.ClaimItemForExport(published, item), Is.False,
+                "the published notification shares the state, so it should not export the item again");
+        });
+    }
+
+    [Test]
+    public void Unpublished_Notification_Is_Also_De_Duplicated()
+    {
+        // un-publishing a single culture is performed as a publish, and raises the saved
+        // notification alongside it.
+        var item = MakeContent(Guid.NewGuid());
+        var messages = new EventMessages();
+        var state = new Dictionary<string, object>();
+
+        var saved = new ContentSavedNotification(item, messages) { State = state };
+        var unpublished = new ContentUnpublishedNotification(item, messages) { State = state };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(saved, item), Is.True);
+            Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(unpublished, item), Is.False);
+        });
+    }
+
+    [Test]
+    public void Publish_Without_A_Save_Still_Claims_The_Item()
+    {
+        // publishing from the tree raises only the published notification - it must still export.
+        var item = MakeContent(Guid.NewGuid());
+        var (_, published) = SaveAndPublishNotifications(item);
+
+        Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(published, item), Is.True);
+    }
+
+    [Test]
+    public void Each_Item_In_A_Branch_Publish_Is_Claimed()
+    {
+        // one notification, many documents, a single shared state - every document exports once.
+        var items = new[] { MakeContent(Guid.NewGuid()), MakeContent(Guid.NewGuid()), MakeContent(Guid.NewGuid()) };
+        var published = new ContentPublishedNotification(items, new EventMessages(), true)
+        {
+            State = new Dictionary<string, object>()
+        };
+
+        Assert.Multiple(() =>
+        {
+            foreach (var item in items)
+            {
+                Assert.That(
+                    PublishableContentHandlerBase<IContent>.ClaimItemForExport(published, item), Is.True,
+                    $"{item.Name} should be exported");
+
+                Assert.That(
+                    PublishableContentHandlerBase<IContent>.ClaimItemForExport(published, item), Is.False,
+                    $"{item.Name} should not be exported twice");
+            }
+        });
+    }
+
+    [Test]
+    public void A_Later_Operation_Claims_The_Item_Again()
+    {
+        // the tracking is per-operation, a second save of the same item must export it again.
+        var item = MakeContent(Guid.NewGuid());
+
+        var (firstSaved, _) = SaveAndPublishNotifications(item);
+        var (secondSaved, _) = SaveAndPublishNotifications(item);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(firstSaved, item), Is.True);
+            Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(secondSaved, item), Is.True);
+        });
+    }
+
+    [Test]
+    public void Existing_Notification_State_Is_Preserved()
+    {
+        // uSync writes its own keys into the notification state, we must not stamp on them.
+        var item = MakeContent(Guid.NewGuid());
+        var (saved, published) = SaveAndPublishNotifications(item);
+
+        saved.State[uSync.BackOffice.uSync.EventStateKey] = true;
+
+        PublishableContentHandlerBase<IContent>.ClaimItemForExport(saved, item);
+
+        Assert.That(published.State[uSync.BackOffice.uSync.EventStateKey], Is.True);
+    }
+}


### PR DESCRIPTION
## What

uSync exported a content or Library (Element) item **twice** for a single save-and-publish, and **three times** for a save that un-published a culture. This fixes it so each item is exported once per Umbraco operation.

## Why

Umbraco 18.1 raises `ContentSavedNotification` for a save-and-publish as well as `ContentPublishedNotification` ([umbraco/Umbraco-CMS#23523](https://github.com/umbraco/Umbraco-CMS/issues/23523), [PR #23528](https://github.com/umbraco/Umbraco-CMS/pull/23528)).

Worth noting for review: the upstream PR was raised against `release/17.6` and patches `ContentService.CommitDocumentChangesInternal`, so the diff makes it look Document-only. In v18 that method lives in `PublishableContentServiceBase`, shared by Documents and Elements — so on `release/18.1` the extra notification fires for **both**, and `ElementHandler` had the same problem as `ContentHandler`.

`ContentHandler` and `ElementHandler` each listen for the saved *and* the published/unpublished notifications. The `<remarks>` on those handlers explained why — *"some publication events do not fire the save notification"* — and that premise is what broke.

## How

Every notification raised by one Umbraco operation carries the **same** notification state instance — `PublishableContentServiceBase` raises them all with `.WithState(notificationState)`, sourced from `savingNotification.State`. So `ProcessItem` now claims each item in that shared state (a `HashSet<Guid>` under a new `uSync.EventExportedItemsKey`) and skips it if an earlier notification in the same operation already exported it.

Three decisions worth a look:

- **First notification wins**, i.e. Saved exports and Published skips. Safe because `SaveContent(content)` runs *before* the Saved notification is raised, and the publish values were applied before that — the item is already in its final published state, on the same instance both notifications carry.
- **Claim before export, not after.** A failed export isn't retried by the next notification in the same operation; it would almost certainly fail again and add a second warning to `notification.Messages`.
- **Lock around the get-or-create.** Dispatch within a scope is sequential so this is belt-and-braces, but the state dictionary is a plain `Dictionary` and `SyncScopedNotificationPublisher` can dispatch on a queued background thread when `BackgroundNotifications` is on.

`SavedNotification` handling for these two handlers is now routed through `ProcessItem` via an override, rather than the inline copy of the export loop in `SyncHandlerRoot` — that copy bypassed the de-duplication. It's untouched for every other handler.

`MediaHandler` derives from `ContentHandlerBase`, not `PublishableContentHandlerBase`, and has no publish notifications, so it's unaffected.

## Behaviour

| Action | Before | After |
|---|---|---|
| Save-and-publish | 2 exports | 1 |
| Save-and-publish un-publishing a culture | 3 exports | 1 |
| Publish / un-publish from tree | 1 | 1 (unchanged) |
| Plain save | 1 | 1 (unchanged) |
| Publish with descendants | 1 per doc | unchanged |
| uSync import | 0 (events paused) | unchanged |

## Testing

New `uSync.Tests/SyncHandlers/ExportDeduplicationTests.cs` covers the save-and-publish pair, the save+unpublish pair, publish-with-no-save, per-item claiming across a branch publish, re-claiming in a later operation, and that uSync's own notification state keys survive.

Full solution builds clean; all 190 tests pass (6 new).

## Not included

Both came out of the same review of the Umbraco 18.1 changes, but are behaviour changes rather than bug fixes, so they're deliberately left out:

- `ContentSavedNotification.SavedCultures` / `ContentPublishedNotification.PublishedCultures` ([#23313](https://github.com/umbraco/Umbraco-CMS/pull/23313)) would let uSync export only the affected cultures, and skip no-op saves.
- `PublishableContentBaseSerializer` still does save-then-publish as two operations rather than the new single-scope `IPublishableContentService.SaveAndPublish` ([#23277](https://github.com/umbraco/Umbraco-CMS/pull/23277)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
