### PR TITLE
Port #997 and #998 (dictionary + sealed/Lock perf work) from v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ History is backfilled from the v18 release history starting at `v18.0.0`.
 
 ### Changed
 
+- Ported the v17 allocation work: fewer redundant dictionary lookups on the hot
+  paths (#997), and `internal`/`private` classes are now `sealed` so the JIT can
+  devirtualize their calls (#998). No behavioural changes.
+
+  > **Extender API:** `SyncHandlerRoot.SyncChangeInfo` is now `sealed`. It stays
+  > `protected`, so handlers can still construct and return one from an
+  > `IsItemCurrentAsync` override — only deriving from it is no longer possible.
+
 - **Handler settings now inherit from `HandlerDefaults`.** When a handler has its
   own settings block, its values are layered _over_ the set's `HandlerDefaults`
   instead of replacing them wholesale. A handler now only needs to specify the

--- a/uSync.AutoTemplates/TemplateWatcher.cs
+++ b/uSync.AutoTemplates/TemplateWatcher.cs
@@ -31,7 +31,6 @@ public partial class TemplateWatcher : IRegisteredObject
     private readonly ILogger<TemplateWatcher> _logger;
     private readonly ITemplateService _templateService;
     private readonly IShortStringHelper _shortStringHelper;
-    private readonly IHostEnvironment _hostEnvironment;
 
     private readonly IFileSystem? _templateFileSystem;
 
@@ -51,14 +50,13 @@ public partial class TemplateWatcher : IRegisteredObject
         ITemplateService templateService)
     {
         _shortStringHelper = shortStringHelper;
-        _hostEnvironment = hostEnvironment;
         _hostingLifetime = hostingLifetime;
 
         _logger = logger;
 
         _templateFileSystem = fileSystems.MvcViewsFileSystem;
 
-        _viewsFolder = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.MvcViews);
+        _viewsFolder = hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.MvcViews);
 
 
         // 
@@ -157,7 +155,7 @@ public partial class TemplateWatcher : IRegisteredObject
     }
 
 
