### PR TITLE
Use a dedicated Lock for the export claim, not Umbraco's dictionary

### DIFF
--- a/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/PublishableContentHandlerBase.cs
@@ -136,6 +136,20 @@ public abstract class PublishableContentHandlerBase<TObject>
     }
 
     /// <summary>
+    ///  Guards the claim below.
+    /// </summary>
+    /// <remarks>
+    ///  the notification state we track claims in is Umbraco's dictionary, not ours, so we can't
+    ///  lock on it - anything else holding a reference could contend with us on an object neither
+    ///  side knows the other is using. This is our own lock instead.
+    ///  <para>
+    ///   statics on a generic type are per closed type, so documents and elements get one each.
+    ///   That suits us: they never share a notification state, so they have nothing to contend over.
+    ///  </para>
+    /// </remarks>
+    private static readonly Lock _claimLock = new();
+
+    /// <summary>
     ///  Claim an item for export, returning false if it has already been exported in this operation.
     /// </summary>
     /// <remarks>
@@ -155,12 +169,18 @@ public abstract class PublishableContentHandlerBase<TObject>
     ///   persisted the item - including its publish state - so the export reflects the finished
     ///   operation whichever notification triggers it.
     ///  </para>
+    ///  <para>
+    ///   Umbraco raises the notifications for one operation one after another, so the lock is
+    ///   belt-and-braces rather than something we expect to contend on - but the state dictionary
+    ///   is a plain Dictionary, and SyncScopedNotificationPublisher can dispatch on a queued
+    ///   background thread when BackgroundNotifications is on.
+    ///  </para>
     /// </remarks>
     internal static bool ClaimItemForExport(EnumerableObjectNotification<TObject> notification, TObject item)
     {
         var state = notification.State;
 
-        lock (state)
+        lock (_claimLock)
         {
             if (state.TryGetValue(uSync.EventExportedItemsKey, out var value) is false
                 || value is not HashSet<Guid> exported)

--- a/uSync.Tests/SyncHandlers/ExportDeduplicationTests.cs
+++ b/uSync.Tests/SyncHandlers/ExportDeduplicationTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 using Moq;
 
@@ -133,6 +135,35 @@ public class ExportDeduplicationTests
             Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(firstSaved, item), Is.True);
             Assert.That(PublishableContentHandlerBase<IContent>.ClaimItemForExport(secondSaved, item), Is.True);
         });
+    }
+
+    [Test]
+    public void Concurrent_Claims_Only_Let_One_Caller_Through()
+    {
+        // Umbraco raises the notifications for an operation one after another, so this shouldn't
+        // happen in practice - but the state dictionary is a plain Dictionary, and the claim is
+        // what stops a torn read of it turning into a duplicate export. Hammer it to prove the
+        // lock does its job.
+        const int itemCount = 50;
+        const int threadsPerItem = 8;
+
+        var items = Enumerable.Range(0, itemCount).Select(_ => MakeContent(Guid.NewGuid())).ToArray();
+        var messages = new EventMessages();
+        var state = new Dictionary<string, object>();
+
+        // every thread gets its own notification, all sharing one state - as they do in an operation.
+        var claims = items
+            .SelectMany(item => Enumerable.Range(0, threadsPerItem).Select(_ => (Item: item, Notification: new ContentSavedNotification(item, messages) { State = state })))
+            .ToArray();
+
+        var results = new bool[claims.Length];
+
+        Parallel.For(0, claims.Length, i =>
+            results[i] = PublishableContentHandlerBase<IContent>.ClaimItemForExport(claims[i].Notification, claims[i].Item));
+
+        Assert.That(
+            results.Count(x => x), Is.EqualTo(itemCount),
+            "exactly one claim per item should succeed, however many threads race for it");
     }
 
     [Test]


### PR DESCRIPTION
Follow-up to the note on [#1019](https://github.com/KevinJump/uSync/pull/1019).

## What

`PublishableContentHandlerBase.ClaimItemForExport` (added in [#1018](https://github.com/KevinJump/uSync/pull/1018)) locked on `notification.State` — Umbraco's dictionary, not ours. Anything else holding a reference to it could contend with us on an object neither side knows the other is using. That's the pattern [#998](https://github.com/KevinJump/uSync/pull/998) moved `TemplateWatcher` away from.

Now a `private static readonly Lock`, matching #998.

## Why a static

The obvious alternative — a per-instance lock — doesn't work: the whole point of the claim is that it's shared across the notifications of one operation, and handlers are resolved per notification dispatch. A static is what covers them all.

Statics on a generic type are per *closed* type, so `PublishableContentHandlerBase<IContent>` and `<IElement>` get one each. That's a bonus rather than a problem: documents and elements never share a notification state, so they have nothing to contend over.

Contention isn't a concern either way — the critical section is a dictionary lookup and a `HashSet.Add`, and uSync's own imports pause events, so this only runs on editor saves.

## Test

Added `Concurrent_Claims_Only_Let_One_Caller_Through`: 50 items × 8 threads racing the claim through `Parallel.For`, asserting exactly 50 claims succeed.

I checked it actually fails without the lock rather than passing regardless — it throws `IndexOutOfRangeException` out of `HashSet.Add` as concurrent adds corrupt the set:

```
--IndexOutOfRangeException
   at System.Collections.Generic.HashSet`1.AddIfNotPresent(T value, Int32& location)
   at System.Collections.Generic.HashSet`1.Add(T item)
   at uSync.BackOffice.SyncHandlers.Handlers.PublishableContentHandlerBase`1.ClaimItemForExport(...)
```

Builds clean; 211 tests pass.

## Note

No changelog entry — this is an internal correctness fix to code that hasn't shipped in a release yet (#1018 is unreleased on `v18/main`), and the behaviour is unchanged.

Worth saying plainly: Umbraco raises the notifications for one operation sequentially, so this guard has always been belt-and-braces rather than something we expect to contend on. It matters because the state dictionary is a plain `Dictionary` and `SyncScopedNotificationPublisher` can dispatch on a queued background thread when `BackgroundNotifications` is on — the cost of being wrong is a corrupted set, not just a duplicate export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
