### PR TITLE
Save blueprints via SaveBlueprint on the bulk save path (v16 backport)

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -159,6 +159,20 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
             contentService.SaveBlueprint(item);
         });
 
+    /// <remarks>
+    ///  has to save via SaveBlueprint, the inherited ContentSerializer.SaveAsync would
+    ///  save through IContentService.Save, and that persists the item with the Document
+    ///  node object type - so the blueprint stops being a blueprint.
+    /// </remarks>
+    public override Task SaveAsync(IEnumerable<IContent> items)
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            foreach (var item in items)
+            {
+                contentService.SaveBlueprint(item);
+            }
+        });
+
     public override Task DeleteItemAsync(IContent item)
         => uSyncTaskHelper.FromResultOf(() =>
         {


### PR DESCRIPTION
Backport of #1035 to `v16/dev`. Fixes #1034 on this branch.

`ContentTemplateSerializer` overrides `SaveItemAsync` to save through `IContentService.SaveBlueprint`, but inherits `SaveAsync(IEnumerable<IContent>)` from `ContentSerializer`, which saves through `IContentService.Save`.

`SyncHandlerRoot.PerformSecondPassImportsAsync` uses that bulk overload for any item whose second pass requires a save, so blueprints get persisted via `DocumentRepository`. Its `PersistUpdatedItem` rebuilds the `NodeDto` with `DocumentRepository.NodeObjectTypeId`, rewriting `umbracoNode.nodeObjectType` from `DocumentBlueprint` to `Document`.

Once that happens `GetBlueprintById` can no longer find the item, so the next import treats it as missing and tries to insert it again — failing with a duplicate key on `IX_umbracoNode_UniqueId`.

Same change as #1035, adjusted for this branch: wrapped in `uSyncTaskHelper.FromResultOf` and using the single argument `SaveBlueprint(item)`, to match the surrounding code.

### Verification

This is the branch the problem was originally found on. Against Umbraco 16.5.1 / uSync 16.1.0, on a site with 9 blueprints:

|                                        | before | after |
| -------------------------------------- | ------ | ----- |
| blueprints with correct object type after first-boot import | 3 / 9  | 9 / 9 |
| duplicate key errors on the next import | 6      | 0     |

Verified end to end by running a clean install twice — empty database and freshly seeded uSync folder, first boot then a second boot — and checking `umbracoNode.nodeObjectType` plus the import logs each time.

Take whichever of this and #1035 suits you, or neither if you would rather port it yourself.
