### PR TITLE
Save blueprints via SaveBlueprint on the bulk save path

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -269,6 +269,21 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
         return Task.CompletedTask;
     }
 
+    /// <remarks>
+    ///  has to save via SaveBlueprint, the inherited ContentSerializer.SaveAsync would
+    ///  save through IContentService.Save, and that persists the item with the Document
+    ///  node object type - so the blueprint stops being a blueprint.
+    /// </remarks>
+    public override Task SaveAsync(IEnumerable<IContent> items)
+    {
+        foreach (var item in items)
+        {
+            contentService.SaveBlueprint(item, null);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public override Task DeleteItemAsync(IContent item)
     {
         contentService.DeleteBlueprint(item);


### PR DESCRIPTION
Fixes #1034.

`ContentTemplateSerializer` overrides `SaveItemAsync` to save through `IContentService.SaveBlueprint`, but inherits `SaveAsync(IEnumerable<IContent>)` from `ContentSerializer`, which saves through `IContentService.Save`.

`SyncHandlerRoot.PerformSecondPassImportsAsync` uses that bulk overload for any item whose second pass requires a save, so blueprints get persisted via `DocumentRepository`. Its `PersistUpdatedItem` rebuilds the `NodeDto` with `DocumentRepository.NodeObjectTypeId`, rewriting `umbracoNode.nodeObjectType` from `DocumentBlueprint` to `Document`.

Once that happens `GetBlueprintById` can no longer find the item, so the next import treats it as missing and tries to insert it again — failing with a duplicate key on `IX_umbracoNode_UniqueId`.

This overrides `SaveAsync` so the bulk path also goes through `SaveBlueprint`.

### Verification

Against Umbraco 16.5.1 / uSync 16.1.0, on a site with 9 blueprints:

|                                        | before | after |
| -------------------------------------- | ------ | ----- |
| blueprints with correct object type after first-boot import | 3 / 9  | 9 / 9 |
| duplicate key errors on the next import | 6      | 0     |

I could not see a sensible place to add a test for this — `uSync.Tests` covers extensions and migrations, and observing this needs a live `IContentService` and a database. Happy to add one if you have a pattern in mind.

### Other branches

I based this on `v18/main`. The same gap is present on `v17/main` and `v16/dev` — the `v16` variant needs the `uSyncTaskHelper.FromResultOf` wrapper and the single-argument `SaveBlueprint(item)` to match that branch. Glad to open backport PRs for either if that's easier than porting it yourself.
