### PR TITLE
fix: use Clear(key) instead of ClearByKey(key) for exact-key cache removal

### DIFF
--- a/uSync.Core/Cache/SyncEntityCache.cs
+++ b/uSync.Core/Cache/SyncEntityCache.cs
@@ -47,7 +47,11 @@ namespace uSync.Core.Cache
 
         public void AddName(int id, Guid guid, string name)
         {
-            nameCache.ClearByKey(id.ToString());
+            // was ClearByKey(id.ToString()) - a full LINQ scan of every entry in nameCache
+            // looking for a prefix match, on every single call. id.ToString() is an exact
+            // key here (no other key is ever a variant/suffix of it in this cache), so a
+            // direct single-key removal is correct and avoids the O(n) scan entirely.
+            nameCache.Clear(id.ToString());
             nameCache.GetCacheItem(id.ToString(), () =>
             {
                 return new CachedName(guid, name);
@@ -103,7 +107,8 @@ namespace uSync.Core.Cache
             }
             else
             {
-                keyCache.ClearByKey(id.ToString());
+                // was ClearByKey (O(n) scan) - id.ToString() is an exact key here too.
+                keyCache.Clear(id.ToString());
                 return null;
             }
         }
@@ -134,7 +139,8 @@ namespace uSync.Core.Cache
             }
             else
             {
-                keyCache.ClearByKey(id.ToString());
+                // was ClearByKey (O(n) scan) - id.ToString() is an exact key here too.
+                keyCache.Clear(id.ToString());
                 return null;
             }
         }

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -659,7 +659,9 @@ namespace uSync.Core.Serialization.Serializers
         protected void ClearAliases()
         {
             aliasCache = null;
-            _appCache.ClearByKey($"usync_{this.Id}");
+            // was ClearByKey (O(n) scan of the whole shared RuntimeCache) - the key here is
+            // exact (this.Id is a single content type), so a direct removal is correct.
+            _appCache.Clear($"usync_{this.Id}");
         }
 
         protected void RemoveAlias(string alias)
@@ -675,7 +677,9 @@ namespace uSync.Core.Serialization.Serializers
 
         private void RefreshAliasCache()
         {
-            _appCache.ClearByKey($"usync_{this.Id}");
+            // was ClearByKey (O(n) scan of the whole shared RuntimeCache) - the key here is
+            // exact (this.Id is a single content type), so a direct removal is correct.
+            _appCache.Clear($"usync_{this.Id}");
             _appCache.GetCacheItem($"usync_{this.Id}", () => { return aliasCache; });
         }
 


### PR DESCRIPTION
`SyncEntityCache.AddName`/`GetEntity` and `ContentTypeBaseSerializer`'s alias cache all call `DictionaryAppCache.ClearByKey(exactKey)`, which does a full scan of every cache entry looking for a prefix match, even though the key passed is always an exact id/guid with no other entry sharing that prefix. `DictionaryAppCache` already exposes `Clear(key)`, a direct dictionary removal with no scan.

`nameCache` in particular is shared across an entire Export/Report run and grows by one entry per resolved ancestor name, so the O(n) scan compounds into O(n^2) as the run progresses. Confirmed via CPU profiling (~91% of wall time in the `Where`/`ToArray` scan) and an isolated benchmark: 60k cached items, 27.4s vs 27ms (~1000x) for a single clear-and-reinsert.

Left the other 5 `ClearByKey` call sites (`uSyncService_Handlers`, `SyncHandlerRoot`: `PrepCaches`/`CleanCaches`) unchanged since those rely on genuine multi-key prefix matching (one is explicitly documented as "a starts with call").

Local fix for LegalDesk V2's uSync migration validation work, moving our real content tree (~440k items) between environments. We'd struggled with this since a support thread in July ("Usync complete issues"), where the Publisher web UI was timing out in minutes on even tiny syncs; we eventually moved to the CLI tool instead (SignalR in the web UI looks like the more likely cause of those particular fast timeouts, separate from this). The CLI then ran into the plain `HttpClient` 100s timeout on our real-scale Export/Report, and profiling that long-running process is what surfaced this `ClearByKey` scan as a genuine O(n^2) bottleneck.

Rebased onto current `v13/main`; builds clean.
