### PR TITLE
Fix silently discarded save failures in Language/DictionaryItem/Webhook serializers (v18 port)

### DIFF
--- a/uSync.Core/Serialization/Serializers/DictionaryItemSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DictionaryItemSerializer.cs
@@ -228,9 +228,17 @@ public class DictionaryItemSerializer : SyncSerializerBase<IDictionaryItem>, ISy
     }
 
     public override async Task SaveItemAsync(IDictionaryItem item)
-        => _ = item.HasIdentity
+    {
+        var attempt = item.HasIdentity
             ? await _dictionaryItemService.UpdateAsync(item, Constants.Security.SuperUserKey)
             : await _dictionaryItemService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save dictionary item {item.ItemKey}: {attempt.Status}");
+        }
+    }
 
     public override Task DeleteItemAsync(IDictionaryItem item)
         => _dictionaryItemService.DeleteAsync(item.Key, Constants.Security.SuperUserKey);

--- a/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
@@ -152,9 +152,17 @@ public class LanguageSerializer : SyncSerializerBase<ILanguage>, ISyncSerializer
         => Task.FromResult(default(ILanguage));
 
     public override async Task SaveItemAsync(ILanguage item)
-        => _ = item.HasIdentity
+    {
+        var attempt = item.HasIdentity
             ? await _languageService.UpdateAsync(item, Constants.Security.SuperUserKey)
             : await _languageService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save language {item.IsoCode}: {attempt.Status}");
+        }
+    }
 
     public override Task DeleteItemAsync(ILanguage item)
         => _languageService.DeleteAsync(item.IsoCode, Constants.Security.SuperUserKey);

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -50,7 +50,17 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
     /// <inheritdoc/>
     /// 
     public override async Task SaveItemAsync(IWebhook item)
-        => _ = item.HasIdentity ? await _webhookService.UpdateAsync(item) : await _webhookService.CreateAsync(item);
+    {
+        var attempt = item.HasIdentity
+            ? await _webhookService.UpdateAsync(item)
+            : await _webhookService.CreateAsync(item);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save webhook {item.Key}: {attempt.Status}");
+        }
+    }
 
     /// <inheritdoc/>
     protected override async Task<SyncAttempt<IWebhook>> DeserializeCoreAsync(XElement node, SyncSerializerOptions options)


### PR DESCRIPTION
## Summary
Cherry-pick of #1039 from v17/main onto v18/main.

- `LanguageSerializer.SaveItemAsync`, `DictionaryItemSerializer.SaveItemAsync`, and `WebhookSerializer.SaveItemAsync` discarded the `Attempt<T, Status>` returned by the underlying Umbraco service's `UpdateAsync`/`CreateAsync`, so a save that Umbraco rejected (e.g. an ISO code the `IsoCodeValidator` doesn't accept) was silently dropped — uSync still counted the item as imported and reported the run as successful.
- Each `SaveItemAsync` now checks `attempt.Success` and throws an `InvalidOperationException` (including the returned operation status) on failure, so the failure surfaces in the import results and log instead of vanishing.

Fixes #1038 (v18 port)

## Test plan
- [x] `dotnet build uSync.Core/uSync.Core.csproj` succeeds
- [x] Manual repro from the issue confirms the failure is now reported rather than silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)