### PR TITLE
Fix discarded save-attempt results across remaining serializers

### DIFF
--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -774,7 +774,15 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         => Task.FromResult(contentService.GetById(id));
 
     public override Task SaveAsync(IEnumerable<IContent> items)
-        => Task.FromResult(contentService.Save(items));
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var result = contentService.Save(items);
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save content items: {result.Result}");
+            }
+        });
 
     public override async Task SaveItemAsync(IContent item)
         => await SaveItemAsync(item, -1);
@@ -785,11 +793,16 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         {
             try
             {
-                contentService.Save(item, userId);
+                var result = contentService.Save(item, userId);
+                if (result.Success is false)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not save content {item.Name}: {result.Result}");
+                }
             }
             catch (ArgumentNullException ex)
             {
-                // we can get thrown a null argument exception by the notifier, 
+                // we can get thrown a null argument exception by the notifier,
                 // which is non critical! but we are ignoring this error. ! <= 8.1.5
                 if (!ex.Message.Contains("siteUri")) throw;
             }

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1395,13 +1395,14 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
             return;
         }
 
-        if (item.Id <= 0)
+        var attempt = item.Id <= 0
+            ? await _baseService.CreateAsync(item, Constants.Security.SuperUserKey)
+            : await _baseService.UpdateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
         {
-            await _baseService.CreateAsync(item, Constants.Security.SuperUserKey);
-        }
-        else
-        {
-            await _baseService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            throw new InvalidOperationException(
+                $"Could not save {typeof(TObject).Name} {item.Alias}: {attempt.Result}");
         }
 
         //if (item.IsDirty()) _baseService.Save(item);

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -204,7 +204,12 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
                 logger.LogDebug("Saving in Serializer because item is dirty [{properties}]", dirty);
 
 
-            await _contentTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            var attempt = await _contentTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save content type {item.Alias}: {attempt.Result}");
+            }
         }
 
         await CleanFolderAsync(item, node);

--- a/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -366,10 +366,15 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
         // see : https://github.com/umbraco/Umbraco-CMS/issues/19732
         // if (item.IsDirty() is false) return;
 
-        if (item.HasIdentity is true)
-            await _dataTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
-        else
-            await _dataTypeService.CreateAsync(item, Constants.Security.SuperUserKey);
+        var attempt = item.HasIdentity is true
+            ? await _dataTypeService.UpdateAsync(item, Constants.Security.SuperUserKey)
+            : await _dataTypeService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save data type {item.Name}: {attempt.Status}");
+        }
     }
 
     public override async Task SaveAsync(IEnumerable<IDataType> items)

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -346,7 +346,12 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
                 })
         };
 
-        await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
+        var attempt = await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save domain {item.DomainName}: {attempt.Status}");
+        }
     }
 
     private sealed class DomainSyncModel
@@ -366,7 +371,12 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
         var existing = await _domainService.GetAssignedDomainsAsync(contentKey.Result, true);
         var remaining = existing.Where(x => x.Key != item.Key).Select(x => new DomainModel { DomainName = x.DomainName, IsoCode = x.LanguageIsoCode! });
 
-        await _domainService.UpdateDomainsAsync(contentKey.Result, new DomainsUpdateModel { Domains = remaining });
+        var attempt = await _domainService.UpdateDomainsAsync(contentKey.Result, new DomainsUpdateModel { Domains = remaining });
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not remove domain {item.DomainName}: {attempt.Status}");
+        }
     }
 
 

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -227,13 +227,37 @@ public class MediaSerializer : ContentSerializerBase<IMedia>, ISyncSerializer<IM
     }
 
     public override Task SaveAsync(IEnumerable<IMedia> items)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Save(items); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Save(items);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save media items: {attempt.Result?.Result}");
+            }
+        });
 
     public override Task SaveItemAsync(IMedia item)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Save(item); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Save(item);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save media {item.Name}: {attempt.Result?.Result}");
+            }
+        });
 
     public override Task DeleteItemAsync(IMedia item)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Delete(item); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Delete(item);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not delete media {item.Name}: {attempt.Result?.Result}");
+            }
+        });
 
     protected override Task<IMedia?> FindParentByIdAsync(int id)
         => Task.FromResult(_mediaService.GetById(id));

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -355,9 +355,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 logger.LogDebug("Saving: {alias} {path}", item.Alias, item.Path);
 
             var result = await _templateService.UpdateAsync(item, userKey);
-            
+
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
+
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save template {item.Alias}: {result.Status}");
+            }
         }
         else
         {
@@ -365,9 +371,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 logger.LogDebug("Creating: {alias} {path}", item.Alias, item.Path);
 
             var result = await _templateService.CreateAsync(item.Name ?? item.Alias, item.Alias, item.Content, userKey, item.Key);
-            
+
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
+
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save template {item.Alias}: {result.Status}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #1038/#1039. Applied the same fix pattern to the 7 remaining "quick win" sites identified in review — serializers whose underlying Umbraco service already returns an `Attempt`/`OperationResult` with a `.Success` flag, but the serializer either discarded it entirely, or (in one case) only logged it at Debug level, so a failed save/delete was reported as a successful import.

- `ContentTypeBaseSerializer.SaveItemAsync` — shared base for **MediaType**, **ContentType**, and **MemberType** serializers; `IContentTypeBaseService<TObject>.CreateAsync`/`UpdateAsync`
- `ContentTypeSerializer.DeserializeSecondPassAsync` — extra direct `_contentTypeService.UpdateAsync` call
- `DataTypeSerializer.SaveItemAsync` — `_dataTypeService.CreateAsync`/`UpdateAsync`
- `DomainSerializer.SaveItemAsync` / `DeleteItemAsync` — `_domainService.UpdateDomainsAsync`
- `TemplateSerializer.SaveItemAsync` — `_templateService.CreateAsync`/`UpdateAsync` (previously logged the failure at Debug level only, never enforced)
- `MediaSerializer.SaveItemAsync` / `SaveAsync` / `DeleteItemAsync` — `_mediaService.Save`/`Delete`
- `ContentSerializer.SaveItemAsync(IContent, int)` / `SaveAsync` — `contentService.Save(...)` (previously not even captured)

Each now checks `.Success` and throws `InvalidOperationException` with the operation status/result on failure, matching the pattern already used for Language/DictionaryItem/Webhook.

Deliberately out of scope (per discussion): serializers where the fix would require switching to a different, model-based Umbraco service (`IMediaEditingService`, `IContentBlueprintEditingService`) or where no Attempt-based alternative exists at all (`RelationTypeSerializer`'s `IRelationType` save, general `IContentService` raw-entity save). Those are candidates for separate, larger follow-up work.

## Test plan
- [x] `dotnet build uSync.Core/uSync.Core.csproj` succeeds
- [x] Manual verification that a rejected save (e.g. invalid content type / data type / template) now surfaces as an import failure rather than silently succeeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)