### PR TITLE
Save blueprints via SaveBlueprint on the bulk save path (v17 backport)

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -258,13 +258,14 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
     ///  node object type - so the blueprint stops being a blueprint.
     /// </remarks>
     public override Task SaveAsync(IEnumerable<IContent> items)
-        => uSyncTaskHelper.FromResultOf(() =>
+    {
+        foreach (var item in items)
         {
-            foreach (var item in items)
-            {
-                contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
-            }
-        });
+            contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
+        }
+
+        return Task.CompletedTask;
+    }
 
     public override Task DeleteItemAsync(IContent item)
         => uSyncTaskHelper.FromResultOf(() =>

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -252,6 +252,20 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
             contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
         });
 
+    /// <remarks>
+    ///  has to save via SaveBlueprint, the inherited ContentSerializer.SaveAsync would
+    ///  save through IContentService.Save, and that persists the item with the Document
+    ///  node object type - so the blueprint stops being a blueprint.
+    /// </remarks>
+    public override Task SaveAsync(IEnumerable<IContent> items)
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            foreach (var item in items)
+            {
+                contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
+            }
+        });
+
     public override Task DeleteItemAsync(IContent item)
         => uSyncTaskHelper.FromResultOf(() =>
         {


### PR DESCRIPTION
Backport of #1035 to `v17/main`, fixing #1034.

`ContentTemplateSerializer` overrides `SaveItemAsync` to save through `IContentService.SaveBlueprint`, but inherits `SaveAsync(IEnumerable<IContent>)` from `ContentSerializer`, which saves through `IContentService.Save`.

`SyncHandlerRoot.PerformSecondPassImportsAsync` uses that bulk overload for any item whose second pass requires a save, so blueprints get persisted via `DocumentRepository`. Its `PersistUpdatedItem` rebuilds the `NodeDto` with `DocumentRepository.NodeObjectTypeId`, rewriting `umbracoNode.nodeObjectType` from `DocumentBlueprint` to `Document`.

Once that happens `GetBlueprintById` can no longer find the item, so the next import treats it as missing and tries to insert it again — failing with a duplicate key on `IX_umbracoNode_UniqueId`.

This overrides `SaveAsync` so the bulk path also goes through `SaveBlueprint`, matching the `v17` style already used by `SaveItemAsync` (`uSyncTaskHelper.FromResultOf` wrapper, `SaveBlueprint(item, null, userId)`).

### Test plan

- [x] `uSync.Core` builds cleanly
- [x] Manual verification against a v17 site with blueprints (as done on v18 in #1035)