-    private static object lockObject = new Object();
+    private static readonly Lock lockObject = new();
 
     private void CheckFile(string filename)
     {

--- a/uSync.BackOffice/Boot/uSyncBootExtension.cs
+++ b/uSync.BackOffice/Boot/uSyncBootExtension.cs
@@ -48,7 +48,7 @@ internal static class uSyncBootExtension
 /// <summary>
 ///  Handler to mange app starting for first boot migrations 
 /// </summary>
-internal class FirstBootAppStartingHandler
+internal sealed class FirstBootAppStartingHandler
     : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
 {
 

--- a/uSync.BackOffice/Configuration/SyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/SyncConfigService.cs
@@ -57,7 +57,7 @@ internal class SyncConfigService : ISyncConfigService
             .ToArray();
     }
 
-    private class SyncFolderItem
+    private sealed class SyncFolderItem
     {
         public required string Path { get; set; }
         public int Weight { get; set; }

--- a/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
+++ b/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
@@ -12,11 +12,10 @@ using Umbraco.Cms.Core.Notifications;
 
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Services;
-using uSync.BackOffice.SyncHandlers.Interfaces;
 
 namespace uSync.BackOffice.Notifications;
 
-internal class SyncScopedNotificationPublisher
+internal sealed class SyncScopedNotificationPublisher
     : ScopedNotificationPublisher<INotificationHandler>, IScopedNotificationPublisher
 {
     private readonly ILogger<SyncScopedNotificationPublisher> _logger;

--- a/uSync.BackOffice/Services/uSyncTriggers.cs
+++ b/uSync.BackOffice/Services/uSyncTriggers.cs
@@ -10,7 +10,7 @@ internal delegate void uSyncTriggerEventHandler(uSyncTriggerArgs e);
 /// <summary>
 ///  used to trigger uSync events from within other elements of uSync
 /// </summary>
-internal class uSyncTriggers
+internal sealed class uSyncTriggers
 {
     internal static event uSyncTriggerEventHandler? DoExport;
     internal static event uSyncTriggerEventHandler? DoImport;
@@ -47,12 +47,11 @@ internal class uSyncTriggers
 
 }
 
-internal class uSyncTriggerArgs
+internal sealed class uSyncTriggerArgs
 {
     public string Folder { get; set; } = string.Empty;
 
     public IEnumerable<string> EntityTypes { get; set; } = [];
 
     public SyncHandlerOptions? HandlerOptions { get; set; }
-
 }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -2012,7 +2012,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// <summary>
     ///  Holds the result of an item comparison - the type of change and the current serialized node.
     /// </summary>
-    protected class SyncChangeInfo
+    protected sealed class SyncChangeInfo
     {
         /// <summary>
         ///  The type of change detected for the item.

--- a/uSync.BackOffice/Tracker/SyncTrackerNotificationHandler.cs
+++ b/uSync.BackOffice/Tracker/SyncTrackerNotificationHandler.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Events;
 
 namespace uSync.BackOffice.Tracker;
 
-internal class SyncTrackerNotificationHandler
+internal sealed class SyncTrackerNotificationHandler
     : INotificationAsyncHandler<uSyncImportCompletedNotification>
 {
     private readonly ISyncTrackerService _syncTrackerService;

--- a/uSync.BackOffice/uSyncBackOffice.cs
+++ b/uSync.BackOffice/uSyncBackOffice.cs
@@ -49,7 +49,7 @@ public class uSync
         internal const string Group = "sync";
     }
 
-    internal class Sets
+    internal sealed class Sets
     {
         internal const string DefaultSet = "Default";
     }

--- a/uSync.Core/DataTypes/DataTypeSerializers/DataListMigratingConfigSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/DataListMigratingConfigSerializer.cs
@@ -37,7 +37,7 @@ internal class DataListMigratingConfigSerializer : ConfigurationSerializerBase, 
 
         return configuration;
     }
-    private class IdValuePair
+    private sealed class IdValuePair
     {
         public int? Id { get; set; }
         public string? Value { get; set; }

--- a/uSync.Core/DataTypes/DataTypeSerializers/FileUploadMigratingConfigSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/FileUploadMigratingConfigSerializer.cs
@@ -42,7 +42,7 @@ internal class FileUploadMigratingConfigSerializer : ConfigurationSerializerBase
         return configuration;
     }
 
-    private class IdValuePair
+    private sealed class IdValuePair
     {
         public int? Id { get; set; }
         public string? Value { get; set; }

--- a/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
@@ -118,8 +118,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
             extensions.Add("Umb.Tiptap.Block");
         }
         
-        if (configuration.ContainsKey("toolbar"))
-            configuration.Remove("toolbar");
+        configuration.Remove("toolbar");
 
         configuration["toolbar"] = new List<List<List<string>>> { new() { newToolbar } };
         
@@ -128,7 +127,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return configuration;
     }
 
-    private bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
+    private static bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
     {
         toolBarList = new List<string>();
         if (toolbar is null) return false;
@@ -146,7 +145,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return true;
     }
 
-    private string? MapToolbarItem(string item)
+    private static string? MapToolbarItem(string item)
     {
         return item switch
         {

--- a/uSync.Core/Extensions/DictionaryExtensions.cs
+++ b/uSync.Core/Extensions/DictionaryExtensions.cs
@@ -15,22 +15,20 @@ internal static class DictionaryExtensions
     {
         if (usernames == null || id == null) return "unknown";
 
-        usernames[id.Value] = usernames.ContainsKey(id.Value)
-            ? usernames[id.Value]
-            : findMethod(id.Value)?.Email ?? "unknown";
+        if (usernames.TryGetValue(id.Value, out string? username))
+            return username;
 
-        return usernames[id.Value];
+        return usernames[id.Value] = findMethod(id.Value)?.Email ?? "unknown";
     }
 
     public static int GetEmails(this Dictionary<string, int> emails, string email, Func<string, IUser> findMethod)
     {
         if (emails == null || string.IsNullOrEmpty(email)) return -1;
 
-        emails[email] = emails.TryGetValue(email, out int value)
-            ? value
-            : findMethod(email)?.Id ?? -1;
+        if (emails.TryGetValue(email, out int value))
+            return value;
 
-        return emails[email];
+        return emails[email] = findMethod(email)?.Id ?? -1;
     }
 
     // This method converts an object to a dictionary of string, object
@@ -40,7 +38,7 @@ internal static class DictionaryExtensions
         var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         // Create a dictionary and populate it with the property names and values
-        var dictionary = new Dictionary<string, object?>();
+        Dictionary<string, object?> dictionary = new(properties.Length);
         foreach (var property in properties)
         {
             dictionary.Add(property.Name, property.GetValue(obj));
@@ -60,7 +58,7 @@ internal static class DictionaryExtensions
         {
             var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            var dictionary = new Dictionary<string, object?>();
+            Dictionary<string, object?> dictionary = new(properties.Length);
             foreach (var property in properties)
             {
                 dictionary.Add(property.Name, property.GetValue(obj));
@@ -87,8 +85,7 @@ internal static class DictionaryExtensions
         {
             foreach (var kvp in dictionary)
             {
-                if (mergedDictionary.ContainsKey(kvp.Key) is true) continue;
-                mergedDictionary.Add(kvp.Key, kvp.Value);
+                mergedDictionary.TryAdd(kvp.Key, kvp.Value);
             }
         }
 
@@ -111,6 +108,6 @@ internal static class DictionaryExtensions
             return s.ToLowerInvariant();
         }
 
-        return char.ToLowerInvariant(s[0]) + s.Substring(1);
+        return $"{char.ToLowerInvariant(s[0])}{s.AsSpan(1)}";
     }
 }

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -87,9 +87,9 @@ public class MediaPicker3Mapper : SyncValueMapperBase, ISyncMapper
 
     private static Guid GetGuidValue(JsonObject obj, string key)
     {
-        if (obj != null && obj.ContainsKey(key))
+        if (obj != null && obj.TryGetPropertyValue(key, out JsonNode? node))
         {
-            if (obj[key]?.ToString().TryGetValueAs<Guid>(out var guid) is true)
+            if (node?.ToString().TryGetValueAs<Guid>(out var guid) is true)
                 return guid;
         }
 

--- a/uSync.Core/Mapping/Mappers/MultiUrlMapper.cs
+++ b/uSync.Core/Mapping/Mappers/MultiUrlMapper.cs
@@ -40,7 +40,7 @@ public class MultiUrlMapper : SyncValueMapperBase, ISyncMapper
     // we need to just be able to read / manipulate the storage 
     // to make things generic .
     [DataContract]
-    internal class LinkDto
+    internal sealed class LinkDto
     {
         [DataMember(Name = "name")]
         public string? Name { get; set; }

--- a/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
+++ b/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
@@ -159,8 +159,7 @@ internal abstract class SyncConfigMergerBase
                 // targetObject[property.Key] = JsonValue.Create(_inheritedValue);
 
                 // inherited is implicit.
-                if (targetObject.ContainsKey(property.Key)) 
-                    targetObject.Remove(property.Key);
+                targetObject.Remove(property.Key);
             }
         }
 
@@ -205,9 +204,9 @@ internal abstract class SyncConfigMergerBase
         for (int i = 0; i < targetArray.Count; i++)
         {
             if (targetArray[i] is not JsonObject targetObject) continue;
-            if (targetObject.ContainsKey(removeProperty) is false) continue;
+            if (targetObject.TryGetPropertyValue(removeProperty, out JsonNode? removal) is false) continue;
 
-            if (targetObject[removeProperty]!.ToString().StartsWith(_removedLabel) is true)
+            if (removal!.ToString().StartsWith(_removedLabel) is true)
             {
                 // we can't remove it while iterating, so add to a list. 
                 removals.Add(i);

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -750,7 +750,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         return [];
     }
 
-    private class TabInfo
+    private sealed class TabInfo
     {
         public TabInfo(string alias)
         {
@@ -991,8 +991,8 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         if (tabNode == null) return [];
 
         var newTabs = tabNode.Elements("Tab")
-            .Select(x => GetTabAliasFromTabGroup(x))
-            .ToList();
+            .Select(GetTabAliasFromTabGroup)
+            .ToArray();
 
         var inheritedTabs =
             item.ContentTypeComposition
@@ -1128,7 +1128,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         return false;
     }
 
-    private class PropertyTypeResult
+    private sealed class PropertyTypeResult
     {
         public bool IsNew { get; set; }
         public IPropertyType? Property { get; set; }

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1401,7 +1401,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
     public bool TabClashesWithExisting(TObject item, string alias, PropertyGroupType tabType)
     {
         EnsureAllTabsCacheLoaded(item);
-        return _allTabs?.ContainsKey(alias) is true && _allTabs?[alias] != tabType;
+        return _allTabs?.TryGetValue(alias, out PropertyGroupType aliasTab) is true && aliasTab != tabType;
     }
 
     public void EnsureAllTabsCacheLoaded(TObject item)

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -345,7 +345,7 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
         await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
     }
 
-    private class DomainSyncModel
+    private sealed class DomainSyncModel
     {
         public required Guid Key { get; set; }
         public required string DomainName { get; set; }

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -189,8 +189,7 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
             var headerValue = header.ValueOrDefault(string.Empty);
 
             if (headerKey == string.Empty) continue;
-            if (newHeaders.ContainsKey(headerKey)) continue; // stop duplicates.
-            newHeaders.Add(headerKey, headerValue);
+            newHeaders.TryAdd(headerKey, headerValue); // stop duplicates.
         }
 
         var existingOrderedEvents = item.Headers.OrderBy(x => x.Key).ToDictionary();

--- a/uSync.History/uSyncHistory.cs
+++ b/uSync.History/uSyncHistory.cs
@@ -24,7 +24,7 @@ namespace uSync.History
         public int SortOrder => 20;
     }
 
-    internal class SyncHistoryConstants
+    internal sealed class SyncHistoryConstants
     {
         public const string ApiName = "uSync.History";
         public const string AppName = "uSync.History";

--- a/uSync.SchemaGenerator/AppSettings.cs
+++ b/uSync.SchemaGenerator/AppSettings.cs
@@ -4,14 +4,14 @@ using uSync.BackOffice.Configuration;
 
 namespace uSync;
 
-internal class AppSettings
+internal sealed class AppSettings
 {
     public uSyncDefinition uSync { get; set; }
 
     /// <summary>
     /// Configuration of uSync settings
     /// </summary>
-    internal class uSyncDefinition
+    internal sealed class uSyncDefinition
     {
         /// <summary>
         /// uSync settings
@@ -33,12 +33,12 @@ internal class AppSettings
         /// </summary>
         public AutoTemplatesDefinition AutoTemplates { get; set; }
 
-        internal class uSyncSetsDefinition
+        internal sealed class uSyncSetsDefinition
         {
             public uSyncHandlerSetSettings Default { get; set; }
         }
 
-        internal class AutoTemplatesDefinition
+        internal sealed class AutoTemplatesDefinition
         {
             /// <summary>
             /// Enable AutoTemplates feature

--- a/uSync.SchemaGenerator/Options.cs
+++ b/uSync.SchemaGenerator/Options.cs
@@ -2,7 +2,7 @@
 
 namespace uSync;
 
-internal class Options
+internal sealed class Options
 {
     [Option('o', "outputFile", Required = false,
         HelpText = "",

--- a/uSync.SchemaGenerator/Program.cs
+++ b/uSync.SchemaGenerator/Program.cs
@@ -10,7 +10,7 @@ namespace uSync;
 ///  Generate the JSON Schema file for uSync. 
 ///   just like in the Umbraco Core - https://github.com/umbraco/Umbraco-CMS/tree/v9/contrib/src/JsonSchema
 /// </summary>
-internal class Program
+internal sealed class Program
 {
     public static async Task Main(string[] args)
     {


### PR DESCRIPTION
Brings [#997](https://github.com/KevinJump/uSync/pull/997) (avoid unneeded dictionary operations) and [#998](https://github.com/KevinJump/uSync/pull/998) (use `System.Threading.Lock`, seal `internal`/`private` classes) onto `v18/main`.

Cherry-picked rather than merged: `v17/main` and `v18/main` diverged back at v17.3.2 and there are ~20 unrelated v17 commits between them, so a merge would drag in far more than these two. Both commits are recorded with `-x`, so they trace back to the v17 originals.

`#997` applied clean. `#998` had two conflicts:

**`SyncHandlerRoot.SyncChangeInfo`** — v17 has it `private`, and #998 sealed it. v18 promoted it to `protected` (with docs) because `ElementHandler` overrides `IsItemCurrentAsync` and constructs one. Resolved as `protected sealed`: keeps v18's accessibility and #998's devirtualization intent. It's only ever instantiated, never derived from, so nothing in the codebase is affected — but it *is* a (minor) extender API change, so it's noted in the changelog.

**`uSync.Core/Json/OrderedPropertiesJsonResolver.cs`** — deleted in v18 by [#1014](https://github.com/KevinJump/uSync/pull/1014) when the JSON helpers moved to `Jumoo.Json`, and modified by #998. Resolved by keeping it deleted; the v18 build uses the `Jumoo.Json` version. The only surviving mention is a comment in `JsonSerializerOptionsTests`.

## Verification

Checked every class #998 sealed against the ported tree — 20 of 21 present, the one absent being `OrderedPropertiesJsonResolver` as above. All the `#997` hunks applied identically to v17, including `MergeIgnoreDuplicates`'s `ContainsKey`+`Add` → `TryAdd` (a different code path from the folder-merge work in #1017, so no overlap).

Solution builds clean; 210 tests pass.

## Note

Not part of the port, but flagged while porting: `PublishableContentHandlerBase.ClaimItemForExport` (added in #1018) uses `lock (state)` on the notification-state dictionary. That's locking on a shared object rather than a dedicated `Lock`, which is exactly the pattern #998 moved away from in `TemplateWatcher`. It can't use `System.Threading.Lock` as-is — the object being locked is Umbraco's dictionary, not ours — but it's worth a look if the sealing/locking cleanup continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
