### PR TITLE
Fix generic 'Failed to create template' error hiding real cause (#1044)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,8 @@
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 
 		<NoWarn>NU1902</NoWarn>
-
+		<NuGetAuditMode>direct</NuGetAuditMode>
+		
 		<PackageReleaseNotes>
 	<![CDATA[- 9.0 : Dotnet core version
 - 9.1 : Net 5/6 targets

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,36 +1,36 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <!-- umbraco site -->
-  <ItemGroup>
-    <PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
-    <PackageVersion Include="Umbraco.Cms" Version="17.3.0" />
-    <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.3.0" />
-    <PackageVersion Include="Clean.Core" Version="7.0.5" />
-  </ItemGroup>
-  <!-- umbraco libraries for packages -->
-  <ItemGroup>
-    <PackageVersion Include="Umbraco.Cms.Core" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Web.Website" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.0" />
-  </ItemGroup>
-  <!-- source link -->
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
-  </ItemGroup>
-  <!-- testing -->
-  <ItemGroup>
-    <PackageVersion Include="Umbraco.Cms.Tests" Version="17.3.0" />
-    <PackageVersion Include="Umbraco.Cms.Tests.Integration" Version="17.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-  </ItemGroup>
-  <!-- command line -->
-  <ItemGroup>
-    <PackageVersion Include="NJsonSchema" Version="11.5.2" />
-    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<!-- umbraco site -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms" Version="17.4.2" />
+		<PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.4.2" />
+		<PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
+		<PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+		<PackageVersion Include="Clean.Core" Version="7.0.5" />
+	</ItemGroup>
+	<!-- umbraco libraries for packages -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms.Core" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Web.Website" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.0" />
+	</ItemGroup>
+	<!-- source link -->
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
+	</ItemGroup>
+	<!-- testing -->
+	<ItemGroup>
+		<PackageVersion Include="Umbraco.Cms.Tests" Version="17.3.0" />
+		<PackageVersion Include="Umbraco.Cms.Tests.Integration" Version="17.3.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+		<PackageVersion Include="coverlet.collector" Version="8.0.1" />
+	</ItemGroup>
+	<!-- command line -->
+	<ItemGroup>
+		<PackageVersion Include="NJsonSchema" Version="11.5.2" />
+		<PackageVersion Include="CommandLineParser" Version="2.9.1" />
+	</ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
 		<PackageVersion Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.4.2" />
 		<PackageVersion Include="Our.Umbraco.ConditionalDisplayers" Version="16.6.0" />
 		<PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
+		<PackageVersion Include="Clean" Version="7.0.5" />
 		<PackageVersion Include="Clean.Core" Version="7.0.5" />
 	</ItemGroup>
 	<!-- umbraco libraries for packages -->

--- a/docs/perf/batch-save-investigation.md
+++ b/docs/perf/batch-save-investigation.md
@@ -1,0 +1,180 @@
+# Investigation: batched content/media save on import (perf item #1)
+
+**Branch:** `v17/investigate/batch-save`
+**Question:** would routing content/media imports through Umbraco's
+`Save(IEnumerable<…>)` (the batch overload) meaningfully reduce database work,
+given that (a) Umbraco's own batching is limited and (b) notifications may not be
+batched?
+
+**Short answer:** No — not as a safe, general win. In the default configuration
+the only saving would come at the cost of the per-item failure isolation that the
+current default is deliberately designed to provide. In the opt-in "suppressed"
+configuration the transaction and notifications are *already* batched by uSync's
+ambient scope, so the batch overload adds almost nothing. Recommendation: **do not
+wire up bulk `Save` for content/media.** Details and evidence below.
+
+---
+
+## 1. What the batch overload actually does
+
+Decompiled from `Umbraco.Cms.Core.Services.ContentService` (Umbraco 17.3.0,
+`Umbraco.Core.dll`). Media (`MediaService`) is equivalent.
+
+`Save(IContent)` — the per-item path uSync uses today:
+
+```csharp
+using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+{
+    scope.WriteLock(Constants.Locks.ContentTree);
+    if (scope.Notifications.PublishCancelable(new ContentSavingNotification(content, …)))
+        { scope.Complete(); return Cancel; }
+    _documentRepository.Save(content);                 // 1 row write
+    scope.Notifications.Publish(new ContentSavedNotification(content, …));
+    scope.Notifications.Publish(new ContentTreeChangeNotification(content, RefreshNode, …));
+    Audit(...);
+    scope.Complete();                                   // 1 transaction commit
+}
+```
+
+`Save(IEnumerable<IContent>)` — the batch overload:
+
+```csharp
+IContent[] array = contents.ToArray();
+using (ICoreScope scope = ScopeProvider.CreateCoreScope())
+{
+    scope.WriteLock(Constants.Locks.ContentTree);
+    if (scope.Notifications.PublishCancelable(new ContentSavingNotification(array, …)))  // ONE, batched
+        { scope.Complete(); return Cancel; }
+    foreach (IContent content in array)
+        _documentRepository.Save(content);              // still 1 row write PER item
+    scope.Notifications.Publish(new ContentSavedNotification(array, …));                 // ONE, batched
+    scope.Notifications.Publish(new ContentTreeChangeNotification(array, RefreshNode, …));// ONE, batched
+    Audit(...);
+    scope.Complete();                                   // ONE transaction commit
+}
+```
+
+Key observations:
+
+- **The actual row writes are identical** — `_documentRepository.Save(content)` runs
+  once per item in both. The batch overload does **not** issue a single set-based
+  SQL statement; it loops. So there is **no reduction in the number of INSERT/UPDATE
+  round-trips**.
+- The batch overload's savings are purely **structural**: 1 scope/transaction/commit
+  and 1 write-lock instead of N, and **notifications *are* batched** — `ContentSaving`,
+  `ContentSaved` and `ContentTreeChange` each fire **once with an array** rather than
+  N times. (This corrects the assumption that "notifications aren't batched" — at the
+  `ContentService` level they are, when you use the batch overload.)
+- The batch overload also **skips** the per-item validation that `Save(IContent)`
+  performs: the `PublishedState` guard and the 255-char name-length check. It also
+  doesn't accept a `ContentSchedule`.
+
+So the theoretical benefit of switching is: **N transactions → 1, and N notification
+dispatches → 1.** No change to the number of row writes.
+
+## 2. Does uSync actually pay "N transactions" today? It depends on config.
+
+uSync wraps an import handler run in
+`ICoreScopeProvider.CreateNotificationScope(...)`
+([`ScopeExtensions.cs`](../../uSync.BackOffice/Extensions/ScopeExtensions.cs)):
+
+```csharp
+if (syncConfigService.Settings.DisableNotificationSuppression)
+    return null;                                    // <-- default path
+return scopeProvider.CreateCoreScope(
+    scopedNotificationPublisher: notificationPublisher,   // SyncScopedNotificationPublisher
+    autoComplete: true);
+```
+
+`DisableNotificationSuppression` **defaults to `true`** on v16+
+([`uSyncSettings.cs:224`](../../uSync.BackOffice/Configuration/uSyncSettings.cs)),
+so there are two very different runtime shapes:
+
+### Default config — `DisableNotificationSuppression = true`
+
+`CreateNotificationScope` returns **null**. There is **no uSync ambient scope**
+around the import (`SyncService_Handlers.cs`: `scope?.Complete()` is a no-op). Each
+per-item `contentService.Save(item)` therefore opens its **own** root scope →
+its **own** transaction/commit, and fires its notifications **immediately**.
+
+- Here, N items really do mean **N transactions + N notification sets**.
+- The batch overload *would* collapse these to 1 + 1.
+- **BUT** this per-item, non-batched behaviour is a *deliberate design decision*.
+  From the setting's own XML docs:
+
+  > on v16 the default is true, because some of the notifications appear to be
+  > closely coupled to the save/publish process, and if something goes wrong in one
+  > item's import it can cause a cascade of failures across everything that might have
+  > been imported along with it. If the notifications are not suppressed, then if an
+  > item fails to import it doesn't stop other items from being imported.
+
+  Batch-saving reintroduces exactly the failure mode this default exists to avoid:
+  a single bad item (DB constraint, a throwing `Saving`/`Saved` handler, an
+  over-long name that the batch overload no longer validates) rolls back or aborts
+  the **whole batch**, and uSync loses its per-item error attribution (which item
+  failed, with what message). This matches the "batching causes issues" experience.
+
+### Opt-in config — `DisableNotificationSuppression = false`
+
+`CreateNotificationScope` returns a real ambient scope using
+`SyncScopedNotificationPublisher`
+([`SyncScopedNotificationPublisher.cs`](../../uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs)).
+
+- **Transaction is already batched.** Umbraco scopes nest; the per-item
+  `contentService.Save` calls become child scopes that share the single ambient
+  transaction, which commits once when uSync completes the outer scope. So the
+  "N transactions" cost is **already gone** without the batch overload.
+- **Notifications are already deferred and grouped.** The scoped publisher collects
+  every notification raised during the import and, at completion, dispatches them
+  grouped by type in one `IEventAggregator.Publish(items)` call per type — or, if
+  `BackgroundNotifications = true`, hands them to the background task queue.
+
+  In this mode, switching to the batch overload only changes "N single-entity
+  `ContentSavedNotification`s, then group-published" into "1 array
+  `ContentSavedNotification`". That is a marginal allocation/dispatch difference,
+  **not** a database saving.
+
+## 3. Why the schema types already use the bulk path — and content doesn't
+
+This asymmetry is intentional. `ContentTypeSerializer`, `MediaTypeSerializer`,
+`MemberTypeSerializer` and `DataTypeSerializer` already override `SaveAsync` and
+honour `SerializerFlags.DoNotSave`, because saving a **doctype/datatype** triggers
+expensive schema changes and full cache/nucache rebuilds — there, batching many into
+one operation is a genuine, large win and the items are few. For **content/media**
+items the per-save cost is dominated by the unavoidable per-row write, and the items
+are many, so the batch overload buys far less while adding the atomicity risk above.
+
+The handler-level bulk hook does exist —
+[`SyncHandlerRoot.ImportAllAsync`](../../uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs)
+calls `serializer.SaveAsync(updates…)` — but only under
+`if (options.Flags.HasFlag(SerializerFlags.DoNotSave))`, and `DoNotSave` is never set
+for the content/media import path. So the plumbing is present but deliberately dormant
+for these types.
+
+## 4. Conclusion & recommendation
+
+| Config | Transactions today | Notifications today | Batch overload benefit | Cost/risk |
+|---|---|---|---|---|
+| **Default** (`DisableNotificationSuppression = true`) | N (one per item) | N, fired immediately | N→1 txn, N→1 notifications | **Loses per-item failure isolation** (the reason this is the default); no reduction in row writes |
+| **Suppressed** (`= false`) | 1 (ambient scope) | Deferred + grouped (opt. background) | ~none (already batched) | Marginal |
+
+**Recommendation: do not wire up bulk `Save(IEnumerable)` for content/media.**
+It delivers no reduction in the dominant cost (per-row writes), its transaction/
+notification batching is either already provided by the suppressed-scope path or
+directly conflicts with the intentional per-item isolation of the default path, and
+it removes per-item error reporting plus two validation checks.
+
+If import throughput on large content sets is the goal, the existing, lower-risk
+levers are configuration, not code:
+
+- **`DisableNotificationSuppression = false`** — collapses the import to a single
+  transaction and defers/groups notifications (this is the "batch" people actually
+  want, done at the scope level rather than the save level).
+- **`BackgroundNotifications = true`** — moves notification processing off the import
+  thread entirely.
+
+If a save-level optimisation is ever revisited, the only shape worth prototyping is a
+**bounded** batch (e.g. save in chunks of N with a per-chunk try/catch that falls back
+to per-item on failure) so the failure blast radius stays small — and it should be
+measured against a real content tree before adoption, since the row-write cost (which
+batching does not change) is expected to dominate.

--- a/uSync.AutoTemplates/AutoTemplateComposer.cs
+++ b/uSync.AutoTemplates/AutoTemplateComposer.cs
@@ -1,4 +1,6 @@
-﻿using Umbraco.Cms.Core.Composing;
+﻿using System.Linq;
+
+using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 
 namespace uSync.AutoTemplates;
@@ -7,6 +9,8 @@ public class AutoTemplateComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.AdduSyncAutoTemplates();
+        // only load when the backoffice is enabled. 
+        if (builder.Services.Any(s => s.ServiceType == typeof(IBackOfficeEnabledMarker)))
+            builder.AdduSyncAutoTemplates();
     }
 }

--- a/uSync.AutoTemplates/TemplateWatcher.cs
+++ b/uSync.AutoTemplates/TemplateWatcher.cs
@@ -31,7 +31,6 @@ public partial class TemplateWatcher : IRegisteredObject
     private readonly ILogger<TemplateWatcher> _logger;
     private readonly ITemplateService _templateService;
     private readonly IShortStringHelper _shortStringHelper;
-    private readonly IHostEnvironment _hostEnvironment;
 
     private readonly IFileSystem? _templateFileSystem;
 
@@ -51,14 +50,13 @@ public partial class TemplateWatcher : IRegisteredObject
         ITemplateService templateService)
     {
         _shortStringHelper = shortStringHelper;
-        _hostEnvironment = hostEnvironment;
         _hostingLifetime = hostingLifetime;
 
         _logger = logger;
 
         _templateFileSystem = fileSystems.MvcViewsFileSystem;
 
-        _viewsFolder = _hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.MvcViews);
+        _viewsFolder = hostEnvironment.MapPathContentRoot(Constants.SystemDirectories.MvcViews);
 
 
         // 
@@ -157,7 +155,7 @@ public partial class TemplateWatcher : IRegisteredObject
     }
 
 
-    private static object lockObject = new Object();
+    private static readonly Lock lockObject = new();
 
     private void CheckFile(string filename)
     {

--- a/uSync.BackOffice/Boot/uSyncBootExtension.cs
+++ b/uSync.BackOffice/Boot/uSyncBootExtension.cs
@@ -48,7 +48,7 @@ internal static class uSyncBootExtension
 /// <summary>
 ///  Handler to mange app starting for first boot migrations 
 /// </summary>
-internal class FirstBootAppStartingHandler
+internal sealed class FirstBootAppStartingHandler
     : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
 {
 

--- a/uSync.BackOffice/Configuration/SyncConfigService.cs
+++ b/uSync.BackOffice/Configuration/SyncConfigService.cs
@@ -57,7 +57,7 @@ internal class SyncConfigService : ISyncConfigService
             .ToArray();
     }
 
-    private class SyncFolderItem
+    private sealed class SyncFolderItem
     {
         public required string Path { get; set; }
         public int Weight { get; set; }

--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -93,7 +93,7 @@ public static class HandlerSettingsExtensions
     {
         if (settings.Settings != null && settings.Settings.TryGetValue(key, out var value) && value is not null)
         {
-            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+            if (value.TryGetValueAs<TResult>(out var result) && result is not null)
                 return result;
         }
 

--- a/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
+++ b/uSync.BackOffice/Configuration/uSyncHandlerSettings.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 
 using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.BackOffice.Configuration;
 
 /// <summary>
@@ -89,10 +91,10 @@ public static class HandlerSettingsExtensions
     /// <returns></returns>
     public static TResult GetSetting<TResult>(this HandlerSettings settings, string key, TResult defaultValue)
     {
-        if (settings.Settings != null && settings.Settings.TryGetValue(key, out var value))
+        if (settings.Settings != null && settings.Settings.TryGetValue(key, out var value) && value is not null)
         {
-            var attempt = value.TryConvertTo<TResult>();
-            if (attempt) return attempt.Result ?? defaultValue;
+            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+                return result;
         }
 
         return defaultValue;

--- a/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
+++ b/uSync.BackOffice/Extensions/uSyncActionExtensions.cs
@@ -137,7 +137,9 @@ public static class uSyncActionExtensions
     public static bool RequiresSave<TObject>(this SyncAttempt<TObject> attempt)
         => attempt.Success && attempt.Change > Core.ChangeType.NoChange && !attempt.Saved && attempt.Item != null;
 
-
+    /// <summary>
+    ///  return the uSyncAction as an ActionView (used in the controllers)
+    /// </summary>
     public static uSyncActionView AsActionView(this uSyncAction action)
     {
         var msg = string.IsNullOrWhiteSpace(action.Message) is false

--- a/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
+++ b/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
@@ -20,8 +20,11 @@ namespace uSync.BackOffice.HealthChecks;
     Group = "uSync")]
 public class SyncFolderIntegrityChecks : HealthCheck
 {
-    private readonly ISyncConfigService _configService;
-    private readonly ISyncFileService _fileService;
+    private readonly ISyncConfigService? _configService;
+    private readonly ISyncFileService? _fileService;
+
+
+    public SyncFolderIntegrityChecks() { }
 
     /// <summary>
     ///  Constructor 
@@ -41,6 +44,18 @@ public class SyncFolderIntegrityChecks : HealthCheck
     /// <inheritdoc/>
     public override Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
     {
+        if (_configService is null || _fileService is null)
+        {
+            return Task.FromResult((IEnumerable<HealthCheckStatus>)new List<HealthCheckStatus>
+            {
+                new HealthCheckStatus("uSync services not available")
+                {
+                    Description = "The uSync services are not available, this likely means the site has no backoffice loaded.",
+                    ResultType = StatusResultType.Info
+                }
+            });
+        }
+
         var items = new List<HealthCheckStatus>
         {
             CheckuSyncFolder(),

--- a/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
+++ b/uSync.BackOffice/HealthChecks/SyncFolderIntegrityChecks.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
@@ -23,7 +24,6 @@ public class SyncFolderIntegrityChecks : HealthCheck
     private readonly ISyncConfigService? _configService;
     private readonly ISyncFileService? _fileService;
 
-
     public SyncFolderIntegrityChecks() { }
 
     /// <summary>
@@ -44,17 +44,8 @@ public class SyncFolderIntegrityChecks : HealthCheck
     /// <inheritdoc/>
     public override Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
     {
-        if (_configService is null || _fileService is null)
-        {
-            return Task.FromResult((IEnumerable<HealthCheckStatus>)new List<HealthCheckStatus>
-            {
-                new HealthCheckStatus("uSync services not available")
-                {
-                    Description = "The uSync services are not available, this likely means the site has no backoffice loaded.",
-                    ResultType = StatusResultType.Info
-                }
-            });
-        }
+        if (_configService is null || _fileService is null) 
+            return Task.FromResult(Enumerable.Empty<HealthCheckStatus>());
 
         var items = new List<HealthCheckStatus>
         {
@@ -67,6 +58,9 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private HealthCheckStatus CheckuSyncFolder()
     {
+        if (_configService is null || _fileService is null)
+            return new HealthCheckStatus("Unable to check uSync folder integrity");
+
         var root = _fileService.GetAbsPath(_configService.GetWorkingFolder());
 
         if (_fileService.DirectoryExists(root) is false)
@@ -100,6 +94,8 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private List<string> CheckFolder(string folder)
     {
+        if (_fileService is null) return [];
+
         var _keys = new Dictionary<Guid, string>();
 
         var clashes = new List<string>();
@@ -143,6 +139,9 @@ public class SyncFolderIntegrityChecks : HealthCheck
 
     private HealthCheckStatus CheckConfigFolderValidity()
     {
+        if (_configService is null || _fileService is null)
+            return new HealthCheckStatus("Unable to check uSync folder integrity");
+
         var root = _fileService.GetAbsPath(_configService.GetWorkingFolder());
 
         if (_fileService.DirectoryExists(root) is false)

--- a/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
+++ b/uSync.BackOffice/Notifications/SyncScopedNotificationPublisher.cs
@@ -12,11 +12,10 @@ using Umbraco.Cms.Core.Notifications;
 
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Services;
-using uSync.BackOffice.SyncHandlers.Interfaces;
 
 namespace uSync.BackOffice.Notifications;
 
-internal class SyncScopedNotificationPublisher
+internal sealed class SyncScopedNotificationPublisher
     : ScopedNotificationPublisher<INotificationHandler>, IScopedNotificationPublisher
 {
     private readonly ILogger<SyncScopedNotificationPublisher> _logger;

--- a/uSync.BackOffice/Services/ISyncFileService.cs
+++ b/uSync.BackOffice/Services/ISyncFileService.cs
@@ -137,6 +137,16 @@ public interface ISyncFileService
     Task<XElement> LoadXElementAsync(string file);
 
     /// <summary>
+    ///  load just the item key (the Key attribute on the root element) from a file.
+    /// </summary>
+    /// <remarks>
+    ///  This streams the file and stops at the root element, so we don't pay the cost
+    ///  of parsing the whole document when all we need is the key (e.g. when working out
+    ///  which items live in a folder for a 'clean' operation).
+    /// </remarks>
+    Task<Guid> LoadKeyFromFileAsync(string file);
+
+    /// <summary>
     ///  merge all the files in the given folders into a single xml node, that can be bulk imported
     /// </summary>
     Task<int> MakeSingleExportFromFolders(string[] folders, string itemType, ISyncTrackerBase? trackerBase, string fileName, string extension);

--- a/uSync.BackOffice/Services/ISyncVersionFileService.cs
+++ b/uSync.BackOffice/Services/ISyncVersionFileService.cs
@@ -2,8 +2,20 @@
 
 namespace uSync.BackOffice.Services;
 
+/// <summary>
+///  Controls the version file we write to disk on syncs (used to warn if sync is old)
+/// </summary>
 public interface ISyncVersionFileService
 {
+    /// <summary>
+    ///  get the Sync file version information for a folder. 
+    /// </summary>
     Task<SyncFileVersionCheckResult> GetSyncFileInfo(string folder);
+
+    /// <summary>
+    ///  write the version information to disk. 
+    /// </summary>
+    /// <param name="folder"></param>
+    /// <returns></returns>
     Task WriteVersionFileAsync(string folder);
 }

--- a/uSync.BackOffice/Services/SyncFileService.cs
+++ b/uSync.BackOffice/Services/SyncFileService.cs
@@ -211,6 +211,51 @@ internal class SyncFileService : ISyncFileService
         }
     }
 
+    private static readonly XmlReaderSettings _keyReaderSettings = new()
+    {
+        CheckCharacters = false,
+        Async = true,
+        IgnoreWhitespace = true,
+        IgnoreComments = true,
+        IgnoreProcessingInstructions = true,
+        DtdProcessing = DtdProcessing.Prohibit,
+    };
+
+    /// <inheritdoc/>
+    public async Task<Guid> LoadKeyFromFileAsync(string file)
+    {
+        EnsureFileExists(file);
+
+        try
+        {
+            using (var stream = OpenRead(file))
+            {
+                if (stream is null)
+                    throw new FileNotFoundException($"Cannot create stream for {file}");
+
+                using (var reader = XmlReader.Create(stream, _keyReaderSettings.Clone()))
+                {
+                    // move to the first (root) element and read its Key attribute,
+                    // we don't need to read any further into the document.
+                    while (await reader.ReadAsync())
+                    {
+                        if (reader.NodeType != XmlNodeType.Element) continue;
+
+                        var key = reader.GetAttribute(global::uSync.Core.uSyncConstants.Xml.Key);
+                        return Guid.TryParse(key, out var guid) ? guid : Guid.Empty;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Error while reading key from {file} {message}", file, ex.Message);
+            throw new Exception($"Error while reading key from {file}", ex);
+        }
+
+        return Guid.Empty;
+    }
+
     /// <inheritdoc/>
     public async Task SaveFileAsync(string filename, Stream stream)
     {

--- a/uSync.BackOffice/Services/SyncVersionFileService.cs
+++ b/uSync.BackOffice/Services/SyncVersionFileService.cs
@@ -119,9 +119,23 @@ internal class SyncVersionFileService : ISyncVersionFileService
     }
 }
 
+/// <summary>
+///  results of a check of the version file 
+/// </summary>
 public class SyncFileVersionCheckResult
 {
+    /// <summary>
+    ///  the sync on disk is current to the current format we are writing. 
+    /// </summary>
     public bool IsCurrent { get; set; }
+
+    /// <summary>
+    ///  the version we are writing to disk
+    /// </summary>
     public string? FormatVersion { get; set; }
+
+    /// <summary>
+    ///  the hmac value for the folders matches. (reserved)
+    /// </summary>
     public bool HmacMatch { get; set; }
 }

--- a/uSync.BackOffice/Services/uSyncTriggers.cs
+++ b/uSync.BackOffice/Services/uSyncTriggers.cs
@@ -10,7 +10,7 @@ internal delegate void uSyncTriggerEventHandler(uSyncTriggerArgs e);
 /// <summary>
 ///  used to trigger uSync events from within other elements of uSync
 /// </summary>
-internal class uSyncTriggers
+internal sealed class uSyncTriggers
 {
     internal static event uSyncTriggerEventHandler? DoExport;
     internal static event uSyncTriggerEventHandler? DoImport;
@@ -47,12 +47,11 @@ internal class uSyncTriggers
 
 }
 
-internal class uSyncTriggerArgs
+internal sealed class uSyncTriggerArgs
 {
     public string Folder { get; set; } = string.Empty;
 
     public IEnumerable<string> EntityTypes { get; set; } = [];
 
     public SyncHandlerOptions? HandlerOptions { get; set; }
-
 }

--- a/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
+++ b/uSync.BackOffice/SyncHandlers/Handlers/ContentHandler.cs
@@ -97,7 +97,15 @@ public class ContentHandler : ContentHandlerBase<IContent>, ISyncHandler,
             var total = long.MaxValue;
             while (page * pageSize < total)
             {
-                items.AddRange(_contentService.GetPagedChildren(parent.Id, page++, pageSize, out total));
+                items.AddRange(_contentService.GetPagedChildren(
+                    id: parent.Id,
+                    pageIndex: page++,
+                    pageSize: pageSize,
+                    totalRecords: out total,
+                    propertyAliases: null,
+                    filter: null,
+                    ordering: null,
+                    loadTemplates: true));
             }
             return items;
 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerBase.cs
@@ -99,9 +99,11 @@ public abstract class SyncHandlerBase<TObject>
 
     private async Task<Guid?> GetCleanParentKeyAsync(string cleanFile)
     {
-        var node = await syncFileService.LoadXElementAsync(cleanFile);
-        if (node.GetKey() == Guid.Empty) return Guid.Empty;
-        return (await GetCleanParentAsync(cleanFile))?.Key;
+        // stream the key rather than parsing the whole file, and reuse it for the
+        // parent lookup so we don't read the clean file a second time.
+        var key = await syncFileService.LoadKeyFromFileAsync(cleanFile);
+        if (key == Guid.Empty) return Guid.Empty;
+        return (await GetFromServiceAsync(key))?.Key;
     }
 
     /// <summary>

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -264,75 +264,79 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     public async Task<IEnumerable<uSyncAction>> ImportAllAsync(string[] folders, HandlerSettings config, uSyncImportOptions options)
     {
         var cacheKey = PrepCaches();
-        runtimeCache.ClearByKey(cacheKey);
-
-        options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
-
-        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
-
-        options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
-
-        // create the update list with items.count space. this is the max size we need this list. 
-        List<uSyncAction> actions = new(items.Count);
-        List<ImportedItem<TObject>> updates = new(items.Count);
-        List<string> cleanMarkers = [];
-
-        int count = 0;
-        int total = items.Count;
-
-        options.Callbacks?.SetRange?.Invoke(count, total);
-
-        foreach (var item in items)
+        try
         {
-            count++;
+            options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
 
+            var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
 
-            var result = await ImportElementAsync(item.Node, item.FileName, config, options);
-            foreach (var attempt in result)
+            options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
+
+            // create the update list with items.count space. this is the max size we need this list.
+            List<uSyncAction> actions = new(items.Count);
+            List<ImportedItem<TObject>> updates = new(items.Count);
+            List<string> cleanMarkers = [];
+
+            int count = 0;
+            int total = items.Count;
+
+            options.Callbacks?.SetRange?.Invoke(count, total);
+
+            foreach (var item in items)
             {
-                if (attempt.Success)
+                count++;
+
+
+                var result = await ImportElementAsync(item.Node, item.FileName, config, options);
+                foreach (var attempt in result)
                 {
-                    if (attempt.Change == ChangeType.Clean)
+                    if (attempt.Success)
                     {
-                        cleanMarkers.Add(item.Path);
+                        if (attempt.Change == ChangeType.Clean)
+                        {
+                            cleanMarkers.Add(item.Path);
+                        }
+                        else if (attempt.Item is not null && attempt.Item is TObject update)
+                        {
+                            updates.Add(new ImportedItem<TObject>(item.Node, update));
+                        }
                     }
-                    else if (attempt.Item is not null && attempt.Item is TObject update)
-                    {
-                        updates.Add(new ImportedItem<TObject>(item.Node, update));
-                    }
+
+                    if (attempt.Change != ChangeType.Clean)
+                        actions.Add(attempt);
+                }
+            }
+
+            // clean up memory we didn't use in the update list.
+            updates.TrimExcess();
+
+            // bulk save?
+            if (updates.Count > 0)
+            {
+                if (options.Flags.HasFlag(SerializerFlags.DoNotSave))
+                {
+                    await serializer.SaveAsync(updates.Select(x => x.Item));
                 }
 
-                if (attempt.Change != ChangeType.Clean)
-                    actions.Add(attempt);
+                await PerformSecondPassImportsAsync(updates, actions, config, options.Callbacks?.Update);
             }
-        }
 
-        // clean up memory we didn't use in the update list. 
-        updates.TrimExcess();
-
-        // bulk save?
-        if (updates.Count > 0)
-        {
-            if (options.Flags.HasFlag(SerializerFlags.DoNotSave))
+            if (actions.All(x => x.Success) && cleanMarkers.Count > 0)
             {
-                await serializer.SaveAsync(updates.Select(x => x.Item));
+                await PerformImportCleanAsync(cleanMarkers, actions, config, options.Callbacks?.Update);
             }
 
-            await PerformSecondPassImportsAsync(updates, actions, config, options.Callbacks?.Update);
-        }
+            options.Callbacks?.Update?.Invoke("Done", 3, 3);
 
-        if (actions.All(x => x.Success) && cleanMarkers.Count > 0)
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("ImportAll: {count} items imported", actions.Count);
+
+            return actions;
+        }
+        finally
         {
-            await PerformImportCleanAsync(cleanMarkers, actions, config, options.Callbacks?.Update);
+            CleanCaches(cacheKey);
         }
-
-        CleanCaches(cacheKey);
-        options.Callbacks?.Update?.Invoke("Done", 3, 3);
-
-        if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("ImportAll: {count} items imported", actions.Count);
-
-        return actions;
     }
 
     /// <summary>
@@ -809,7 +813,19 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// Export all items to a give folder on the disk
     /// </summary>
     virtual public async Task<IEnumerable<uSyncAction>> ExportAllAsync(string[] folders, HandlerSettings settings, SyncUpdateCallback? callback)
-        => await ExportAllAsync(default, folders, settings, callback);
+    {
+        // scope the runtime cache (e.g. child-item lookups) to this export run, so the
+        // cache keys stay stable across async thread hops and are cleared when we're done.
+        var cacheKey = BeginCacheScope();
+        try
+        {
+            return await ExportAllAsync(default, folders, settings, callback);
+        }
+        finally
+        {
+            EndCacheScope(cacheKey);
+        }
+    }
 
 
     /// <summary>
@@ -1066,28 +1082,33 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         List<uSyncAction> actions = [];
 
         var cacheKey = PrepCaches();
-
-        callback?.Invoke("Calculating order", 1, 3);
-
-        var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(callback));
-        var options = new uSyncImportOptions();
-
-        int count = 0;
-
-        foreach (var item in items)
+        try
         {
-            count++;
-            callback?.Invoke(Path.GetFileNameWithoutExtension(item.Path), count, items.Count);
-            actions.AddRange(await ReportElementAsync(item.Node, item.FileName, config, options));
+            callback?.Invoke("Calculating order", 1, 3);
+
+            var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(callback));
+            var options = new uSyncImportOptions();
+
+            int count = 0;
+
+            foreach (var item in items)
+            {
+                count++;
+                callback?.Invoke(Path.GetFileNameWithoutExtension(item.Path), count, items.Count);
+                actions.AddRange(await ReportElementAsync(item.Node, item.FileName, config, options));
+            }
+
+            callback?.Invoke("Validating Report", 2, 3);
+            var validationActions = await ReportMissingParentsAsync([.. actions]);
+            actions.AddRange(ReportDeleteCheck(uSyncConfig.GetWorkingFolder(), validationActions));
+
+            callback?.Invoke($"Done ({this.ItemType})", 3, 3);
+            return actions;
         }
-
-        callback?.Invoke("Validating Report", 2, 3);
-        var validationActions = await ReportMissingParentsAsync([.. actions]);
-        actions.AddRange(ReportDeleteCheck(uSyncConfig.GetWorkingFolder(), validationActions));
-
-        CleanCaches(cacheKey);
-        callback?.Invoke($"Done ({this.ItemType})", 3, 3);
-        return actions;
+        finally
+        {
+            CleanCaches(cacheKey);
+        }
     }
 
     /// <summary>
@@ -1577,6 +1598,13 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     ///  </remarks>
     protected virtual async Task CleanUpAsync(TObject item, string newFile, string folder)
     {
+        // when using a flat folder structure with guid file names, an item's file is always
+        // "{key}.{ext}" in the same folder - it never changes name or location - so there can
+        // never be a stale duplicate file to clean up. Skip the (recursive) folder scan, which
+        // otherwise runs on every save/move/delete. (Content/Media make the same check earlier.)
+        if (DefaultConfig.UseFlatStructure && DefaultConfig.GuidNames)
+            return;
+
         var physicalFile = syncFileService.GetAbsPath(newFile);
 
         var files = syncFileService.GetFiles(folder, $"*.{this.uSyncConfig.Settings.DefaultExtension}");
@@ -1969,32 +1997,70 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
 
     /// <summary>
-    ///  get the key for any caches we might call (thread based cache value)
+    ///  per-operation cache scope id.
+    /// </summary>
+    /// <remarks>
+    ///  this flows with the async operation (via AsyncLocal) so the runtime-cache keys
+    ///  stay stable even when a continuation resumes on a different thread. Previously the
+    ///  key was based on the managed thread id, which could change mid-operation across an
+    ///  await - defeating the cache (misses) and leaving orphaned entries in the shared
+    ///  runtime cache that the end-of-operation cleanup (running on another thread) missed.
+    ///
+    ///  when no operation scope is active (ad-hoc lookups) we fall back to the managed
+    ///  thread id, preserving the previous behavior for those callers.
+    /// </remarks>
+    private readonly AsyncLocal<string?> _cacheScope = new();
+
+    /// <summary>
+    ///  get the key for any caches we might call (scoped to the current operation)
     /// </summary>
     /// <returns></returns>
     protected string GetCacheKeyBase()
-        => $"keyCache_{this.Alias}_{Environment.CurrentManagedThreadId}";
+        => $"keyCache_{this.Alias}_{_cacheScope.Value ?? $"t{Environment.CurrentManagedThreadId}"}";
 
     private string PrepCaches()
     {
         if (this.serializer is ISyncCachedSerializer cachedSerializer)
             cachedSerializer.InitializeCache();
 
-        // make sure the runtime cache is clean.
-        var key = GetCacheKeyBase();
-
-        // this also clears the folder cache - as its a starts with call.
-        runtimeCache.ClearByKey(key);
-        return key;
+        return BeginCacheScope();
     }
 
     private void CleanCaches(string cacheKey)
     {
-        runtimeCache.ClearByKey(cacheKey);
+        EndCacheScope(cacheKey);
 
         if (this.serializer is ISyncCachedSerializer cachedSerializer)
             cachedSerializer.DisposeCache();
+    }
 
+    /// <summary>
+    ///  begin a runtime-cache scope for a single logical operation (import/report/export).
+    /// </summary>
+    /// <remarks>
+    ///  the scope id flows with the async operation (see <see cref="_cacheScope"/>) so the
+    ///  cache keys stay stable across await/thread hops, and the entries can be reliably
+    ///  cleared when the operation finishes.
+    /// </remarks>
+    /// <returns>the base cache key for the scope.</returns>
+    private string BeginCacheScope()
+    {
+        _cacheScope.Value = Guid.NewGuid().ToString("N");
+
+        // this also clears the folder cache - as its a 'starts with' call.
+        var key = GetCacheKeyBase();
+        runtimeCache.ClearByKey(key);
+        return key;
+    }
+
+    /// <summary>
+    ///  end the runtime-cache scope started by <see cref="BeginCacheScope"/>, clearing the
+    ///  entries cached during the operation.
+    /// </summary>
+    private void EndCacheScope(string cacheKey)
+    {
+        runtimeCache.ClearByKey(cacheKey);
+        _cacheScope.Value = null;
     }
 
     #region roots notifications 

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -983,10 +983,9 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
                     await syncFileService.SaveXElementAsync(attempt.Item, filename);
                 }
 
-                if (config.CreateClean && await HasChildrenAsync(item))
-                {
+                if (config.CreateClean)
                     await CreateCleanFileAsync(GetItemKey(item), filename);
-                }
+
             }
             else
             {

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -697,8 +697,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         foreach (var file in files)
         {
-            var node = await syncFileService.LoadXElementAsync(file);
-            var key = node.GetKey();
+            // we only need the key here, so stream it rather than parsing the whole file.
+            var key = await syncFileService.LoadKeyFromFileAsync(file);
             if (key != Guid.Empty)
             {
                 keySet.Add(key);
@@ -719,8 +719,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
     /// </summary>
     protected async Task<TObject?> GetCleanParentAsync(string file)
     {
-        var node = await syncFileService.LoadXElementAsync(file);
-        var key = node.GetKey();
+        // we only need the key to find the parent, so stream it rather than parsing the whole file.
+        var key = await syncFileService.LoadKeyFromFileAsync(file);
         if (key == Guid.Empty) return default;
         return await GetFromServiceAsync(key);
     }

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -1962,7 +1962,7 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         return null;
     }
 
-    private class SyncChangeInfo
+    private sealed class SyncChangeInfo
     {
         public ChangeType Change { get; set; }
         public XElement? CurrentNode { get; set; }

--- a/uSync.BackOffice/Tracker/SyncTrackerNotificationHandler.cs
+++ b/uSync.BackOffice/Tracker/SyncTrackerNotificationHandler.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Core.Events;
 
 namespace uSync.BackOffice.Tracker;
 
-internal class SyncTrackerNotificationHandler
+internal sealed class SyncTrackerNotificationHandler
     : INotificationAsyncHandler<uSyncImportCompletedNotification>
 {
     private readonly ISyncTrackerService _syncTrackerService;

--- a/uSync.BackOffice/uSyncBackOffice.cs
+++ b/uSync.BackOffice/uSyncBackOffice.cs
@@ -38,7 +38,7 @@ public class uSync
         internal const string Group = "sync";
     }
 
-    internal class Sets
+    internal sealed class Sets
     {
         internal const string DefaultSet = "Default";
     }

--- a/uSync.BackOffice/uSyncBackOffice.cs
+++ b/uSync.BackOffice/uSyncBackOffice.cs
@@ -7,6 +7,9 @@ namespace uSync.BackOffice;
 /// </summary>
 public class uSync
 {
+    /// <summary>
+    ///  assembly version for uSync
+    /// </summary>
     public static Version Version => typeof(uSync).Assembly.GetName().Version ?? new Version(15, 0, 0);
 
     /// <summary>

--- a/uSync.BackOffice/uSyncBackOfficeComposer.cs
+++ b/uSync.BackOffice/uSyncBackOfficeComposer.cs
@@ -1,6 +1,12 @@
 ﻿
+using Microsoft.Extensions.Logging;
+
+using System.Linq;
+
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+
+using uSync.Core.Extensions;
 
 namespace uSync.BackOffice;
 
@@ -12,10 +18,12 @@ public class uSyncBackOfficeComposer : IComposer
     /// <inheritdoc/>
     public void Compose(IUmbracoBuilder builder)
     {
-        // the composers add uSync, but the extension methods
-        // will only add the values if uSync hasn't already 
-        // been added, so you can for example add uSync to your
-        // startup.cs file. and then the composers don't fire
-        builder.AdduSync();
+        if (builder.IsUmbracoBackOfficeEnabled() is true) {
+            // the composers add uSync, but the extension methods
+            // will only add the values if uSync hasn't already 
+            // been added, so you can for example add uSync to your
+            // startup.cs file. and then the composers don't fire
+            builder.AdduSync();
+        }
     }
 }

--- a/uSync.Backoffice.Management.Api/ApiComposer.cs
+++ b/uSync.Backoffice.Management.Api/ApiComposer.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.DependencyInjection;
 using uSync.Backoffice.Management.Api.Configuration;
 using uSync.Backoffice.Management.Api.Services;
 using uSync.BackOffice;
+using uSync.Core.Extensions;
 
 namespace uSync.Backoffice.Management.Api;
 
@@ -15,6 +16,9 @@ public class ApiComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
+        if (builder.IsUmbracoBackOfficeEnabled() is false)
+            return;
+
         builder.Services.AddSingleton<IOperationIdHandler, uSyncCustomOperationHandler>();
 
         builder.Services.ConfigureOptions<ConfigSyncApiSwaggerGenOptions>();

--- a/uSync.Backoffice.Management.Client/uSyncManifestReader.cs
+++ b/uSync.Backoffice.Management.Client/uSyncManifestReader.cs
@@ -10,6 +10,7 @@ using Umbraco.Extensions;
 
 using uSync.BackOffice.Configuration;
 using uSync.BackOffice.Extensions;
+using uSync.Core.Extensions;
 
 namespace uSync.Backoffice.Management.Client;
 
@@ -18,8 +19,12 @@ public class uSyncManifestComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
-        builder.Services.AddSingleton<IPackageManifestReader, uSyncManifestReader>();
-        builder.Services.AddSingleton<IPackageManifestReader, SyncSectionManifestReader>();
+        if (builder.IsUmbracoBackOfficeEnabled())
+        {
+            // only load this when the backoffice is enabled. 
+            builder.Services.AddSingleton<IPackageManifestReader, uSyncManifestReader>();
+            builder.Services.AddSingleton<IPackageManifestReader, SyncSectionManifestReader>();
+        }
     }
 }
 

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -3506,9 +3506,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -4747,9 +4747,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
 			"dev": true,
 			"funding": [
 				{

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.5",
+	"version": "17.3.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.5",
+			"version": "17.3.6",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.4",
+	"version": "17.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.4",
+			"version": "17.3.5",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "17.3.6",
 			"license": "MPL-2.0",
 			"devDependencies": {
-				"@hey-api/openapi-ts": "^0.95.0",
+				"@hey-api/openapi-ts": "^0.97.0",
 				"@microsoft/signalr": "^10.0.0",
 				"@umbraco-cms/backoffice": "^17.3.0",
 				"eslint": "^10.2.0",
@@ -239,64 +239,65 @@
 			}
 		},
 		"node_modules/@hey-api/codegen-core": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.7.4.tgz",
-			"integrity": "sha512-DGd9yeSQzflOWO3Y5mt1GRXkXH9O/yIMgbxPjwLI3jwu/3nAjoXXD26lEeFb6tclYlg0JAqTIs5d930G/qxHeA==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.1.tgz",
+			"integrity": "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hey-api/types": "0.1.4",
 				"ansi-colors": "4.1.3",
-				"c12": "3.3.3",
+				"c12": "3.3.4",
 				"color-support": "1.1.3"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=22.13.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/hey-api"
 			}
 		},
 		"node_modules/@hey-api/json-schema-ref-parser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.3.1.tgz",
-			"integrity": "sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
+			"integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jsdevtools/ono": "7.1.3",
 				"@types/json-schema": "7.0.15",
-				"js-yaml": "4.1.1"
+				"yaml": "2.8.3"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=22.13.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/hey-api"
 			}
 		},
 		"node_modules/@hey-api/openapi-ts": {
-			"version": "0.95.0",
-			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.95.0.tgz",
-			"integrity": "sha512-lk5C+WKl5yqEmliQihEyhX/jNcWlAykTSEqkDeKa9xSq5YDAzOFvx7oos8YTqiIzdc4TemtlEaB8Rns7+8A0qg==",
+			"version": "0.97.0",
+			"resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.0.tgz",
+			"integrity": "sha512-WZkKgrDlZpxKlDv2HkBCzaAYeuM+EtZKFmKGBv9/JblAKpX3JQTROi7PzlCZE3eisetRPSakbcRgn+LGyB7EiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@hey-api/codegen-core": "0.7.4",
-				"@hey-api/json-schema-ref-parser": "1.3.1",
-				"@hey-api/shared": "0.3.0",
-				"@hey-api/spec-types": "0.1.0",
+				"@hey-api/codegen-core": "0.8.1",
+				"@hey-api/json-schema-ref-parser": "1.4.1",
+				"@hey-api/shared": "0.4.2",
+				"@hey-api/spec-types": "0.2.0",
 				"@hey-api/types": "0.1.4",
+				"@lukeed/ms": "2.0.2",
 				"ansi-colors": "4.1.3",
 				"color-support": "1.1.3",
 				"commander": "14.0.3",
-				"get-tsconfig": "4.13.6"
+				"get-tsconfig": "4.14.0"
 			},
 			"bin": {
 				"openapi-ts": "bin/run.js"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=22.13.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/hey-api"
@@ -306,32 +307,32 @@
 			}
 		},
 		"node_modules/@hey-api/shared": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.3.0.tgz",
-			"integrity": "sha512-G+4GPojdLEh9bUwRG88teMPM1HdqMm/IsJ38cbnNxhyDu1FkFGwilkA1EqnULCzfTam/ZoZkaLdmAd8xEh4Xsw==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.2.tgz",
+			"integrity": "sha512-4fconS10E0Xr4/acV8G+BkApxaIStxrT0GhB9BDTQWvrFTy5/nV933SyFk8qImcbpKvgv9hpn3N+7bV8oFrbjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@hey-api/codegen-core": "0.7.4",
-				"@hey-api/json-schema-ref-parser": "1.3.1",
-				"@hey-api/spec-types": "0.1.0",
+				"@hey-api/codegen-core": "0.8.1",
+				"@hey-api/json-schema-ref-parser": "1.4.1",
+				"@hey-api/spec-types": "0.2.0",
 				"@hey-api/types": "0.1.4",
 				"ansi-colors": "4.1.3",
 				"cross-spawn": "7.0.6",
 				"open": "11.0.0",
-				"semver": "7.7.3"
+				"semver": "7.7.4"
 			},
 			"engines": {
-				"node": ">=20.19.0"
+				"node": ">=22.13.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/hey-api"
 			}
 		},
 		"node_modules/@hey-api/shared/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -342,9 +343,9 @@
 			}
 		},
 		"node_modules/@hey-api/spec-types": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.1.0.tgz",
-			"integrity": "sha512-StS4RrAO5pyJCBwe6uF9MAuPflkztriW+FPnVb7oEjzDYv1sxPwP+f7fL6u6D+UVrKpZ/9bPNx/xXVdkeWPU6A==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+			"integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -442,6 +443,16 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@lit-labs/ssr-dom-shim": "^1.2.0"
+			}
+		},
+		"node_modules/@lukeed/ms": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+			"integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@microsoft/api-extractor": {
@@ -2909,7 +2920,8 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -2958,24 +2970,24 @@
 			}
 		},
 		"node_modules/c12": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
-			"integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+			"integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^5.0.0",
-				"confbox": "^0.2.2",
-				"defu": "^6.1.4",
-				"dotenv": "^17.2.3",
+				"confbox": "^0.2.4",
+				"defu": "^6.1.6",
+				"dotenv": "^17.3.1",
 				"exsolve": "^1.0.8",
-				"giget": "^2.0.0",
+				"giget": "^3.2.0",
 				"jiti": "^2.6.1",
 				"ohash": "^2.0.11",
 				"pathe": "^2.0.3",
-				"perfect-debounce": "^2.0.0",
+				"perfect-debounce": "^2.1.0",
 				"pkg-types": "^2.3.0",
-				"rc9": "^2.1.2"
+				"rc9": "^3.0.1"
 			},
 			"peerDependencies": {
 				"magicast": "*"
@@ -2987,14 +2999,14 @@
 			}
 		},
 		"node_modules/c12/node_modules/pkg-types": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-			"integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"confbox": "^0.2.2",
-				"exsolve": "^1.0.7",
+				"confbox": "^0.2.4",
+				"exsolve": "^1.0.8",
 				"pathe": "^2.0.3"
 			}
 		},
@@ -3012,16 +3024,6 @@
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/citty": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"consola": "^3.2.3"
 			}
 		},
 		"node_modules/color-support": {
@@ -3060,21 +3062,11 @@
 			"license": "MIT"
 		},
 		"node_modules/confbox": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-			"integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/consola": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.18.0 || >=16.10.0"
-			}
 		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
@@ -3220,9 +3212,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.4.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-			"integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -3661,9 +3653,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.6",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3674,19 +3666,11 @@
 			}
 		},
 		"node_modules/giget": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-			"integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+			"integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"citty": "^0.1.6",
-				"consola": "^3.4.0",
-				"defu": "^6.1.4",
-				"node-fetch-native": "^1.6.6",
-				"nypm": "^0.6.0",
-				"pathe": "^2.0.3"
-			},
 			"bin": {
 				"giget": "dist/cli.mjs"
 			}
@@ -3900,19 +3884,6 @@
 			"integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -4578,38 +4549,6 @@
 				}
 			}
 		},
-		"node_modules/node-fetch-native": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/nypm": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-			"integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"citty": "^0.2.0",
-				"pathe": "^2.0.3",
-				"tinyexec": "^1.0.2"
-			},
-			"bin": {
-				"nypm": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/nypm/node_modules/citty": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-			"integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/ohash": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -5135,14 +5074,14 @@
 			"license": "MIT"
 		},
 		"node_modules/rc9": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+			"integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"defu": "^6.1.4",
-				"destr": "^2.0.3"
+				"defu": "^6.1.6",
+				"destr": "^2.0.5"
 			}
 		},
 		"node_modules/readdirp": {
@@ -5396,16 +5335,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/tinyexec": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/tinyglobby": {
@@ -5752,6 +5681,22 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -4251,10 +4251,20 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -4391,16 +4401,26 @@
 			}
 		},
 		"node_modules/markdown-it": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+			"integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1",
 				"entities": "^4.4.0",
-				"linkify-it": "^5.0.0",
+				"linkify-it": "^5.0.1",
 				"mdurl": "^2.0.0",
 				"punycode.js": "^2.3.1",
 				"uc.micro": "^2.1.0"

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.6",
+	"version": "17.3.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.6",
+			"version": "17.3.7",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.97.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -16,7 +16,7 @@
 				"lit": "^3.3.2",
 				"prettier": "^3.8.1",
 				"typescript": "^5.9.3",
-				"vite": "^8.0.5",
+				"vite": "^8.0.16",
 				"vite-plugin-dts": "^4.5.4"
 			}
 		},
@@ -71,26 +71,24 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -102,7 +100,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -520,14 +517,14 @@
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-			"integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -539,9 +536,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.122.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-			"integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -557,9 +554,9 @@
 			"peer": true
 		},
 		"node_modules/@rolldown/binding-android-arm64": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-			"integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+			"integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
 			"cpu": [
 				"arm64"
 			],
@@ -574,9 +571,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-arm64": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-			"integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+			"integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -591,9 +588,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-darwin-x64": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-			"integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+			"integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
 			"cpu": [
 				"x64"
 			],
@@ -608,9 +605,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-freebsd-x64": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-			"integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+			"integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
 			"cpu": [
 				"x64"
 			],
@@ -625,9 +622,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-			"integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+			"integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
 			"cpu": [
 				"arm"
 			],
@@ -642,13 +639,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-gnu": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-			"integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+			"integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -659,13 +659,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-arm64-musl": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-			"integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -676,13 +679,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-			"integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+			"integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -693,13 +699,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-s390x-gnu": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-			"integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -710,13 +719,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-gnu": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-			"integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+			"integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -727,13 +739,16 @@
 			}
 		},
 		"node_modules/@rolldown/binding-linux-x64-musl": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-			"integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -744,9 +759,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-openharmony-arm64": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-			"integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+			"integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
 			"cpu": [
 				"arm64"
 			],
@@ -761,9 +776,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-wasm32-wasi": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-			"integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+			"integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
 			"cpu": [
 				"wasm32"
 			],
@@ -771,16 +786,18 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@napi-rs/wasm-runtime": "^1.1.1"
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
 			},
 			"engines": {
-				"node": ">=14.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-			"integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+			"integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
 			"cpu": [
 				"arm64"
 			],
@@ -795,9 +812,9 @@
 			}
 		},
 		"node_modules/@rolldown/binding-win32-x64-msvc": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-			"integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+			"integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
 			"cpu": [
 				"x64"
 			],
@@ -812,9 +829,9 @@
 			}
 		},
 		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-			"integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1452,9 +1469,9 @@
 			}
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -4495,9 +4512,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.13",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+			"integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4747,9 +4764,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -4767,7 +4784,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5171,14 +5188,14 @@
 			}
 		},
 		"node_modules/rolldown": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-			"integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+			"integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "=0.122.0",
-				"@rolldown/pluginutils": "1.0.0-rc.12"
+				"@oxc-project/types": "=0.133.0",
+				"@rolldown/pluginutils": "^1.0.0"
 			},
 			"bin": {
 				"rolldown": "bin/cli.mjs"
@@ -5187,21 +5204,21 @@
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rolldown/binding-android-arm64": "1.0.0-rc.12",
-				"@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-				"@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-				"@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+				"@rolldown/binding-android-arm64": "1.0.3",
+				"@rolldown/binding-darwin-arm64": "1.0.3",
+				"@rolldown/binding-darwin-x64": "1.0.3",
+				"@rolldown/binding-freebsd-x64": "1.0.3",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.3",
+				"@rolldown/binding-linux-arm64-musl": "1.0.3",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-gnu": "1.0.3",
+				"@rolldown/binding-linux-x64-musl": "1.0.3",
+				"@rolldown/binding-openharmony-arm64": "1.0.3",
+				"@rolldown/binding-wasm32-wasi": "1.0.3",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.3",
+				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
 		"node_modules/rope-sequence": {
@@ -5372,14 +5389,14 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -5507,17 +5524,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-			"integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+			"version": "8.0.16",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
-				"postcss": "^8.5.8",
-				"rolldown": "1.0.0-rc.12",
-				"tinyglobby": "^0.2.15"
+				"postcss": "^8.5.15",
+				"rolldown": "1.0.3",
+				"tinyglobby": "^0.2.17"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -5533,7 +5550,7 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
-				"@vitejs/devtools": "^0.1.0",
+				"@vitejs/devtools": "^0.1.18",
 				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.2",
+	"version": "17.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.2",
+			"version": "17.3.3",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -4251,9 +4251,9 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
 			"dev": true,
 			"funding": [
 				{

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -3497,9 +3497,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -2769,9 +2769,9 @@
 			}
 		},
 		"node_modules/@vue/language-core/node_modules/brace-expansion": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2919,9 +2919,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@jumoo/usync",
-	"version": "17.3.3",
+	"version": "17.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@jumoo/usync",
-			"version": "17.3.3",
+			"version": "17.3.4",
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"@hey-api/openapi-ts": "^0.95.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -3514,9 +3514,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{

--- a/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package-lock.json
@@ -5637,9 +5637,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -55,7 +55,7 @@
 		"make": "npm run build && npm run client:make"
 	},
 	"devDependencies": {
-		"@hey-api/openapi-ts": "^0.95.0",
+		"@hey-api/openapi-ts": "^0.97.0",
 		"@microsoft/signalr": "^10.0.0",
 		"@umbraco-cms/backoffice": "^17.3.0",
 		"eslint": "^10.2.0",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.2",
+	"version": "17.3.3",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.5",
+	"version": "17.3.6",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.3",
+	"version": "17.3.4",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.6",
+	"version": "17.3.7",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -8,7 +8,7 @@
 	"homepage": "https://jumoo.co.uk/uSync",
 	"license": "MPL-2.0",
 	"type": "module",
-	"version": "17.3.4",
+	"version": "17.3.5",
 	"main": "./dist/usync.js",
 	"types": "./dist/index.d.ts",
 	"module": "./dist/usync.js",

--- a/uSync.Backoffice.Management.Client/usync-assets/package.json
+++ b/uSync.Backoffice.Management.Client/usync-assets/package.json
@@ -62,7 +62,7 @@
 		"lit": "^3.3.2",
 		"prettier": "^3.8.1",
 		"typescript": "^5.9.3",
-		"vite": "^8.0.5",
+		"vite": "^8.0.16",
 		"vite-plugin-dts": "^4.5.4"
 	}
 }

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-action-box.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-action-box.ts
@@ -63,7 +63,7 @@ export class uSyncActionBox extends UmbLitElement {
 			<uui-box class="action-box ${this.disabled ? 'disabled' : ''}">
 				<div class="box-content">
 					<h2 class="box-heading" title=${this.getLastSyncDate()}>
-						${this.group?.groupName}
+						${this.localize.termOrDefault(`uSync_group${this.group?.groupName}`, this.group?.groupName ?? '')}
 					</h2>
 					<umb-icon name=${this.group?.icon}></umb-icon>
 					<div class="box-buttons">${dropdownButtons}</div>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-progress-box.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-progress-box.ts
@@ -63,6 +63,14 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 		}, 2000);
 	}
 
+	#camelize(str: string) {
+		return str
+			.replace(/(?:^\w|[A-Z]|\b\w)/g, function (word: string, index: number) {
+				return index === 0 ? word.toLowerCase() : word.toUpperCase();
+			})
+			.replace(/\s+/g, '');
+	}
+
 	render() {
 		let actions = this.actions;
 		if (!this.actions || this.actions.length === 0) {
@@ -79,6 +87,8 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 		let actionHtml = actions?.map((action) => {
 			if (action.status == HandlerStatus.COMPLETE) progress++;
 
+			const actionName = this.#camelize(action.name ?? 'unknown');
+
 			return html`
 				<div
 					class="action 
@@ -88,7 +98,7 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 						<uui-icon .name=${action.icon ?? 'icon-box'}></uui-icon>
 						${this.renderBadge(action)}
 					</div>
-					<h4>${action.name ?? 'unknown'}</h4>
+					<h4>${this.localize.termOrDefault(`treeHeaders_${actionName}`, actionName)}</h4>
 				</div>
 			`;
 		});
@@ -107,7 +117,7 @@ export class uSyncProcessBox extends UmbElementMixin(LitElement) {
 
 		return html`
 			<uui-box>
-				<h2>${this.title}</h2>
+				<h2>${this.localize.termOrDefault(`uSync_group${this.title}`, this.title)}</h2>
 				<div class="action-list">${actionHtml}</div>
 				<div class="update-box">${this.updateMsg?.message}</div>
 				<uui-progress-bar

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-group-view.ts
@@ -42,7 +42,7 @@ export class uSyncResultGroupView extends UmbLitElement {
 				<div
 					class="summary ${when(this.expanded, () => 'expanded')}"
 					@click=${() => (this.expanded = !this.expanded)}>
-					<h4>${this.localize.term('uSync_' + this.groupName)}</h4>
+					<h4>${this.localize.termOrDefault('uSync_' + this.groupName, this.groupName)}</h4>
 					<div class="summary-right">
 						<h4 class="count">${changeCount}/${this.results?.length}</h4>
 						<uui-icon

--- a/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-view.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/components/usync-results-view.ts
@@ -117,7 +117,7 @@ export class uSyncResultsView extends UmbElementMixin(LitElement) {
 
 		return html`<div class="result-header">
 			<uui-toggle
-				.label=${this.localize.term('uSync_showAll')}
+				.label=${this.localize.termOrDefault('uSync_showAll', 'Show all items')}
 				?checked=${this.showAll}
 				@change=${this.#toggleShowAll}></uui-toggle>
 			<umb-localize .key=${localKey} .args=${[count, changes]}

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/details-modal-element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/details-modal-element.ts
@@ -86,7 +86,7 @@ export class uSyncDetailsModalElement extends UmbModalBaseElement<
 			type="button"
 			look="outline"
 			.state=${this.importState}
-			.label=${this.localize.term('uSync_importSingle')}
+			.label=${this.localize.termOrDefault('uSync_importSingle', 'Import')}
 			@click="${this.#onImport}"></uui-button>`;
 	}
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/legacy-modal-element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/legacy-modal-element.ts
@@ -30,7 +30,7 @@ export class uSyncLegacyModalElement extends UmbModalBaseElement<
 	renderLegacyFolder(folder: string | null | undefined) {
 		return folder === undefined || folder === null
 			? nothing
-			: html`${this.localize.term('uSync.legacyInfo', [folder])}`;
+			: html`${this.localize.termOrDefault('uSync.legacyInfo', 'uSync has found a legacy uSync folder', folder)}`;
 	}
 
 	renderLegacyTypes(legacyTypes: Array<string> | undefined) {
@@ -43,14 +43,12 @@ export class uSyncLegacyModalElement extends UmbModalBaseElement<
 		});
 
 		return html`<div>
-			${this.localize.term('uSync.legacyObsolete', [legacyTypeHtml])}
+			${this.localize.termOrDefault('uSync.legacyObsolete', 'Obsolete DataTypes', legacyTypeHtml)}
 		</div>`;
 	}
 
 	renderCopy() {
-		return html`${this.localize.term('uSync.legacyCopy', [
-			this.data?.legacyFolder ?? 'uSync/v15',
-		])} `;
+		return html`${this.localize.termOrDefault('uSync.legacyCopy', 'Copy to uSync folder', this.data?.legacyFolder ?? 'uSync/v15')} `;
 	}
 
 	static styles = css`

--- a/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/single-import-modal.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/dialogs/single-import-modal.element.ts
@@ -64,7 +64,7 @@ export default class SyncImportSingleModalElement extends UmbModalBaseElement<
 							color="positive"
 							type="button"
 							.state=${this.importState}
-							.label=${this.localize.term('uSync_importSingle')}
+							.label=${this.localize.termOrDefault('uSync_importSingle', 'Import')}
 							@click="${this.#doImport}"></uui-button>`,
 				)}
 			</div>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/da-dk.ts
@@ -1,0 +1,191 @@
+export default {
+	uSync: {
+		section: 'Synkronisering',
+		name: 'uSync',
+		banner: 'uSync alt på én gang',
+
+		migrate: 'Migrer',
+		defaultView: 'Standard',
+		settingsView: 'Indstillinger',
+		addons: 'Tilføjelser',
+
+		groupEverything: 'Alt',
+		groupContent: 'Indhold',
+		groupSettings: 'Indstillinger',
+		groupForms: 'Formularer',
+		groupMedia: 'Medie',
+		groupMembers: 'Medlemmer',
+
+		Report: 'Rapport',
+		Import: 'Importer',
+		Export: 'Eksporter',
+		ImportForce: 'Importer (Tvungen)',
+		ExportClean: 'Eksporter (Ren)',
+		ExportFile: 'Eksporter til fil',
+		ImportFile: 'Importer fra fil',
+
+		noChange: 'Intet har ændret sig',
+		showAll: 'Vis alle elementer',
+
+		detailHeadline: 'Registrerede ændringer',
+		detailHeader: 'Ting der er anderledes',
+
+		runningInBackground:
+			'uSync kører denne proces i baggrunden. Hvis du navigerer væk fra denne side, vil den fortsætte med at køre.',
+
+		connectionLost:
+			'Forbindelsen til serveren er gået tabt. Processen vil fortsætte med at køre i baggrunden, men du vil ikke se opdateringer her.',
+
+		importSingle: 'Importer',
+		importSingleWarning:
+			'Dette vil importere dette element til Umbraco. Hvis dette element har afhængigheder, vil de ikke blive importeret og skal løses manuelt.',
+		importSingleSuccess: 'Elementet er blevet importeret korrekt',
+		importSingleFailed: `<p>Der opstod en fejl ved import af elementet</p><strong>%0%</strong>`,
+
+		changeAction: 'Handling',
+		changeItem: 'Element',
+		changeDiffrence: 'Forskel',
+		changeCreate: 'Dette element findes ikke i Umbraco og oprettes',
+		noChangesImport: 'Der blev ikke foretaget ændringer i dette element',
+		noChangesReport: 'Ingen ændringer registreret',
+		noChangesDelete: 'Dette element er blevet slettet fra Umbraco',
+
+		importHeader: 'Importer fra fil',
+
+		success: 'Succes',
+		change: 'Ændring',
+		changeType: 'Type',
+		changeName: 'Navn',
+		changeDetail: 'Detalje',
+		changeHeading: 'Resultater',
+		changeCount: '{1}/{0} ændringer',
+		noChangeCount: '0/{0} ændringer',
+
+		legacyInfo: `<p>uSync har fundet en ældre uSync-mappe på <strong>%0%</strong>.<br />
+						Det er sandsynligt, at indholdet skal konverteres på en eller anden måde</p>`,
+
+		legacyObsolete: `<h4>Forældede datatyper</h4>
+				<ul>%0%</ul>
+				<p>Du kan konvertere disse datatyper ved hjælp af
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(I den fulde uSync-udgivelse vil konvertering ske her.)</em></p>`,
+
+		legacyCopy: `<h4>Kopiér til uSync/v14</h4>
+					<p>Du kan kopiere din %0%-mappe til ~/uSync/v14-mappen<br />og køre en import.</p>
+					<p>Hvis intet skal konverteres, bør alt importeres korrekt.</p>
+					<p><strong>Fjern eller omdøb %0%-mappen for at forhindre denne popup</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-uoverensstemmelse <uui-icon name="alert"></uui-icon></h4>
+			<p>Det ser ud til, at indstillingen <code>Imaging:HMAC</code>, der bruges til at generere filerne i uSync-mappen, ikke stemmer overens med den aktuelle indstilling for dette websted.</p>
+			<p>Billeder i RTE-kontrolelementer vil have HMAC-værdien tilføjet til URL-værdien, og uden yderligere konfiguration vises disse billeder muligvis ikke korrekt.</p>
+			<ul><li>Du kan aktivere "HMAC-mapping" i uSync,</li>
+			<li>eller du kan sikre, at HMAC-værdien i indstillingen <code>Imaging:HMAC</code> stemmer overens med den værdi, der bruges til at generere filerne i uSync-mappen</li></ul>`,
+		formatMismatch:
+			'Synkroniseringsfilformatversionen stemmer ikke overens med den forventede version. Dette kan indikere et potentielt kompatibilitetsproblem.',
+
+		legacyBanner:
+			'Dette websted indeholder filer fra en tidligere version af uSync. Se detaljerne under fanen Ældre.',
+
+		legacyCopyTitle: 'Overskriv v%0%-filer',
+		legacyCopyContent:
+			'Er du sikker på, at du vil overskrive indholdet af mappen %0% med de ældre uSync-mappefilerne?',
+
+		legacyIgnoreTitle: 'Ignorer ældre filer',
+		legacyIgnoreContent:
+			'Er du sikker på, at du vil ignorere filerne i den ældre uSync-mappe?',
+
+		errorHeader:
+			'Dette element stødte på en fejl under processen. Detaljerne er nedenfor:',
+
+		uploadIntro: 'Vælg en zip-fil med uSync-filer, som du vil uploade',
+		uploadSuccess: 'Filerne er blevet uploadet og udtrukket til uSync-mappen',
+		uploadError: 'Der opstod en fejl ved upload af filerne',
+
+		ILanguage: 'Sprog',
+		IDictionaryItem: 'Ordbogselementer',
+		IDataType: 'Datatyper',
+		ITemplate: 'Skabeloner',
+		IContentType: 'Indholdstyper',
+		IMediaType: 'Medietyper',
+		IMemberType: 'Medlemstyper',
+		IContent: 'Indhold',
+		IMedia: 'Medie',
+		IDomain: 'Domæner',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Relationstyper',
+		MediaFile: 'Mediefiler',
+		XElement: 'Andet',
+		LanguageHandler: 'Sprog',
+		DictionaryHandler: 'Ordbogselementer',
+		DataTypeHandler: 'Datatyper',
+		TemplateHandler: 'Skabeloner',
+		ContentTypeHandler: 'Indholdstyper',
+		MediaTypeHandler: 'Medietyper',
+		MemberTypeHandler: 'Medlemstyper',
+		ContentHandler: 'Indhold',
+		MediaHandler: 'Medie',
+		RelationTypeHandler: 'Relationstyper',
+		EntityContainer: 'Containere',
+	},
+	USyncSettings: {
+		settings: 'uSync-indstillinger',
+		filesAndFolders: 'Filer og mapper',
+		handlerDefaults: 'Handlerstandarder',
+
+		processingMode: 'Behandlingstilstand',
+		processingModeDesc:
+			'Hvordan uSync-processen kører, enten i baggrunden eller interaktivt (Normal)',
+
+		importAtStartup: 'Importer ved opstart',
+		importAtStartupDesc: 'Kør en import af filer fra disken, når Umbraco starter',
+
+		exportAtStartup: 'Eksporter ved opstart',
+		exportAtStartupDesc: 'Eksporter Umbraco-indstillingerne, når webstedet starter',
+
+		exportOnSave: 'Eksporter ved gem',
+		exportOnSaveDesc: 'Generer uSync-filer, når elementer gemmes',
+
+		uiEnabledGroups: 'Aktiverede UI-grupper',
+		uiEnabledGroupsDesc: 'Handlergrupper, der kan ses/bruges på dashboardet',
+
+		failOnMissingParent: 'Fejl ved manglende overordnet',
+		failOnMissingParentDesc: 'Fejl ved manglende overordnet element',
+
+		currentHandlerSet: 'Aktuelt sæt',
+
+		handlerSet: 'Standardhandlersæt',
+		handlerSetDesc: 'Det standardhandlersæt, der bruges for webstedet',
+
+		flatStructure: 'Flad struktur',
+		flatStructureDesc: 'Alle elementer af en type gemmes i en flad mappestruktur',
+
+		guidNames: 'Brug GUID som filnavne',
+		guidNamesDesc: 'Brug et elements GUID som filnavn',
+
+		handlerGroups: 'Handlergrupper',
+		handlerGroupsDesc: 'Grupper til at begrænse handlersættet til',
+
+		disabledHandlers: 'Deaktiverede handlere',
+		disabledHandlersDesc: 'Handlere eksplicit deaktiveret for dette handlersæt',
+
+		folders: 'Mapper',
+		foldersDesc:
+			'Mapper uSync vil søge efter filer i (elementer gemmes normalt i den sidste mappe på listen)',
+
+		rootSite: 'Rodwebsted',
+		rootSiteDesc: 'Er dette websted en rod for andre websteder.',
+
+		rootLocked: 'Rod låst',
+		rootLockedDesc: 'Er ændringer for elementer fra rodwebstedet låst?',
+
+		help: 'Indstillinger styres via filen appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Se vores dokumentation</a>',
+
+		bootSettings: 'Indstillinger for første opstart 🥾',
+
+		firstBoot: 'Importer ved første opstart',
+		firstBootDesc: 'Kør importprocessen ved webstedets første opstart',
+
+		firstBootGroup: 'Grupper for første opstart',
+		firstBootGroupDesc: 'De grupper, der køres ved første opstart',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/de-de.ts
@@ -1,0 +1,191 @@
+export default {
+	uSync: {
+		section: 'Synchronisation',
+		name: 'uSync',
+		banner: 'uSync für alles',
+
+		migrate: 'Migrieren',
+		defaultView: 'Standard',
+		settingsView: 'Einstellungen',
+		addons: 'Erweiterungen',
+
+		groupEverything: 'Alles',
+		groupContent: 'Inhalt',
+		groupSettings: 'Einstellungen',
+		groupForms: 'Formulare',
+		groupMedia: 'Medien',
+		groupMembers: 'Mitglieder',
+
+		Report: 'Bericht',
+		Import: 'Importieren',
+		Export: 'Exportieren',
+		ImportForce: 'Importieren (Erzwingen)',
+		ExportClean: 'Exportieren (Bereinigt)',
+		ExportFile: 'In Datei exportieren',
+		ImportFile: 'Aus Datei importieren',
+
+		noChange: 'Es hat sich nichts geändert',
+		showAll: 'Alle Elemente anzeigen',
+
+		detailHeadline: 'Erkannte Änderungen',
+		detailHeader: 'Was sich unterscheidet',
+
+		runningInBackground:
+			'uSync führt diesen Prozess im Hintergrund aus. Wenn Sie diese Seite verlassen, wird er weiterhin ausgeführt.',
+
+		connectionLost:
+			'Die Verbindung zum Server wurde unterbrochen. Der Prozess wird im Hintergrund weiter ausgeführt, aber Sie werden hier keine Aktualisierungen sehen.',
+
+		importSingle: 'Importieren',
+		importSingleWarning:
+			'Dadurch wird dieses Element in Umbraco importiert. Wenn dieses Element Abhängigkeiten hat, werden diese nicht importiert und müssen manuell aufgelöst werden.',
+		importSingleSuccess: 'Das Element wurde erfolgreich importiert',
+		importSingleFailed: `<p>Beim Importieren des Elements ist ein Fehler aufgetreten</p><strong>%0%</strong>`,
+
+		changeAction: 'Aktion',
+		changeItem: 'Element',
+		changeDiffrence: 'Unterschied',
+		changeCreate: 'Dieses Element existiert nicht in Umbraco und wird erstellt',
+		noChangesImport: 'Es wurden keine Änderungen an diesem Element vorgenommen',
+		noChangesReport: 'Keine Änderungen erkannt',
+		noChangesDelete: 'Dieses Element wurde aus Umbraco gelöscht',
+
+		importHeader: 'Aus Datei importieren',
+
+		success: 'Erfolg',
+		change: 'Änderung',
+		changeType: 'Typ',
+		changeName: 'Name',
+		changeDetail: 'Detail',
+		changeHeading: 'Ergebnisse',
+		changeCount: '{1}/{0} Änderungen',
+		noChangeCount: '0/{0} Änderungen',
+
+		legacyInfo: `<p>uSync hat einen Legacy-uSync-Ordner unter <strong>%0%</strong> gefunden.<br />
+						Der Inhalt muss wahrscheinlich konvertiert werden</p>`,
+
+		legacyObsolete: `<h4>Veraltete Datentypen</h4>
+				<ul>%0%</ul>
+				<p>Sie können diese Datentypen mit
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a> konvertieren<br />
+					<em>(In der vollständigen uSync-Version wird die Konvertierung hier stattfinden.)</em></p>`,
+
+		legacyCopy: `<h4>Nach uSync/v14 kopieren</h4>
+					<p>Sie können Ihren %0%-Ordner in den ~/uSync/v14-Ordner kopieren<br />und einen Import ausführen.</p>
+					<p>Wenn nichts konvertiert werden muss, sollte alles korrekt importiert werden.</p>
+					<p><strong>Entfernen oder benennen Sie den %0%-Ordner um, um dieses Popup zu verhindern</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-Abweichung <uui-icon name="alert"></uui-icon></h4>
+			<p>Es scheint, dass die <code>Imaging:HMAC</code>-Einstellung, die zum Generieren der Dateien im uSync-Ordner verwendet wurde, nicht mit der aktuellen Einstellung dieser Website übereinstimmt.</p>
+			<p>Bilder in RTE-Steuerelementen haben den HMAC-Wert an die URL angehängt. Ohne zusätzliche Konfiguration werden diese Bilder möglicherweise nicht korrekt dargestellt.</p>
+			<ul><li>Sie können die "HMAC-Zuordnung" in uSync aktivieren,</li>
+			<li>oder Sie können sicherstellen, dass der HMAC-Wert in der <code>Imaging:HMAC</code>-Einstellung mit dem Wert übereinstimmt, der zum Generieren der Dateien im uSync-Ordner verwendet wurde</li></ul>`,
+		formatMismatch:
+			'Die Formatversion der Synchronisierungsdatei stimmt nicht mit der erwarteten Version überein. Dies kann auf ein potenzielles Kompatibilitätsproblem hinweisen.',
+
+		legacyBanner:
+			'Diese Website enthält Dateien einer früheren Version von uSync. Details finden Sie auf der Registerkarte Legacy.',
+
+		legacyCopyTitle: 'v%0%-Dateien überschreiben',
+		legacyCopyContent:
+			'Möchten Sie den Inhalt des Ordners %0% wirklich mit den Legacy-uSync-Ordnerdateien überschreiben?',
+
+		legacyIgnoreTitle: 'Legacy-Dateien ignorieren',
+		legacyIgnoreContent:
+			'Möchten Sie die Dateien im Legacy-uSync-Ordner wirklich ignorieren?',
+
+		errorHeader:
+			'Bei diesem Element ist während des Prozesses ein Fehler aufgetreten. Die Details sind unten aufgeführt:',
+
+		uploadIntro: 'Wählen Sie eine ZIP-Datei mit uSync-Dateien aus, die Sie hochladen möchten',
+		uploadSuccess: 'Die Dateien wurden hochgeladen und in den uSync-Ordner extrahiert',
+		uploadError: 'Beim Hochladen der Dateien ist ein Fehler aufgetreten',
+
+		ILanguage: 'Sprache',
+		IDictionaryItem: 'Wörterbuchelemente',
+		IDataType: 'Datentypen',
+		ITemplate: 'Vorlagen',
+		IContentType: 'Inhaltstypen',
+		IMediaType: 'Medientypen',
+		IMemberType: 'Mitgliedstypen',
+		IContent: 'Inhalt',
+		IMedia: 'Medien',
+		IDomain: 'Domänen',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Beziehungstypen',
+		MediaFile: 'Mediendateien',
+		XElement: 'Sonstiges',
+		LanguageHandler: 'Sprachen',
+		DictionaryHandler: 'Wörterbuchelemente',
+		DataTypeHandler: 'Datentypen',
+		TemplateHandler: 'Vorlagen',
+		ContentTypeHandler: 'Inhaltstypen',
+		MediaTypeHandler: 'Medientypen',
+		MemberTypeHandler: 'Mitgliedstypen',
+		ContentHandler: 'Inhalt',
+		MediaHandler: 'Medien',
+		RelationTypeHandler: 'Beziehungstypen',
+		EntityContainer: 'Container',
+	},
+	USyncSettings: {
+		settings: 'uSync-Einstellungen',
+		filesAndFolders: 'Dateien und Ordner',
+		handlerDefaults: 'Handler-Standardwerte',
+
+		processingMode: 'Verarbeitungsmodus',
+		processingModeDesc:
+			'Wie der uSync-Prozess ausgeführt wird, entweder im Hintergrund oder interaktiv (Normal)',
+
+		importAtStartup: 'Beim Start importieren',
+		importAtStartupDesc: 'Einen Import von Dateien von der Festplatte beim Start von Umbraco ausführen',
+
+		exportAtStartup: 'Beim Start exportieren',
+		exportAtStartupDesc: 'Die Umbraco-Einstellungen beim Start der Website exportieren',
+
+		exportOnSave: 'Beim Speichern exportieren',
+		exportOnSaveDesc: 'uSync-Dateien generieren, wenn Elemente gespeichert werden',
+
+		uiEnabledGroups: 'UI-aktivierte Gruppen',
+		uiEnabledGroupsDesc: 'Handler-Gruppen, die im Dashboard angezeigt/verwendet werden können',
+
+		failOnMissingParent: 'Fehler bei fehlendem Elternelement',
+		failOnMissingParentDesc: 'Fehler bei fehlendem Elternelement',
+
+		currentHandlerSet: 'Aktuelles Set',
+
+		handlerSet: 'Standard-Handler-Set',
+		handlerSetDesc: 'Das Standard-Handler-Set für die Website',
+
+		flatStructure: 'Flache Struktur',
+		flatStructureDesc: 'Alle Elemente eines Typs werden in einer flachen Ordnerstruktur gespeichert',
+
+		guidNames: 'GUIDs als Dateinamen verwenden',
+		guidNamesDesc: 'Die GUID eines Elements als Dateiname verwenden',
+
+		handlerGroups: 'Handler-Gruppen',
+		handlerGroupsDesc: 'Gruppen zur Einschränkung des Handler-Sets',
+
+		disabledHandlers: 'Deaktivierte Handler',
+		disabledHandlersDesc: 'Handler, die für dieses Handler-Set explizit deaktiviert sind',
+
+		folders: 'Ordner',
+		foldersDesc:
+			'Ordner, in denen uSync nach Dateien sucht (Elemente werden normalerweise im letzten Ordner der Liste gespeichert)',
+
+		rootSite: 'Root-Website',
+		rootSiteDesc: 'Ist diese Website ein Root für andere Websites.',
+
+		rootLocked: 'Root gesperrt',
+		rootLockedDesc: 'Sind Änderungen an Elementen der Root-Website gesperrt?',
+
+		help: 'Die Einstellungen werden über die Datei appsettings.json gesteuert. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Siehe unsere Dokumentation</a>',
+
+		bootSettings: 'Einstellungen für den ersten Start 🥾',
+
+		firstBoot: 'Beim ersten Start importieren',
+		firstBootDesc: 'Den Importprozess beim ersten Start der Website ausführen',
+
+		firstBootGroup: 'Gruppen für den ersten Start',
+		firstBootGroupDesc: 'Die Gruppen, die beim ersten Start ausgeführt werden',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/en-us.ts
@@ -4,6 +4,18 @@ export default {
 		name: 'uSync',
 		banner: 'uSync all the things',
 
+		migrate: 'Migrate',
+		defaultView: 'Default',
+		settingsView: 'Settings',
+		addons: 'Add-ons',
+
+		groupEverything: 'Everything',
+		groupContent: 'Content',
+		groupSettings: 'Settings',
+		groupForms: 'Forms',
+		groupMedia: 'Media',
+		groupMembers: 'Members',
+
 		Report: 'Report',
 		Import: 'Import',
 		Export: 'Export',

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/es-es.ts
@@ -1,0 +1,191 @@
+export default {
+	uSync: {
+		section: 'Sincronización',
+		name: 'uSync',
+		banner: 'uSync para todo',
+
+		migrate: 'Migrar',
+		defaultView: 'Predeterminado',
+		settingsView: 'Configuración',
+		addons: 'Complementos',
+
+		groupEverything: 'Todo',
+		groupContent: 'Contenido',
+		groupSettings: 'Configuración',
+		groupForms: 'Formularios',
+		groupMedia: 'Medios',
+		groupMembers: 'Miembros',
+
+		Report: 'Informe',
+		Import: 'Importar',
+		Export: 'Exportar',
+		ImportForce: 'Importar (Forzar)',
+		ExportClean: 'Exportar (Limpio)',
+		ExportFile: 'Exportar a archivo',
+		ImportFile: 'Importar desde archivo',
+
+		noChange: 'Nada ha cambiado',
+		showAll: 'Mostrar todos los elementos',
+
+		detailHeadline: 'Cambios detectados',
+		detailHeader: 'Cosas que son diferentes',
+
+		runningInBackground:
+			'uSync está ejecutando este proceso en segundo plano. Si navega fuera de esta página, continuará ejecutándose.',
+
+		connectionLost:
+			'Se ha perdido la conexión con el servidor. El proceso continuará ejecutándose en segundo plano, pero no verá actualizaciones aquí.',
+
+		importSingle: 'Importar',
+		importSingleWarning:
+			'Esto importará este elemento en Umbraco. Si este elemento tiene dependencias, no serán importadas y deberán resolverse manualmente.',
+		importSingleSuccess: 'El elemento se ha importado correctamente',
+		importSingleFailed: `<p>Se produjo un error al importar el elemento</p><strong>%0%</strong>`,
+
+		changeAction: 'Acción',
+		changeItem: 'Elemento',
+		changeDiffrence: 'Diferencia',
+		changeCreate: 'Este elemento no existe en Umbraco y está siendo creado',
+		noChangesImport: 'No se realizaron cambios en este elemento',
+		noChangesReport: 'No se detectaron cambios',
+		noChangesDelete: 'Este elemento ha sido eliminado de Umbraco',
+
+		importHeader: 'Importar desde archivo',
+
+		success: 'Éxito',
+		change: 'Cambio',
+		changeType: 'Tipo',
+		changeName: 'Nombre',
+		changeDetail: 'Detalle',
+		changeHeading: 'Resultados',
+		changeCount: '{1}/{0} cambios',
+		noChangeCount: '0/{0} cambios',
+
+		legacyInfo: `<p>uSync ha encontrado una carpeta uSync heredada en <strong>%0%</strong>.<br />
+						Es probable que su contenido necesite convertirse de alguna manera</p>`,
+
+		legacyObsolete: `<h4>Tipos de datos obsoletos</h4>
+				<ul>%0%</ul>
+				<p>Puede convertir estos tipos de datos usando
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(En la versión completa de uSync, la conversión se realizará aquí.)</em></p>`,
+
+		legacyCopy: `<h4>Copiar a uSync/v14</h4>
+					<p>Puede copiar su carpeta %0% a la carpeta ~/uSync/v14<br />y ejecutar una importación.</p>
+					<p>Si nada necesita convertirse, todo debería importarse correctamente.</p>
+					<p><strong>Elimine o cambie el nombre de la carpeta %0% para evitar este popup</strong></p>`,
+
+		hmacMismatch: `<h4>Discrepancia HMAC <uui-icon name="alert"></uui-icon></h4>
+			<p>Parece que la configuración <code>Imaging:HMAC</code> utilizada para generar los archivos en la carpeta uSync no coincide con la configuración actual de este sitio.</p>
+			<p>Las imágenes dentro de los controles RTE tendrán el valor HMAC añadido a la URL, y sin configuración adicional, estas imágenes pueden no mostrarse correctamente.</p>
+			<ul><li>Puede activar el "mapeo HMAC" en uSync,</li>
+			<li>o puede asegurarse de que el valor HMAC en la configuración <code>Imaging:HMAC</code> coincida con el valor utilizado para generar los archivos en la carpeta uSync</li></ul>`,
+		formatMismatch:
+			'La versión del formato del archivo de sincronización no coincide con la versión esperada. Esto puede indicar un posible problema de compatibilidad.',
+
+		legacyBanner:
+			'Este sitio contiene archivos de una versión anterior de uSync. Consulte los detalles en la pestaña Heredado.',
+
+		legacyCopyTitle: 'Sobrescribir archivos v%0%',
+		legacyCopyContent:
+			'¿Está seguro de que desea sobrescribir el contenido de la carpeta %0% con los archivos de la carpeta uSync heredada?',
+
+		legacyIgnoreTitle: 'Ignorar archivos heredados',
+		legacyIgnoreContent:
+			'¿Está seguro de que desea ignorar los archivos en la carpeta uSync heredada?',
+
+		errorHeader:
+			'Este elemento encontró un error durante el proceso. Los detalles se muestran a continuación:',
+
+		uploadIntro: 'Seleccione un archivo zip que contenga los archivos uSync que desea cargar',
+		uploadSuccess: 'Los archivos han sido cargados y extraídos en la carpeta uSync',
+		uploadError: 'Se produjo un error al cargar los archivos',
+
+		ILanguage: 'Idioma',
+		IDictionaryItem: 'Elementos del diccionario',
+		IDataType: 'Tipos de datos',
+		ITemplate: 'Plantillas',
+		IContentType: 'Tipos de contenido',
+		IMediaType: 'Tipos de medios',
+		IMemberType: 'Tipos de miembros',
+		IContent: 'Contenido',
+		IMedia: 'Medios',
+		IDomain: 'Dominios',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Tipos de relaciones',
+		MediaFile: 'Archivos de medios',
+		XElement: 'Otro',
+		LanguageHandler: 'Idiomas',
+		DictionaryHandler: 'Elementos del diccionario',
+		DataTypeHandler: 'Tipos de datos',
+		TemplateHandler: 'Plantillas',
+		ContentTypeHandler: 'Tipos de contenido',
+		MediaTypeHandler: 'Tipos de medios',
+		MemberTypeHandler: 'Tipos de miembros',
+		ContentHandler: 'Contenido',
+		MediaHandler: 'Medios',
+		RelationTypeHandler: 'Tipos de relaciones',
+		EntityContainer: 'Contenedores',
+	},
+	USyncSettings: {
+		settings: 'Configuración de uSync',
+		filesAndFolders: 'Archivos y carpetas',
+		handlerDefaults: 'Valores predeterminados del controlador',
+
+		processingMode: 'Modo de procesamiento',
+		processingModeDesc:
+			'Cómo se ejecuta el proceso uSync, ya sea en segundo plano o de forma interactiva (Normal)',
+
+		importAtStartup: 'Importar al inicio',
+		importAtStartupDesc: 'Ejecutar una importación de archivos desde el disco cuando Umbraco se inicia',
+
+		exportAtStartup: 'Exportar al inicio',
+		exportAtStartupDesc: 'Exportar la configuración de Umbraco cuando el sitio se inicia',
+
+		exportOnSave: 'Exportar al guardar',
+		exportOnSaveDesc: 'Generar archivos uSync cuando se guardan elementos',
+
+		uiEnabledGroups: 'Grupos habilitados en la interfaz',
+		uiEnabledGroupsDesc: 'Grupos de controladores que se pueden ver/usar en el panel',
+
+		failOnMissingParent: 'Error si falta el padre',
+		failOnMissingParentDesc: 'Error si falta el elemento padre',
+
+		currentHandlerSet: 'Conjunto actual',
+
+		handlerSet: 'Conjunto de controladores predeterminado',
+		handlerSetDesc: 'El conjunto de controladores predeterminado a usar para el sitio',
+
+		flatStructure: 'Estructura plana',
+		flatStructureDesc: 'Todos los elementos de un tipo se almacenan en una estructura de carpetas plana',
+
+		guidNames: 'Usar GUID como nombres de archivo',
+		guidNamesDesc: 'Usar el GUID de un elemento como nombre de archivo',
+
+		handlerGroups: 'Grupos de controladores',
+		handlerGroupsDesc: 'Grupos para limitar el conjunto de controladores',
+
+		disabledHandlers: 'Controladores deshabilitados',
+		disabledHandlersDesc: 'Controladores explícitamente deshabilitados para este conjunto de controladores',
+
+		folders: 'Carpetas',
+		foldersDesc:
+			'Carpetas donde uSync buscará archivos (los elementos normalmente se guardan en la última carpeta de la lista)',
+
+		rootSite: 'Sitio raíz',
+		rootSiteDesc: 'Este sitio es una raíz para otros sitios.',
+
+		rootLocked: 'Raíz bloqueada',
+		rootLockedDesc: '¿Están bloqueados los cambios de los elementos que provienen del sitio raíz?',
+
+		help: 'La configuración se controla mediante el archivo appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Ver nuestra documentación</a>',
+
+		bootSettings: 'Configuración del primer arranque 🥾',
+
+		firstBoot: 'Importar en el primer arranque',
+		firstBootDesc: 'Ejecutar el proceso de importación en el primer arranque del sitio',
+
+		firstBootGroup: 'Grupos del primer arranque',
+		firstBootGroupDesc: 'Los grupos a ejecutar en el primer arranque',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/fr-fr.ts
@@ -1,0 +1,191 @@
+export default {
+	uSync: {
+		section: 'Synchronisation',
+		name: 'uSync',
+		banner: 'uSync pour tout synchroniser',
+
+		migrate: 'Migrer',
+		defaultView: 'Défaut',
+		settingsView: 'Paramètres',
+		addons: 'Extensions',
+
+		groupEverything: 'Tout',
+		groupContent: 'Contenu',
+		groupSettings: 'Paramètres',
+		groupForms: 'Formulaires',
+		groupMedia: 'Médias',
+		groupMembers: 'Membres',
+
+		Report: 'Rapport',
+		Import: 'Importer',
+		Export: 'Exporter',
+		ImportForce: 'Importer (Forcer)',
+		ExportClean: 'Exporter (Propre)',
+		ExportFile: 'Exporter vers fichier',
+		ImportFile: 'Importer depuis fichier',
+
+		noChange: 'Rien n\'a changé',
+		showAll: 'Afficher tous les éléments',
+
+		detailHeadline: 'Modifications détectées',
+		detailHeader: 'Ce qui est différent',
+
+		runningInBackground:
+			'uSync exécute ce processus en arrière-plan. Si vous quittez cette page, il continuera de fonctionner.',
+
+		connectionLost:
+			'La connexion au serveur a été perdue. Le processus continuera de s\'exécuter en arrière-plan, mais vous ne verrez pas les mises à jour ici.',
+
+		importSingle: 'Importer',
+		importSingleWarning:
+			'Cela importera cet élément dans Umbraco. Si cet élément a des dépendances, elles ne seront pas importées et devront être résolues manuellement.',
+		importSingleSuccess: 'L\'élément a été importé avec succès',
+		importSingleFailed: `<p>Une erreur s'est produite lors de l'importation de l'élément</p><strong>%0%</strong>`,
+
+		changeAction: 'Action',
+		changeItem: 'Élément',
+		changeDiffrence: 'Différence',
+		changeCreate: 'Cet élément n\'existe pas dans Umbraco et est en cours de création',
+		noChangesImport: 'Aucune modification n\'a été apportée à cet élément',
+		noChangesReport: 'Aucune modification détectée',
+		noChangesDelete: 'Cet élément a été supprimé d\'Umbraco',
+
+		importHeader: 'Importer depuis un fichier',
+
+		success: 'Succès',
+		change: 'Modification',
+		changeType: 'Type',
+		changeName: 'Nom',
+		changeDetail: 'Détail',
+		changeHeading: 'Résultats',
+		changeCount: '{1}/{0} modifications',
+		noChangeCount: '0/{0} modifications',
+
+		legacyInfo: `<p>uSync a trouvé un dossier uSync hérité à <strong>%0%</strong>.<br />
+						Il est probable que son contenu devra être converti d'une façon ou d'une autre</p>`,
+
+		legacyObsolete: `<h4>Types de données obsolètes</h4>
+				<ul>%0%</ul>
+				<p>Vous pouvez convertir ces types de données en utilisant
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(Dans la version complète d'uSync, la conversion se fera ici.)</em></p>`,
+
+		legacyCopy: `<h4>Copier vers uSync/v14</h4>
+					<p>Vous pouvez copier votre dossier %0% vers le dossier ~/uSync/v14<br />et exécuter une importation.</p>
+					<p>Si rien ne nécessite de conversion, tout devrait s'importer correctement.</p>
+					<p><strong>Supprimez ou renommez le dossier %0% pour éviter cette popup</strong></p>`,
+
+		hmacMismatch: `<h4>Incompatibilité HMAC <uui-icon name="alert"></uui-icon></h4>
+			<p>Il semble que le paramètre <code>Imaging:HMAC</code> utilisé pour générer les fichiers dans le dossier uSync ne corresponde pas au paramètre actuel de ce site.</p>
+			<p>Les images dans les contrôles RTE auront la valeur HMAC ajoutée à l'URL, et sans configuration supplémentaire, ces images pourraient ne pas s'afficher correctement.</p>
+			<ul><li>Vous pouvez activer le "mappage HMAC" dans uSync,</li>
+			<li>ou vous pouvez vous assurer que la valeur HMAC dans le paramètre <code>Imaging:HMAC</code> correspond à la valeur utilisée pour générer les fichiers dans le dossier uSync</li></ul>`,
+		formatMismatch:
+			'La version du format du fichier de synchronisation ne correspond pas à la version attendue. Cela peut indiquer un problème de compatibilité potentiel.',
+
+		legacyBanner:
+			'Ce site contient des fichiers d\'une version précédente d\'uSync. Consultez les détails dans l\'onglet Héritage.',
+
+		legacyCopyTitle: 'Écraser les fichiers v%0%',
+		legacyCopyContent:
+			'Êtes-vous sûr de vouloir écraser le contenu du dossier %0% avec les fichiers du dossier uSync hérité ?',
+
+		legacyIgnoreTitle: 'Ignorer les fichiers hérités',
+		legacyIgnoreContent:
+			'Êtes-vous sûr de vouloir ignorer les fichiers dans le dossier uSync hérité ?',
+
+		errorHeader:
+			'Cet élément a rencontré une erreur lors du processus. Les détails sont ci-dessous :',
+
+		uploadIntro: 'Sélectionnez un fichier zip contenant les fichiers uSync que vous souhaitez télécharger',
+		uploadSuccess: 'Les fichiers ont été téléchargés et extraits dans le dossier uSync',
+		uploadError: 'Une erreur s\'est produite lors du téléchargement des fichiers',
+
+		ILanguage: 'Langue',
+		IDictionaryItem: 'Éléments du dictionnaire',
+		IDataType: 'Types de données',
+		ITemplate: 'Modèles',
+		IContentType: 'Types de contenu',
+		IMediaType: 'Types de médias',
+		IMemberType: 'Types de membres',
+		IContent: 'Contenu',
+		IMedia: 'Média',
+		IDomain: 'Domaines',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Types de relations',
+		MediaFile: 'Fichiers médias',
+		XElement: 'Autre',
+		LanguageHandler: 'Langues',
+		DictionaryHandler: 'Éléments du dictionnaire',
+		DataTypeHandler: 'Types de données',
+		TemplateHandler: 'Modèles',
+		ContentTypeHandler: 'Types de contenu',
+		MediaTypeHandler: 'Types de médias',
+		MemberTypeHandler: 'Types de membres',
+		ContentHandler: 'Contenu',
+		MediaHandler: 'Média',
+		RelationTypeHandler: 'Types de relations',
+		EntityContainer: 'Conteneurs',
+	},
+	USyncSettings: {
+		settings: 'Paramètres uSync',
+		filesAndFolders: 'Fichiers et dossiers',
+		handlerDefaults: 'Paramètres par défaut des gestionnaires',
+
+		processingMode: 'Mode de traitement',
+		processingModeDesc:
+			'Comment le processus uSync s\'exécute, soit en arrière-plan, soit de manière interactive (Normal)',
+
+		importAtStartup: 'Importer au démarrage',
+		importAtStartupDesc: 'Exécuter une importation de fichiers depuis le disque au démarrage d\'Umbraco',
+
+		exportAtStartup: 'Exporter au démarrage',
+		exportAtStartupDesc: 'Exporter les paramètres Umbraco au démarrage du site',
+
+		exportOnSave: 'Exporter à l\'enregistrement',
+		exportOnSaveDesc: 'Générer des fichiers uSync lors de l\'enregistrement des éléments',
+
+		uiEnabledGroups: 'Groupes activés dans l\'interface',
+		uiEnabledGroupsDesc: 'Groupes de gestionnaires visibles/utilisables sur le tableau de bord',
+
+		failOnMissingParent: 'Échec si parent manquant',
+		failOnMissingParentDesc: 'Échec si l\'élément parent est manquant',
+
+		currentHandlerSet: 'Ensemble actuel',
+
+		handlerSet: 'Ensemble de gestionnaires par défaut',
+		handlerSetDesc: 'L\'ensemble de gestionnaires par défaut à utiliser pour le site',
+
+		flatStructure: 'Structure plate',
+		flatStructureDesc: 'Tous les éléments d\'un type sont stockés dans une structure de dossiers plate',
+
+		guidNames: 'Utiliser les GUID comme noms de fichiers',
+		guidNamesDesc: 'Utiliser le GUID d\'un élément comme nom de fichier',
+
+		handlerGroups: 'Groupes de gestionnaires',
+		handlerGroupsDesc: 'Groupes pour limiter l\'ensemble de gestionnaires',
+
+		disabledHandlers: 'Gestionnaires désactivés',
+		disabledHandlersDesc: 'Gestionnaires explicitement désactivés pour cet ensemble de gestionnaires',
+
+		folders: 'Dossiers',
+		foldersDesc:
+			'Dossiers dans lesquels uSync recherchera des fichiers (les éléments sont normalement enregistrés dans le dernier dossier de la liste)',
+
+		rootSite: 'Site racine',
+		rootSiteDesc: 'Ce site est-il une racine pour d\'autres sites.',
+
+		rootLocked: 'Racine verrouillée',
+		rootLockedDesc: 'Les modifications des éléments provenant du site racine sont-elles verrouillées ?',
+
+		help: 'Les paramètres sont contrôlés via le fichier appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Voir notre documentation</a>',
+
+		bootSettings: 'Paramètres du premier démarrage 🥾',
+
+		firstBoot: 'Importer au premier démarrage',
+		firstBootDesc: 'Exécuter le processus d\'importation au premier démarrage du site',
+
+		firstBootGroup: 'Groupes du premier démarrage',
+		firstBootGroupDesc: 'Les groupes à exécuter au premier démarrage',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/files/nl-nl.ts
@@ -1,0 +1,191 @@
+export default {
+	uSync: {
+		section: 'Synchronisatie',
+		name: 'uSync',
+		banner: 'uSync voor alles',
+
+		migrate: 'Migreren',
+		defaultView: 'Standaard',
+		settingsView: 'Instellingen',
+		addons: 'Add-ons',
+
+		groupEverything: 'Alles',
+		groupContent: 'Inhoud',
+		groupSettings: 'Instellingen',
+		groupForms: 'Formulieren',
+		groupMedia: 'Media',
+		groupMembers: 'Leden',
+
+		Report: 'Rapport',
+		Import: 'Importeren',
+		Export: 'Exporteren',
+		ImportForce: 'Importeren (Forceren)',
+		ExportClean: 'Exporteren (Schoon)',
+		ExportFile: 'Exporteren naar bestand',
+		ImportFile: 'Importeren vanuit bestand',
+
+		noChange: 'Er is niets veranderd',
+		showAll: 'Alle items weergeven',
+
+		detailHeadline: 'Gedetecteerde wijzigingen',
+		detailHeader: 'Wat er anders is',
+
+		runningInBackground:
+			'uSync voert dit proces op de achtergrond uit. Als u van deze pagina navigeert, blijft het doorlopen.',
+
+		connectionLost:
+			'De verbinding met de server is verbroken. Het proces blijft op de achtergrond draaien, maar u ziet hier geen updates.',
+
+		importSingle: 'Importeren',
+		importSingleWarning:
+			'Dit importeert dit item in Umbraco. Als dit item afhankelijkheden heeft, worden deze niet geïmporteerd en moeten handmatig worden opgelost.',
+		importSingleSuccess: 'Het item is succesvol geïmporteerd',
+		importSingleFailed: `<p>Er is een fout opgetreden bij het importeren van het item</p><strong>%0%</strong>`,
+
+		changeAction: 'Actie',
+		changeItem: 'Item',
+		changeDiffrence: 'Verschil',
+		changeCreate: 'Dit item bestaat niet in Umbraco en wordt aangemaakt',
+		noChangesImport: 'Er zijn geen wijzigingen aangebracht aan dit item',
+		noChangesReport: 'Geen wijzigingen gedetecteerd',
+		noChangesDelete: 'Dit item is verwijderd uit Umbraco',
+
+		importHeader: 'Importeren vanuit bestand',
+
+		success: 'Succes',
+		change: 'Wijziging',
+		changeType: 'Type',
+		changeName: 'Naam',
+		changeDetail: 'Detail',
+		changeHeading: 'Resultaten',
+		changeCount: '{1}/{0} wijzigingen',
+		noChangeCount: '0/{0} wijzigingen',
+
+		legacyInfo: `<p>uSync heeft een verouderde uSync-map gevonden op <strong>%0%</strong>.<br />
+						Het is waarschijnlijk dat de inhoud op de een of andere manier geconverteerd moet worden</p>`,
+
+		legacyObsolete: `<h4>Verouderde gegevenstypen</h4>
+				<ul>%0%</ul>
+				<p>U kunt deze gegevenstypen converteren met
+					<a href="https://github.com/Jumoo/uSyncMigrations" target="_blank">uSync.Migrations</a><br />
+					<em>(In de volledige uSync-release zal de conversie hier plaatsvinden.)</em></p>`,
+
+		legacyCopy: `<h4>Kopiëren naar uSync/v14</h4>
+					<p>U kunt uw %0%-map kopiëren naar de ~/uSync/v14-map<br />en een import uitvoeren.</p>
+					<p>Als er niets geconverteerd hoeft te worden, zou alles correct moeten importeren.</p>
+					<p><strong>Verwijder of hernoem de %0%-map om deze popup te voorkomen</strong></p>`,
+
+		hmacMismatch: `<h4>HMAC-mismatch <uui-icon name="alert"></uui-icon></h4>
+			<p>Het lijkt erop dat de <code>Imaging:HMAC</code>-instelling die werd gebruikt om de bestanden in de uSync-map te genereren, niet overeenkomt met de huidige instelling voor deze site.</p>
+			<p>Afbeeldingen in RTE-besturingselementen hebben de HMAC-waarde toegevoegd aan de URL-waarde, en zonder aanvullende configuratie worden deze afbeeldingen mogelijk niet correct weergegeven.</p>
+			<ul><li>U kunt "HMAC-mapping" inschakelen in uSync,</li>
+			<li>of u kunt ervoor zorgen dat de HMAC-waarde in de <code>Imaging:HMAC</code>-instelling overeenkomt met de waarde die werd gebruikt om de bestanden in de uSync-map te genereren</li></ul>`,
+		formatMismatch:
+			'De versie van het synchronisatiebestandsformaat komt niet overeen met de verwachte versie. Dit kan wijzen op een mogelijk compatibiliteitsprobleem.',
+
+		legacyBanner:
+			'Deze site bevat bestanden van een eerdere versie van uSync. Bekijk de details op het tabblad Verouderd.',
+
+		legacyCopyTitle: 'v%0%-bestanden overschrijven',
+		legacyCopyContent:
+			'Weet u zeker dat u de inhoud van de map %0% wilt overschrijven met de verouderde uSync-mapbestanden?',
+
+		legacyIgnoreTitle: 'Verouderde bestanden negeren',
+		legacyIgnoreContent:
+			'Weet u zeker dat u de bestanden in de verouderde uSync-map wilt negeren?',
+
+		errorHeader:
+			'Dit item heeft een fout ondervonden tijdens het proces. De details staan hieronder:',
+
+		uploadIntro: 'Selecteer een zip-bestand met uSync-bestanden die u wilt uploaden',
+		uploadSuccess: 'De bestanden zijn geüpload en uitgepakt naar de uSync-map',
+		uploadError: 'Er is een fout opgetreden bij het uploaden van de bestanden',
+
+		ILanguage: 'Taal',
+		IDictionaryItem: 'Woordenboekitems',
+		IDataType: 'Gegevenstypen',
+		ITemplate: 'Sjablonen',
+		IContentType: 'Inhoudstypen',
+		IMediaType: 'Mediatypen',
+		IMemberType: 'Ledentypen',
+		IContent: 'Inhoud',
+		IMedia: 'Media',
+		IDomain: 'Domeinen',
+		IWebhook: 'Webhooks',
+		IRelationType: 'Relatietypen',
+		MediaFile: 'Mediabestanden',
+		XElement: 'Overig',
+		LanguageHandler: 'Talen',
+		DictionaryHandler: 'Woordenboekitems',
+		DataTypeHandler: 'Gegevenstypen',
+		TemplateHandler: 'Sjablonen',
+		ContentTypeHandler: 'Inhoudstypen',
+		MediaTypeHandler: 'Mediatypen',
+		MemberTypeHandler: 'Ledentypen',
+		ContentHandler: 'Inhoud',
+		MediaHandler: 'Media',
+		RelationTypeHandler: 'Relatietypen',
+		EntityContainer: 'Containers',
+	},
+	USyncSettings: {
+		settings: 'uSync-instellingen',
+		filesAndFolders: 'Bestanden en mappen',
+		handlerDefaults: 'Handler-standaardwaarden',
+
+		processingMode: 'Verwerkingsmodus',
+		processingModeDesc:
+			'Hoe het uSync-proces wordt uitgevoerd, op de achtergrond of interactief (Normaal)',
+
+		importAtStartup: 'Importeren bij opstarten',
+		importAtStartupDesc: 'Een import van bestanden van de schijf uitvoeren wanneer Umbraco start',
+
+		exportAtStartup: 'Exporteren bij opstarten',
+		exportAtStartupDesc: 'De Umbraco-instellingen exporteren wanneer de site opstart',
+
+		exportOnSave: 'Exporteren bij opslaan',
+		exportOnSaveDesc: 'uSync-bestanden genereren wanneer items worden opgeslagen',
+
+		uiEnabledGroups: 'UI-ingeschakelde groepen',
+		uiEnabledGroupsDesc: 'Handlergroepen die zichtbaar/bruikbaar zijn op het dashboard',
+
+		failOnMissingParent: 'Fout bij ontbrekend bovenliggend item',
+		failOnMissingParentDesc: 'Fout bij ontbrekend bovenliggend item',
+
+		currentHandlerSet: 'Huidige set',
+
+		handlerSet: 'Standaard handlerset',
+		handlerSetDesc: 'De standaard handlerset voor de site',
+
+		flatStructure: 'Platte structuur',
+		flatStructureDesc: 'Alle items van een type worden opgeslagen in een platte mappenstructuur',
+
+		guidNames: 'GUID\'s als bestandsnamen gebruiken',
+		guidNamesDesc: 'De GUID van een item als bestandsnaam gebruiken',
+
+		handlerGroups: 'Handlergroepen',
+		handlerGroupsDesc: 'Groepen om de handlerset te beperken',
+
+		disabledHandlers: 'Uitgeschakelde handlers',
+		disabledHandlersDesc: 'Handlers die expliciet zijn uitgeschakeld voor deze handlerset',
+
+		folders: 'Mappen',
+		foldersDesc:
+			'Mappen waarin uSync naar bestanden zoekt (items worden normaal opgeslagen in de laatste map in de lijst)',
+
+		rootSite: 'Rootsite',
+		rootSiteDesc: 'Is deze site een root voor andere sites.',
+
+		rootLocked: 'Root vergrendeld',
+		rootLockedDesc: 'Zijn wijzigingen voor items van de rootsite vergrendeld?',
+
+		help: 'Instellingen worden beheerd via het bestand appsettings.json. <a href="https://docs.jumoo.co.uk/usync/uSync/reference/config" target="_blank" rel="noopener">Zie onze documentatie</a>',
+
+		bootSettings: 'Instellingen voor eerste opstart 🥾',
+
+		firstBoot: 'Importeren bij eerste opstart',
+		firstBootDesc: 'Het importproces uitvoeren bij de eerste opstart van de site',
+
+		firstBootGroup: 'Groepen voor eerste opstart',
+		firstBootGroupDesc: 'De groepen die worden uitgevoerd bij de eerste opstart',
+	},
+};

--- a/uSync.Backoffice.Management.Client/usync-assets/src/lang/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/lang/manifest.ts
@@ -9,6 +9,56 @@ const localizations: Array<UmbExtensionManifest> = [
 		},
 		js: () => import('./files/en-us'),
 	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.dadk',
+		name: 'Danish',
+		weight: 0,
+		meta: {
+			culture: 'da',
+		},
+		js: () => import('./files/da-dk'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.frfr',
+		name: 'French',
+		weight: 0,
+		meta: {
+			culture: 'fr',
+		},
+		js: () => import('./files/fr-fr'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.eses',
+		name: 'Spanish',
+		weight: 0,
+		meta: {
+			culture: 'es',
+		},
+		js: () => import('./files/es-es'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.dede',
+		name: 'German',
+		weight: 0,
+		meta: {
+			culture: 'de',
+		},
+		js: () => import('./files/de-de'),
+	},
+	{
+		type: 'localization',
+		alias: 'usync.lang.nlnl',
+		name: 'Dutch',
+		weight: 0,
+		meta: {
+			culture: 'nl',
+		},
+		js: () => import('./files/nl-nl'),
+	},
 ];
 
 export const manifests: UmbExtensionManifest[] = [...localizations];

--- a/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/tree/manifest.ts
@@ -64,7 +64,7 @@ const menuSidebarApp: UmbExtensionManifest = {
 	name: 'uSync section sidebar menu',
 	weight: 150,
 	meta: {
-		label: 'Synchronisation',
+		label: '#uSync_section',
 		menu: menu.alias,
 	},
 	conditions: [

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/components/usync-action-button.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/components/usync-action-button.ts
@@ -42,7 +42,7 @@ export class SyncActionButtonElement extends UmbLitElement {
 				<uui-button
 					class="action-button"
 					.disabled=${this.disabled}
-					label=${this.localize.term(`uSync_${this.button?.label}`)}
+					label=${this.localize.termOrDefault(`uSync_${this.button?.label}`, this.button?.label ?? '')}
 					color=${<UUIInterfaceColor>this.button?.color}
 					look=${<UUIInterfaceLook>this.button?.look}
 					state=${ifDefined(this.state)}
@@ -63,7 +63,7 @@ export class SyncActionButtonElement extends UmbLitElement {
 		const buttons = this.button?.children.map((item: SyncActionButton) => {
 			return html` <uui-menu-item
 				.disabled=${this.disabled}
-				.label=${this.localize.term(`uSync_${item.label}`)}
+				.label=${this.localize.termOrDefault(`uSync_${item.label}`, item.label)}
 				@click-label=${() => this.#onClick(item)}></uui-menu-item>`;
 		});
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/dialogs/import-modal.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/dialogs/import-modal.element.ts
@@ -29,7 +29,7 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 
 	render() {
 		return html`
-			<umb-body-layout .headline=${this.localize.term('uSync_importHeader')}>
+			<umb-body-layout .headline=${this.localize.termOrDefault('uSync_importHeader', 'Import from file')}>
 				${this.renderForm()} ${this.renderResult()}
 			</umb-body-layout>
 		`;
@@ -38,7 +38,7 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 	renderForm() {
 		if (this.result !== undefined) return;
 
-		return html` ${this.localize.term('uSync_uploadIntro')}
+		return html` ${this.localize.termOrDefault('uSync_uploadIntro', 'Select a zip file containing uSync files that you want to upload')}
 			<usync-file-upload @uploaded=${this.#onUploaded}></usync-file-upload>
 			<div slot="actions">
 				<uui-button
@@ -53,8 +53,8 @@ export class uSyncImportModalDialog extends UmbModalBaseElement<any, any> {
 
 		return html`${when(
 				this.result.success,
-				() => html`${this.localize.term('uSync_uploadSuccess')}`,
-				() => html`${this.localize.term('uSync_uploadError')} ${this.result?.errors}`,
+				() => html`${this.localize.termOrDefault('uSync_uploadSuccess', 'The files have been uploaded and extracted to the uSync folder')}`,
+				() => html`${this.localize.termOrDefault('uSync_uploadError', 'There was an error uploading the files')} ${this.result?.errors}`,
 			)}
 			<div slot="actions">
 				<uui-button id="continue" label="Import" @click="${this.#onImport}"></uui-button>

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/manifest.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/manifest.ts
@@ -38,7 +38,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/default/default.element.js'),
 		weight: 300,
 		meta: {
-			label: 'Default',
+			label: '#uSync_defaultView',
 			pathname: 'default',
 			icon: 'usync-logo',
 		},
@@ -56,7 +56,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/settings/settings.element.js'),
 		weight: 200,
 		meta: {
-			label: 'Settings',
+			label: '#uSync_settingsView',
 			pathname: 'settings',
 			icon: 'icon-settings',
 		},
@@ -74,7 +74,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/addons/addons.element.js'),
 		weight: 100,
 		meta: {
-			label: 'AddOns',
+			label: '#uSync_addons',
 			pathname: 'addons',
 			icon: 'icon-box',
 		},
@@ -92,7 +92,7 @@ const workspaceViews: Array<UmbExtensionManifest> = [
 		js: () => import('./views/legacy/legacy.element.js'),
 		weight: 150,
 		meta: {
-			label: 'Migrate',
+			label: '#uSync_migrate',
 			pathname: 'legacy',
 			icon: 'icon-arrow-up',
 		},

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/default/default.element.ts
@@ -243,11 +243,11 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 
 		return html`<div class="set-picker">
 			<label for="set-select"
-				>${this.localize.term('USyncSettings_currentHandlerSet')}</label
+				>${this.localize.termOrDefault('USyncSettings_currentHandlerSet', 'Current Set')}</label
 			>
 			<uui-select
 				id="set-select"
-				.label=${this.localize.term('USyncSettings_currentHandlerSet')}
+				.label=${this.localize.termOrDefault('USyncSettings_currentHandlerSet', 'Current Set')}
 				.options=${options}
 				@change=${(e: Event) => {
 					const select = e.target as HTMLSelectElement;
@@ -264,7 +264,7 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 			: html`
 					<div class="legacy-banner">
 						<umb-icon name="icon-alert"></umb-icon>
-						${this.localize.term('uSync_legacyBanner')}
+						${this.localize.termOrDefault('uSync_legacyBanner', 'This site contains files from a previous version of uSync, view the details in the legacy tab.')}
 					</div>
 				`;
 	}
@@ -333,15 +333,15 @@ export class uSyncDefaultViewElement extends UmbLitElement {
 		if (!this._connected) {
 			return html` <uui-box class="banner warning">
 				<uui-icon name="icon-alert"></uui-icon>
-				${this.localize.term('uSync_runningInBackground')}
+				${this.localize.termOrDefault('uSync_runningInBackground', 'uSync is running this process in background, if you navigate away from this page it will continue to run.')}
 				<br />
-				${this.localize.term('uSync_connectionLost')}
+				${this.localize.termOrDefault('uSync_connectionLost', 'the connection to the server has been lost, the process will continue to run in the background but you will not see updates here.')}
 			</uui-box>`;
 		}
 
 		return html`<uui-box class="banner info">
 			<uui-icon name="icon-info"></uui-icon>
-			${this.localize.term('uSync_runningInBackground')}
+			${this.localize.termOrDefault('uSync_runningInBackground', 'uSync is running this process in background, if you navigate away from this page it will continue to run.')}
 		</uui-box>`;
 	}
 

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/legacy/legacy.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/legacy/legacy.element.ts
@@ -42,12 +42,8 @@ export class SyncLegacyFilesElement extends UmbLitElement {
 
 		const confirmContext = modalContext?.open(this, UMB_CONFIRM_MODAL, {
 			data: {
-				headline: this.localize.term('uSync_legacyCopyTitle', [
-					this._legacy?.latestVersion,
-				]),
-				content: html`${this.localize.term('uSync_legacyCopyContent', [
-					this._legacy?.latestFolder,
-				])}`,
+				headline: this.localize.termOrDefault('uSync_legacyCopyTitle', 'Overwrite files', this._legacy?.latestVersion),
+				content: html`${this.localize.termOrDefault('uSync_legacyCopyContent', 'Are you sure you want to overwrite the contents of the folder with the legacy uSync folder files?', this._legacy?.latestFolder)}`,
 				color: 'danger',
 				confirmLabel: 'Copy',
 			},
@@ -68,8 +64,8 @@ export class SyncLegacyFilesElement extends UmbLitElement {
 		const modalContext = await this.getContext(UMB_MODAL_MANAGER_CONTEXT);
 		const confirmContext = modalContext?.open(this, UMB_CONFIRM_MODAL, {
 			data: {
-				headline: this.localize.term('uSync_legacyIgnoreTitle'),
-				content: html`${this.localize.term('uSync_legacyIgnoreContent')}`,
+				headline: this.localize.termOrDefault('uSync_legacyIgnoreTitle', 'Ignore legacy files'),
+				content: html`${this.localize.termOrDefault('uSync_legacyIgnoreContent', 'Are you sure you want to ignore the files in the legacy uSync folder?')}`,
 				color: 'danger',
 				confirmLabel: 'Ignore',
 			},

--- a/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
+++ b/uSync.Backoffice.Management.Client/usync-assets/src/workspace/views/settings/settings.element.ts
@@ -49,105 +49,107 @@ export class USyncSettingsViewElement extends UmbElementMixin(LitElement) {
 			<umb-body-layout>
 				<div class="usync-settings-layout">
 					<div>
-						<uui-box headline=${this.localize.term('USyncSettings_settings')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_settings', 'uSync Settings')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_processingMode')}
-								.description=${this.localize.term('USyncSettings_processingModeDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_processingMode', 'Processing Mode')}
+								.description=${this.localize.termOrDefault('USyncSettings_processingModeDesc', 'How the uSync process runs, either in the background or interactively (Normal)')}
 								.value=${this.settings?.processingMode}></usync-setting-item>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_importAtStartup')}
-								.description=${this.localize.term('USyncSettings_importAtStartupDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_importAtStartup', 'Import at startup')}
+								.description=${this.localize.termOrDefault('USyncSettings_importAtStartupDesc', 'Run an import of files from the disk when Umbraco starts')}
 								.value=${this.settings?.importAtStartup}></usync-setting-item>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_exportAtStartup')}
-								.description=${this.localize.term('USyncSettings_exportAtStartupDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_exportAtStartup', 'Export at startup')}
+								.description=${this.localize.termOrDefault('USyncSettings_exportAtStartupDesc', 'Export the Umbraco settings when the site starts up')}
 								.value=${this.settings?.exportAtStartup}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_exportOnSave')}
-								.description=${this.localize.term('USyncSettings_exportOnSaveDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_exportOnSave', 'Export on save')}
+								.description=${this.localize.termOrDefault('USyncSettings_exportOnSaveDesc', 'Generate uSync files when items are saved')}
 								.value=${this.settings?.exportOnSave}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_uiEnabledGroups')}
-								.description=${this.localize.term('USyncSettings_uiEnabledGroupsDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_uiEnabledGroups', 'UI Enabled groups')}
+								.description=${this.localize.termOrDefault('USyncSettings_uiEnabledGroupsDesc', 'Handler groups that can be seen/used on the dashboard')}
 								.value=${this.settings?.uiEnabledGroups}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_failOnMissingParent')}
-								.description=${this.localize.term(
+								.name=${this.localize.termOrDefault('USyncSettings_failOnMissingParent', 'Fail on missing parent')}
+								.description=${this.localize.termOrDefault(
 									'USyncSettings_failOnMissingParentDesc',
+									'Fail on missing parent',
 								)}
 								.value=${this.settings?.failOnMissingParent}></usync-setting-item>
 						</uui-box>
 
-						<uui-box headline=${this.localize.term('USyncSettings_filesAndFolders')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_filesAndFolders', 'File and folders')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_rootSite')}
-								.description=${this.localize.term('USyncSettings_rootSiteDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_rootSite', 'Root Site')}
+								.description=${this.localize.termOrDefault('USyncSettings_rootSiteDesc', 'Is this site a root for other sites.')}
 								.value=${this.settings?.isRootSite}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_rootLocked')}
-								.description=${this.localize.term('USyncSettings_rootLockedDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_rootLocked', 'Root Locked')}
+								.description=${this.localize.termOrDefault('USyncSettings_rootLockedDesc', 'Are changes for items that are from the root site locked?')}
 								.value=${this.settings?.lockRoot}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_folders')}
-								.description=${this.localize.term('USyncSettings_foldersDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_folders', 'Folders')}
+								.description=${this.localize.termOrDefault('USyncSettings_foldersDesc', 'Folders uSync will look for files, (items are normally saved into last folder in the list)')}
 								.value=${this.settings?.folders}></usync-setting-item>
 						</uui-box>
 					</div>
 
 					<div>
-						<uui-box headline=${this.localize.term('USyncSettings_handlerDefaults')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_handlerDefaults', 'Handler defaults')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_handlerSet')}
-								.description=${this.localize.term('USyncSettings_handlerSetDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_handlerSet', 'Default handler set')}
+								.description=${this.localize.termOrDefault('USyncSettings_handlerSetDesc', 'The default handler set to use for the site')}
 								.value=${this.settings?.defaultSet}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_flatStructure')}
-								.description=${this.localize.term('USyncSettings_flatStructureDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_flatStructure', 'Flat structure')}
+								.description=${this.localize.termOrDefault('USyncSettings_flatStructureDesc', 'All items of a type are stored in a flat folder structure')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.useFlatStructure}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_guidNames')}
-								.description=${this.localize.term('USyncSettings_guidNamesDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_guidNames', 'Use guids for filenames')}
+								.description=${this.localize.termOrDefault('USyncSettings_guidNamesDesc', 'Use the GUID of an item as the filename')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.guidNames}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_handlerGroups')}
-								.description=${this.localize.term('USyncSettings_handlerGroupsDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_handlerGroups', 'Handler groups')}
+								.description=${this.localize.termOrDefault('USyncSettings_handlerGroupsDesc', 'Groups to limit handler set to')}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.group}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_failOnMissingParent')}
-								.description=${this.localize.term(
+								.name=${this.localize.termOrDefault('USyncSettings_failOnMissingParent', 'Fail on missing parent')}
+								.description=${this.localize.termOrDefault(
 									'USyncSettings_failOnMissingParentDesc',
+									'Fail on missing parent',
 								)}
 								.value=${this.handlerSettings?.handlerDefaults
 									?.failOnMissingParent}></usync-setting-item>
 
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_disabledHandlers')}
-								.description=${this.localize.term('USyncSettings_disabledHandlersDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_disabledHandlers', 'Disabled Handlers')}
+								.description=${this.localize.termOrDefault('USyncSettings_disabledHandlersDesc', 'Handlers explicitly disabled for this handler set')}
 								.value=${this.handlerSettings?.disabledHandlers}></usync-setting-item>
 						</uui-box>
-						<uui-box headline=${this.localize.term('USyncSettings_bootSettings')}>
+						<uui-box headline=${this.localize.termOrDefault('USyncSettings_bootSettings', 'First boot settings')}>
 							<usync-setting-item
-								.name=${this.localize.term('USyncSettings_firstBoot')}
-								.description=${this.localize.term('USyncSettings_firstBootDesc')}
+								.name=${this.localize.termOrDefault('USyncSettings_firstBoot', 'Import on First boot')}
+								.description=${this.localize.termOrDefault('USyncSettings_firstBootDesc', 'Run the import process on first boot of the site')}
 								.value=${this.settings?.importOnFirstBoot}></usync-setting-item>
 							${when(
 								this.settings?.importOnFirstBoot,
 								() =>
 									html` <usync-setting-item
-										.name=${this.localize.term('USyncSettings_firstBootGroup')}
-										.description=${this.localize.term('USyncSettings_firstBootGroupDesc')}
+										.name=${this.localize.termOrDefault('USyncSettings_firstBootGroup', 'First boot groups')}
+										.description=${this.localize.termOrDefault('USyncSettings_firstBootGroupDesc', 'The groups to run on first boot')}
 										.value=${this.settings?.firstBootGroup}></usync-setting-item>`,
 							)}
 						</uui-box>

--- a/uSync.Core/Cache/SyncEntityCache.cs
+++ b/uSync.Core/Cache/SyncEntityCache.cs
@@ -39,7 +39,10 @@ public class SyncEntityCache
     public CachedName? GetName(int id)
     {
         if (!_cacheEnabled) return default;
-        return cache.GetCacheItem<CachedName>(id.ToString());
+        // read from nameCache - this is where AddName stores CachedName values.
+        // (reading from `cache` returned IEntitySlim entries under the same key,
+        //  which threw a swallowed InvalidCastException and never actually cached).
+        return nameCache.GetCacheItem<CachedName>(id.ToString());
     }
 
     public void AddName(int id, Guid guid, string name)

--- a/uSync.Core/DataTypes/DataTypeSerializers/DataListMigratingConfigSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/DataListMigratingConfigSerializer.cs
@@ -37,7 +37,7 @@ internal class DataListMigratingConfigSerializer : ConfigurationSerializerBase, 
 
         return configuration;
     }
-    private class IdValuePair
+    private sealed class IdValuePair
     {
         public int? Id { get; set; }
         public string? Value { get; set; }

--- a/uSync.Core/DataTypes/DataTypeSerializers/FileUploadMigratingConfigSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/FileUploadMigratingConfigSerializer.cs
@@ -42,7 +42,7 @@ internal class FileUploadMigratingConfigSerializer : ConfigurationSerializerBase
         return configuration;
     }
 
-    private class IdValuePair
+    private sealed class IdValuePair
     {
         public int? Id { get; set; }
         public string? Value { get; set; }

--- a/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
+++ b/uSync.Core/DataTypes/DataTypeSerializers/RichTextEditorMigratingSerializer.cs
@@ -118,8 +118,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
             extensions.Add("Umb.Tiptap.Block");
         }
         
-        if (configuration.ContainsKey("toolbar"))
-            configuration.Remove("toolbar");
+        configuration.Remove("toolbar");
 
         configuration["toolbar"] = new List<List<List<string>>> { new() { newToolbar } };
         
@@ -128,7 +127,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return configuration;
     }
 
-    private bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
+    private static bool TryGetToolbarArray(object? toolbar, out List<string> toolBarList)
     {
         toolBarList = new List<string>();
         if (toolbar is null) return false;
@@ -146,7 +145,7 @@ internal class RichTextEditorMigratingSerializer : ConfigurationSerializerBase, 
         return true;
     }
 
-    private string? MapToolbarItem(string item)
+    private static string? MapToolbarItem(string item)
     {
         return item switch
         {

--- a/uSync.Core/Extensions/ConversionExtensions.cs
+++ b/uSync.Core/Extensions/ConversionExtensions.cs
@@ -1,14 +1,10 @@
-﻿using Umbraco.Extensions;
-
-namespace uSync.Core.Extensions;
+﻿namespace uSync.Core.Extensions;
 internal static class ConversionExtensions
 {
     public static TObject? GetValueAs<TObject>(this object value)
     {
         if (value == null) return default;
-        var attempt = value.TryConvertTo<TObject>();
-        if (!attempt) return default;
-        return attempt.Result;
+        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
     }
 
     public static Guid ConvertToGuid(this int value)

--- a/uSync.Core/Extensions/ConversionExtensions.cs
+++ b/uSync.Core/Extensions/ConversionExtensions.cs
@@ -4,7 +4,7 @@ internal static class ConversionExtensions
     public static TObject? GetValueAs<TObject>(this object value)
     {
         if (value == null) return default;
-        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
+        return value.TryGetValueAs<TObject>(out var result) ? result : default;
     }
 
     public static Guid ConvertToGuid(this int value)

--- a/uSync.Core/Extensions/ConversionExtensions.cs
+++ b/uSync.Core/Extensions/ConversionExtensions.cs
@@ -13,8 +13,8 @@ internal static class ConversionExtensions
 
     public static Guid ConvertToGuid(this int value)
     {
-        byte[] bytes = new byte[16];
-        BitConverter.GetBytes(value).CopyTo(bytes, 0);
+        Span<byte> bytes = stackalloc byte[16];
+        BitConverter.TryWriteBytes(bytes, value);
         return new Guid(bytes);
     }
 }

--- a/uSync.Core/Extensions/DictionaryExtensions.cs
+++ b/uSync.Core/Extensions/DictionaryExtensions.cs
@@ -15,22 +15,20 @@ internal static class DictionaryExtensions
     {
         if (usernames == null || id == null) return "unknown";
 
-        usernames[id.Value] = usernames.ContainsKey(id.Value)
-            ? usernames[id.Value]
-            : findMethod(id.Value)?.Email ?? "unknown";
+        if (usernames.TryGetValue(id.Value, out string? username))
+            return username;
 
-        return usernames[id.Value];
+        return usernames[id.Value] = findMethod(id.Value)?.Email ?? "unknown";
     }
 
     public static int GetEmails(this Dictionary<string, int> emails, string email, Func<string, IUser> findMethod)
     {
         if (emails == null || string.IsNullOrEmpty(email)) return -1;
 
-        emails[email] = emails.TryGetValue(email, out int value)
-            ? value
-            : findMethod(email)?.Id ?? -1;
+        if (emails.TryGetValue(email, out int value))
+            return value;
 
-        return emails[email];
+        return emails[email] = findMethod(email)?.Id ?? -1;
     }
 
     // This method converts an object to a dictionary of string, object
@@ -40,7 +38,7 @@ internal static class DictionaryExtensions
         var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         // Create a dictionary and populate it with the property names and values
-        var dictionary = new Dictionary<string, object?>();
+        Dictionary<string, object?> dictionary = new(properties.Length);
         foreach (var property in properties)
         {
             dictionary.Add(property.Name, property.GetValue(obj));
@@ -60,7 +58,7 @@ internal static class DictionaryExtensions
         {
             var properties = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            var dictionary = new Dictionary<string, object?>();
+            Dictionary<string, object?> dictionary = new(properties.Length);
             foreach (var property in properties)
             {
                 dictionary.Add(property.Name, property.GetValue(obj));
@@ -87,8 +85,7 @@ internal static class DictionaryExtensions
         {
             foreach (var kvp in dictionary)
             {
-                if (mergedDictionary.ContainsKey(kvp.Key) is true) continue;
-                mergedDictionary.Add(kvp.Key, kvp.Value);
+                mergedDictionary.TryAdd(kvp.Key, kvp.Value);
             }
         }
 
@@ -111,6 +108,6 @@ internal static class DictionaryExtensions
             return s.ToLowerInvariant();
         }
 
-        return char.ToLowerInvariant(s[0]) + s.Substring(1);
+        return $"{char.ToLowerInvariant(s[0])}{s.AsSpan(1)}";
     }
 }

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -511,11 +512,24 @@ public static class JsonTextExtensions
     ///  tells us if the json for an object is equal, helps when the config objects don't have their
     ///  own Equals functions
     /// </summary>
-    public static bool IsJsonEqual(this object currentObject, object newObject)
+    public static bool IsJsonEqual(this object? currentObject, object? newObject)
     {
-        var currentString = currentObject.SerializeJsonString(false);
-        var newString = newObject.SerializeJsonString(false);
-        return currentString == newString;
+        if (currentObject is null && newObject is null)
+            return true;
+        if (currentObject is null)
+            return false;
+        if (newObject is null)
+            return false;
+
+        ArrayBufferWriter<byte> currentObjectBufferWriter = new(); 
+        using Utf8JsonWriter currentObjectUtf8JsonWriter = new(currentObjectBufferWriter);
+        JsonSerializer.Serialize(currentObjectUtf8JsonWriter, currentObject, _flatOptions);
+
+        ArrayBufferWriter<byte> newObjectBufferWriter = new();
+        using Utf8JsonWriter newObjectUtf8JsonWriter = new(newObjectBufferWriter);
+        JsonSerializer.Serialize(newObjectUtf8JsonWriter, newObject, _flatOptions);
+
+        return currentObjectBufferWriter.WrittenSpan.SequenceEqual(newObjectBufferWriter.WrittenSpan);
     }
 
     #endregion

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -400,6 +400,43 @@ public static class JsonTextExtensions
         return true;
     }
 
+    /// <summary>
+    ///  Convert a value to the requested type, pre-empting the first-chance
+    ///  InvalidCastException that Umbraco's TryConvertTo throws when converting
+    ///  a JsonElement to a value type (see uSync.Complete issue #304).
+    /// </summary>
+    /// <remarks>
+    ///  Settings/config values often arrive as JsonElement (bound from appsettings.json).
+    ///  Asking Umbraco's TryConvertTo to turn one into e.g. a bool throws (and swallows)
+    ///  an InvalidCastException every call - harmless, but noisy and slow when a debugger
+    ///  is attached. Doing the JsonElement conversion with System.Text.Json first means the
+    ///  common path never throws; anything STJ can't handle still falls back to TryConvertTo.
+    /// </remarks>
+    public static bool TryConvertPreChecked<TObject>(this object? value, [MaybeNullWhen(false)] out TObject result)
+    {
+        result = default;
+        if (value is null) return false;
+
+        if (value is JsonElement element)
+        {
+            try
+            {
+                result = element.Deserialize<TObject>(_defaultOptions);
+                if (result is not null) return true;
+            }
+            catch
+            {
+                // not something STJ could convert directly - fall back to TryConvertTo below.
+            }
+        }
+
+        var attempt = value.TryConvertTo<TObject>();
+        if (attempt.Success is false || attempt.Result is null) return false;
+
+        result = attempt.Result;
+        return true;
+    }
+
     #endregion
 
     #region property getters 

--- a/uSync.Core/Extensions/JsonTextExtensions.cs
+++ b/uSync.Core/Extensions/JsonTextExtensions.cs
@@ -390,34 +390,27 @@ public static class JsonTextExtensions
     public static string SerializeJsonString(this object value, bool indent = true)
         => value is null ? string.Empty : JsonSerializer.Serialize(value, indent ? _defaultOptions : _flatOptions);
 
-    private static bool TryGetValueAs<TObject>(this object value, [MaybeNullWhen(false)] out TObject result)
-    {
-        result = default;
-        if (value == null) return false;
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt is false || attempt.Result is null) return attempt;
-        result = attempt.Result;
-        return true;
-    }
-
     /// <summary>
-    ///  Convert a value to the requested type, pre-empting the first-chance
-    ///  InvalidCastException that Umbraco's TryConvertTo throws when converting
-    ///  a JsonElement to a value type (see uSync.Complete issue #304).
+    ///  Convert a value to the requested type.
     /// </summary>
     /// <remarks>
-    ///  Settings/config values often arrive as JsonElement (bound from appsettings.json).
-    ///  Asking Umbraco's TryConvertTo to turn one into e.g. a bool throws (and swallows)
-    ///  an InvalidCastException every call - harmless, but noisy and slow when a debugger
-    ///  is attached. Doing the JsonElement conversion with System.Text.Json first means the
-    ///  common path never throws; anything STJ can't handle still falls back to TryConvertTo.
+    ///  Pre-empts the first-chance InvalidCastException that Umbraco's TryConvertTo
+    ///  throws when converting a JsonElement to a value type (see uSync.Complete
+    ///  issue #304). Settings/config values often arrive as JsonElement (bound from
+    ///  appsettings.json); doing that conversion with System.Text.Json first means the
+    ///  common path never throws. String conversions (which TryConvertTo already
+    ///  handles cleanly) and anything STJ can't handle still fall back to TryConvertTo.
     /// </remarks>
-    public static bool TryConvertPreChecked<TObject>(this object? value, [MaybeNullWhen(false)] out TObject result)
+    public static bool TryGetValueAs<TObject>(this object? value, [MaybeNullWhen(false)] out TObject result)
     {
         result = default;
         if (value is null) return false;
 
-        if (value is JsonElement element)
+        // Umbraco's TryConvertTo turns a JsonElement into a string cleanly, but throws
+        // (and swallows) an InvalidCastException for JsonElement -> value type. Do the
+        // value-type conversion with System.Text.Json first to avoid that noise; string
+        // and anything STJ can't handle fall through to TryConvertTo below.
+        if (value is JsonElement element && typeof(TObject) != typeof(string))
         {
             try
             {
@@ -431,6 +424,38 @@ public static class JsonTextExtensions
         }
 
         var attempt = value.TryConvertTo<TObject>();
+        if (attempt.Success is false || attempt.Result is null) return false;
+
+        result = attempt.Result;
+        return true;
+    }
+
+    /// <summary>
+    ///  Convert a value to the requested runtime type.
+    /// </summary>
+    /// <remarks>
+    ///  Non-generic companion to the generic TryGetValueAs for callers that only
+    ///  have a runtime Type. Same JsonElement pre-check.
+    /// </remarks>
+    public static bool TryGetValueAs(this object? value, Type targetType, [MaybeNullWhen(false)] out object result)
+    {
+        result = default;
+        if (value is null) return false;
+
+        if (value is JsonElement element && targetType != typeof(string))
+        {
+            try
+            {
+                result = element.Deserialize(targetType, _defaultOptions);
+                if (result is not null) return true;
+            }
+            catch
+            {
+                // not something STJ could convert directly - fall back to TryConvertTo below.
+            }
+        }
+
+        var attempt = value.TryConvertTo(targetType);
         if (attempt.Success is false || attempt.Result is null) return false;
 
         result = attempt.Result;
@@ -498,8 +523,7 @@ public static class JsonTextExtensions
         if (obj.TryGetPropertyValue(propertyName, out var value) is false || value is null)
             return defaultValue;
 
-        var attempt = value.TryConvertTo<TResult>();
-        return attempt.ResultOr(defaultValue);
+        return value.TryGetValueAs<TResult>(out var result) ? result : defaultValue;
     }
 
     public static bool TryGetPropertyAsArray(this JsonObject jsonObject, string propertyName, [MaybeNullWhen(false)] out JsonArray result)

--- a/uSync.Core/Extensions/ListExtensions.cs
+++ b/uSync.Core/Extensions/ListExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.Core;
 
 public static class ListExtensions
@@ -40,10 +42,9 @@ public static class ListExtensions
         foreach (var item in items)
         {
             if (string.IsNullOrWhiteSpace(item)) continue;
-            var attempt = item.TryConvertTo<T>();
-            if (attempt.Success && attempt.Result is not null)
+            if (item.TryGetValueAs<T>(out var result))
             {
-                yield return attempt.Result;
+                yield return result;
             }
         }
     }

--- a/uSync.Core/Extensions/ObjectPropertyExtensions.cs
+++ b/uSync.Core/Extensions/ObjectPropertyExtensions.cs
@@ -75,11 +75,6 @@ public static class ObjectPropertyExtensions
         var value = info.GetValue(property);
         if (value == null) return defaultValue;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result ?? defaultValue;
-
-        return defaultValue;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : defaultValue;
     }
 }

--- a/uSync.Core/Extensions/StringExtensions.cs
+++ b/uSync.Core/Extensions/StringExtensions.cs
@@ -62,7 +62,7 @@ public static class StringExtensions
         // a Guid is 3 blocks + 8 bits
 
         // so it turns into a 3*8+2 = 26 chars string
-        var chars = new char[length];
+        Span<char> chars = stackalloc char[length];
 
         var i = 0;
         var j = 0;

--- a/uSync.Core/Extensions/SyncBuilderExtensions.cs
+++ b/uSync.Core/Extensions/SyncBuilderExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Cms.Core.DependencyInjection;
+
+namespace uSync.Core.Extensions;
+
+public static class SyncBuilderExtensions
+{
+    public static bool IsUmbracoBackOfficeEnabled(this IUmbracoBuilder builder)
+        => builder.Services.Any(s => s.ServiceType == typeof(IBackOfficeEnabledMarker));
+}

--- a/uSync.Core/Extensions/XElementExtensions.cs
+++ b/uSync.Core/Extensions/XElementExtensions.cs
@@ -138,7 +138,37 @@ public static class XElementExtensions
     public static TObject ValueOrDefault<TObject>([AllowNull] this XElement? node, TObject defaultValue)
     {
         var value = node.ValueOrDefault(string.Empty);
-        if (value == string.Empty) return defaultValue;
+        if (value.Length == 0) return defaultValue;
+
+        return value.ConvertOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    ///  Convert a non-empty string value to the requested type.
+    /// </summary>
+    /// <remarks>
+    ///  These getters are called for (almost) every attribute of every node during a
+    ///  report/import. The handful of value types actually used have direct, allocation
+    ///  free parsers that are much cheaper than routing through Umbraco's reflection based
+    ///  TryConvertTo. The typeof(TObject) == typeof(...) comparisons are folded to
+    ///  constants by the JIT per generic instantiation, so the branches have no runtime
+    ///  cost. Anything not matched falls through to TryGetValueAs.
+    /// </remarks>
+    private static TObject ConvertOrDefault<TObject>(this string value, TObject defaultValue)
+    {
+        if (typeof(TObject) == typeof(int))
+            return int.TryParse(value, out var i) ? (TObject)(object)i : defaultValue;
+
+        if (typeof(TObject) == typeof(Guid))
+            return Guid.TryParse(value, out var g) ? (TObject)(object)g : defaultValue;
+
+        if (typeof(TObject) == typeof(bool))
+            return bool.TryParse(value, out var b) ? (TObject)(object)b : defaultValue;
+
+        if (typeof(TObject).IsEnum)
+            return Enum.TryParse(typeof(TObject), value, true, out var e) && e is TObject enumValue
+                ? enumValue
+                : defaultValue;
 
         return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
@@ -284,9 +314,9 @@ public static class XElementExtensions
     public static TObject ValueOrDefault<TObject>([AllowNull] this XAttribute attribute, TObject defaultValue)
     {
         var value = attribute.ValueOrDefault(string.Empty);
-        if (value == string.Empty) return defaultValue;
+        if (value.Length == 0) return defaultValue;
 
-        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
+        return value.ConvertOrDefault(defaultValue);
     }
     #endregion
 
@@ -307,17 +337,17 @@ public static class XElementExtensions
     /// </remarks>
     public static async Task<string> MakePlatformSafeHashAsync(this XElement node)
     {
-        using (MemoryStream stream = new MemoryStream())
-        {
-            await node.SaveAsync(stream, SaveOptions.None, CancellationToken.None);
-            stream.Seek(0, SeekOrigin.Begin);
+        using HashAlgorithm hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA1.Create() : MD5.Create();
 
-            using (HashAlgorithm hashAlgorithm = CryptoConfig.AllowOnlyFipsAlgorithms ? SHA1.Create() : MD5.Create())
-            {
-                var hash = await hashAlgorithm.ComputeHashAsync(stream);
-                return Convert.ToHexStringLower(hash);
-            }
+        // stream the xml straight into the hash instead of buffering the whole
+        // serialized document into a MemoryStream first. CryptoStream feeds each
+        // written block to the algorithm as it arrives, so nothing is held in memory.
+        using (var cryptoStream = new CryptoStream(Stream.Null, hashAlgorithm, CryptoStreamMode.Write))
+        {
+            await node.SaveAsync(cryptoStream, SaveOptions.None, CancellationToken.None);
         }
+
+        return Convert.ToHexStringLower(hashAlgorithm.Hash!);
     }
 
 }

--- a/uSync.Core/Extensions/XElementExtensions.cs
+++ b/uSync.Core/Extensions/XElementExtensions.cs
@@ -5,6 +5,8 @@ using System.Xml.Linq;
 
 using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.Core;
 
 public static class XElementExtensions
@@ -138,11 +140,7 @@ public static class XElementExtensions
         var value = node.ValueOrDefault(string.Empty);
         if (value == string.Empty) return defaultValue;
 
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt)
-            return attempt.Result ?? defaultValue;
-
-        return defaultValue;
+        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
 
 
@@ -209,8 +207,7 @@ public static class XElementExtensions
     {
         if (node is null) return;
 
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success)
+        if (value.TryGetValueAs<string>(out var stringValue))
         {
             var element = node.Element(name);
             if (element is null)
@@ -219,7 +216,7 @@ public static class XElementExtensions
                 node.Add(element);
             }
 
-            element.Value = attempt.Result ?? string.Empty;
+            element.Value = stringValue ?? string.Empty;
         }
     }
 
@@ -289,11 +286,7 @@ public static class XElementExtensions
         var value = attribute.ValueOrDefault(string.Empty);
         if (value == string.Empty) return defaultValue;
 
-        var attempt = value.TryConvertTo<TObject>();
-        if (attempt)
-            return attempt.Result ?? defaultValue;
-
-        return defaultValue;
+        return value.TryGetValueAs<TObject>(out var result) ? result : defaultValue;
     }
     #endregion
 

--- a/uSync.Core/Json/OrderedPropertiesJsonResolver.cs
+++ b/uSync.Core/Json/OrderedPropertiesJsonResolver.cs
@@ -14,7 +14,7 @@ namespace uSync.Core.Json;
 ///  less changes in the files = faster comparison checks.
 /// </para>
 /// </remarks>
-internal class OrderedPropertiesJsonResolver : DefaultJsonTypeInfoResolver
+internal sealed class OrderedPropertiesJsonResolver : DefaultJsonTypeInfoResolver
 {
     public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
     {

--- a/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapper.cs
@@ -2,8 +2,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-using System.Text.RegularExpressions;
-
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Media;
@@ -11,7 +9,6 @@ using Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
-using uSync.Core.Dependency;
 using uSync.Core.Extensions;
 using uSync.Core.Serialization;
 
@@ -28,49 +25,33 @@ namespace uSync.Core.Mapping;
 /// becomes 
 /// {"src":"/media/2cud1lzo/15656993711_ccd199b83e_k.jpg","crops":null}
 /// </remarks>
-public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
+public class ImagePathMapper : ImagePathMapperBase, ISyncMapper
 {
-    private const string _genericMediaPath = "/media";
-
-    private readonly string _siteRoot;
-    private string? _mediaFolder;
-    private readonly ILogger<ImagePathMapper> _logger;
-    private readonly IConfiguration _configuration;
     private readonly IImageUrlGenerator _imageUrlGenerator;
 
     public ImagePathMapper(
-        IConfiguration configuration,
-        IOptionsMonitor<GlobalSettings> _globalOptions,
         IEntityService entityService,
         ILogger<ImagePathMapper> logger,
-        IImageUrlGenerator imageUrlGenerator) : base(entityService)
+        IConfiguration configuration,
+        IOptionsMonitor<GlobalSettings> globalOptions,
+        IImageUrlGenerator imageUrlGenerator) : base(entityService, logger, configuration, globalOptions)
     {
-        _logger = logger;
-        _configuration = configuration;
-
-        // todo: site root might need us to include extra NuGet.
-        _siteRoot = "";
-
-        _mediaFolder = GetMediaFolderSetting(_globalOptions.CurrentValue.UmbracoMediaPath.TrimStart('~'));
-        _globalOptions.OnChange(x => _mediaFolder = GetMediaFolderSetting(x.UmbracoMediaPath.TrimStart('~')));
-
-        if (logger.IsEnabled(LogLevel.Debug))
-            logger.LogDebug("Media Folders: [{media}]", _mediaFolder ?? "(Blank)");
-
         _imageUrlGenerator = imageUrlGenerator;
     }
 
     public override string Name => "ImageCropper Mapper";
 
     public override string[] Editors => [
-        Constants.PropertyEditors.Aliases.ImageCropper,
-        Constants.PropertyEditors.Aliases.UploadField
+        Constants.PropertyEditors.Aliases.ImageCropper
     ];
 
     public override Task<string?> GetExportValueAsync(object value, string editorAlias)
     {
         return uSyncTaskHelper.FromResultOf(() =>
         {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Getting export value for ImageCropper with value {Value}", value);
+
             var stringValue = value?.ToString();
             if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
 
@@ -107,76 +88,6 @@ public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
         });
     }
 
-    private string StripSitePath(string filePath)
-    {
-        var path = filePath;
-        if (_siteRoot.Length > 0 && !string.IsNullOrWhiteSpace(filePath) && filePath.InvariantStartsWith(_siteRoot))
-            path = filePath.Substring(_siteRoot.Length);
-
-        return ReplacePath(path, _mediaFolder, _genericMediaPath);
-    }
-
-    private string PrePendSitePath(string filePath)
-    {
-        var path = filePath;
-        if (_siteRoot.Length > 0 && !string.IsNullOrEmpty(filePath))
-            path = $"{_siteRoot}{filePath}";
-
-        return ReplacePath(path, _genericMediaPath, _mediaFolder);
-    }
-
-
-    /// <summary>
-    ///  makes a specific media path generic. 
-    /// </summary>
-    /// <remarks>
-    ///  sometimes paths may be defined by umbraco settings, (especially blob settings)
-    ///  that mean they are not stored as /media 
-    ///  
-    ///  for the sake of generic importing we want the folder stored to be /media. 
-    ///  so we re-write the setting on import and export 
-    ///  
-    ///  assumes you have a app setting in the web.config 
-    ///  
-    ///     <add key="uSync.mediaFolder">/someFolder</add>
-    ///
-    /// </remarks>
-    /// <returns></returns>
-    private static string ReplacePath(string filePath, string? currentPath, string? targetPath)
-    {
-        if (!string.IsNullOrWhiteSpace(targetPath)
-            && !string.IsNullOrWhiteSpace(currentPath)
-            && !currentPath.Equals(targetPath))
-        {
-            return Regex.Replace(filePath, $"^{currentPath}", targetPath, RegexOptions.IgnoreCase);
-        }
-
-        return filePath;
-    }
-
-    /// <summary>
-    ///  Get the media rewrite folder 
-    /// </summary>
-    /// <remarks>
-    ///     looks in appSettings for uSync:mediaFolder 
-    ///     
-    ///  <add key="uSync.mediaFolder" value="/something" />
-    /// 
-    ///  or in uSync8.config for media setting 
-    ///  
-    ///  <backoffice>
-    ///     <media>
-    ///         <folder>/someFolder</folder>
-    ///     </media>
-    ///  </backoffice>
-    /// </remarks>
-    private string GetMediaFolderSetting(string umbracoMediaPath)
-    {
-        var folder = this._configuration.GetValue<string>("uSync:MediaFolder", string.Empty);
-        if (!string.IsNullOrEmpty(folder)) return folder;
-
-        return umbracoMediaPath;
-    }
 
     public override Task<string?> GetImportValueAsync(string value, string editorAlias, SyncSerializerOptions options)
     {
@@ -201,50 +112,5 @@ public class ImagePathMapper : SyncValueMapperBase, ISyncMapper
 
             return json.SerializeJsonNode(true);
         });
-    }
-
-    /// <summary>
-    ///  Get the actual media file as a dependency. 
-    /// </summary>
-    public override Task<IEnumerable<uSyncDependency>> GetDependenciesAsync(object value, string editorAlias, DependencyFlags flags)
-    {
-        return uSyncTaskHelper.FromResultOf<IEnumerable<uSyncDependency>>(() =>
-        {
-
-            var stringValue = value?.ToString();
-            if (string.IsNullOrWhiteSpace(stringValue))
-                return [];
-
-            var stringPath = GetImagePath(stringValue).TrimStart('/').ToLower();
-
-            if (!string.IsNullOrWhiteSpace(stringPath))
-            {
-                return [new uSyncDependency()
-                {
-                    Name = $"File: {Path.GetFileName(stringPath)}",
-                    Udi = Udi.Create(Constants.UdiEntityType.MediaFile, stringPath),
-                    Flags = flags,
-                    Order = DependencyOrders.OrderFromEntityType(Constants.UdiEntityType.MediaFile),
-                    Level = 0
-                }];
-            }
-
-            return [];
-        });
-    }
-
-    private string GetImagePath(string stringValue)
-    {
-        if (stringValue.TryParseToJsonObject(out var json) is false || json is null)
-            return StripSitePath(stringValue);
-
-
-        if (json.TryGetPropertyValue("src", out var srcNode) is true)
-        {
-            var source = srcNode?.GetValue<string>() ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(source) is false) return source;
-        }
-
-        return string.Empty;
     }
 }

--- a/uSync.Core/Mapping/Mappers/ImagePathMapperBase.cs
+++ b/uSync.Core/Mapping/Mappers/ImagePathMapperBase.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using System.Text.RegularExpressions;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
+
+using uSync.Core.Dependency;
+using uSync.Core.Extensions;
+
+namespace uSync.Core.Mapping;
+
+public abstract class ImagePathMapperBase : SyncValueMapperBase
+{
+    private readonly IConfiguration _configuration;
+    protected readonly ILogger<ImagePathMapperBase> _logger;
+
+    private const string _genericMediaPath = "/media";
+    private readonly string _siteRoot;
+    private string? _mediaFolder;
+
+    public ImagePathMapperBase(
+        IEntityService entityService,
+        ILogger<ImagePathMapperBase> logger,
+        IConfiguration configuration,
+        IOptionsMonitor<GlobalSettings> globalOptions
+    ) : base(entityService)
+    {
+        _configuration = configuration;
+        _logger = logger;
+
+        // todo: site root might need us to include extra NuGet.
+        _siteRoot = "";
+
+        _mediaFolder = GetMediaFolderSetting(globalOptions.CurrentValue.UmbracoMediaPath.TrimStart('~'));
+        globalOptions.OnChange(x => _mediaFolder = GetMediaFolderSetting(x.UmbracoMediaPath.TrimStart('~')));
+
+        if (logger.IsEnabled(LogLevel.Debug))
+            logger.LogDebug("Media Folders: [{media}]", _mediaFolder ?? "(Blank)");
+
+    }
+
+
+    protected string StripSitePath(string filePath)
+    {
+        var path = filePath;
+        if (_siteRoot.Length > 0 && !string.IsNullOrWhiteSpace(filePath) && filePath.InvariantStartsWith(_siteRoot))
+            path = filePath.Substring(_siteRoot.Length);
+
+        return ReplacePath(path, _mediaFolder, _genericMediaPath);
+    }
+
+    protected string PrePendSitePath(string filePath)
+    {
+        var path = filePath;
+        if (_siteRoot.Length > 0 && !string.IsNullOrEmpty(filePath))
+            path = $"{_siteRoot}{filePath}";
+
+        return ReplacePath(path, _genericMediaPath, _mediaFolder);
+    }
+
+
+    /// <summary>
+    ///  makes a specific media path generic. 
+    /// </summary>
+    /// <remarks>
+    ///  sometimes paths may be defined by umbraco settings, (especially blob settings)
+    ///  that mean they are not stored as /media 
+    ///  
+    ///  for the sake of generic importing we want the folder stored to be /media. 
+    ///  so we re-write the setting on import and export 
+    ///  
+    ///  assumes you have a app setting in the web.config 
+    ///  
+    ///     <add key="uSync.mediaFolder">/someFolder</add>
+    ///
+    /// </remarks>
+    /// <returns></returns>
+    private static string ReplacePath(string filePath, string? currentPath, string? targetPath)
+    {
+        if (!string.IsNullOrWhiteSpace(targetPath)
+            && !string.IsNullOrWhiteSpace(currentPath)
+            && !currentPath.Equals(targetPath))
+        {
+            return Regex.Replace(filePath, $"^{currentPath}", targetPath, RegexOptions.IgnoreCase);
+        }
+
+        return filePath;
+    }
+
+    /// <summary>
+    ///  Get the media rewrite folder 
+    /// </summary>
+    /// <remarks>
+    ///     looks in appSettings for uSync:mediaFolder 
+    ///     
+    ///  <add key="uSync.mediaFolder" value="/something" />
+    /// 
+    ///  or in uSync8.config for media setting 
+    ///  
+    ///  <backoffice>
+    ///     <media>
+    ///         <folder>/someFolder</folder>
+    ///     </media>
+    ///  </backoffice>
+    /// </remarks>
+    private string GetMediaFolderSetting(string umbracoMediaPath)
+    {
+        var folder = this._configuration.GetValue<string>("uSync:MediaFolder", string.Empty);
+        if (!string.IsNullOrEmpty(folder)) return folder;
+
+        return umbracoMediaPath;
+    }
+
+    /// <summary>
+    ///  Get the actual media file as a dependency. 
+    /// </summary>
+    public override Task<IEnumerable<uSyncDependency>> GetDependenciesAsync(object value, string editorAlias, DependencyFlags flags)
+    {
+        return uSyncTaskHelper.FromResultOf<IEnumerable<uSyncDependency>>(() =>
+        {
+
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue))
+                return [];
+
+            var stringPath = GetImagePath(stringValue).TrimStart('/').ToLower();
+
+            if (!string.IsNullOrWhiteSpace(stringPath))
+            {
+                return [new uSyncDependency()
+                {
+                    Name = $"File: {Path.GetFileName(stringPath)}",
+                    Udi = Udi.Create(Constants.UdiEntityType.MediaFile, stringPath),
+                    Flags = flags,
+                    Order = DependencyOrders.OrderFromEntityType(Constants.UdiEntityType.MediaFile),
+                    Level = 0
+                }];
+            }
+
+            return [];
+        });
+    }
+
+    private string GetImagePath(string stringValue)
+    {
+        if (stringValue.TryParseToJsonObject(out var json) is false || json is null)
+            return StripSitePath(stringValue);
+
+
+        if (json.TryGetPropertyValue("src", out var srcNode) is true)
+        {
+            var source = srcNode?.GetValue<string>() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(source) is false) return source;
+        }
+
+        return string.Empty;
+    }
+}

--- a/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
+++ b/uSync.Core/Mapping/Mappers/ImageUploadMapper.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.Extensions;
+using uSync.Core.Serialization;
+
+namespace uSync.Core.Mapping;
+
+/// <summary>
+///  image uploads don't store any of the json, stuff, so they are similar to image croppers,
+///  but a bit simpler. 
+/// </summary>
+public class ImageUploadMapper : ImagePathMapperBase, ISyncMapper
+{
+    public ImageUploadMapper(
+        IEntityService entityService,
+        ILogger<ImagePathMapperBase> logger,
+        IConfiguration configuration,
+        IOptionsMonitor<GlobalSettings> globalOptions) : base(entityService, logger, configuration, globalOptions)
+    { }
+
+    public override string Name => "Image Upload Mapper";
+    public override string[] Editors => [Constants.PropertyEditors.Aliases.UploadField];
+    public override Task<string?> GetExportValueAsync(object value, string editorAlias)
+    {
+        return uSyncTaskHelper.FromResultOf(() =>
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Getting export value for ImageUpload with value {Value}", value);
+
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
+            return StripSitePath(stringValue);
+        });
+    }
+
+    public override Task<string?> GetImportValueAsync(string value, string editorAlias, SyncSerializerOptions options)
+    {
+        return uSyncTaskHelper.FromResultOf(() =>
+        {
+            var stringValue = value?.ToString();
+            if (string.IsNullOrWhiteSpace(stringValue)) return stringValue;
+            return PrePendSitePath(stringValue);
+        });
+    }
+}

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -86,9 +86,9 @@ public class MediaPicker3Mapper : SyncValueMapperBase, ISyncMapper
 
     private static Guid GetGuidValue(JsonObject obj, string key)
     {
-        if (obj != null && obj.ContainsKey(key))
+        if (obj != null && obj.TryGetPropertyValue(key, out JsonNode? node))
         {
-            if (obj[key]?.ToString().TryGetValueAs<Guid>(out var guid) is true)
+            if (node?.ToString().TryGetValueAs<Guid>(out var guid) is true)
                 return guid;
         }
 

--- a/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
+++ b/uSync.Core/Mapping/Mappers/MediaPicker3Mapper.cs
@@ -88,9 +88,8 @@ public class MediaPicker3Mapper : SyncValueMapperBase, ISyncMapper
     {
         if (obj != null && obj.ContainsKey(key))
         {
-            var attempt = obj[key]?.ToString().TryConvertTo<Guid>();
-            if (attempt?.Success is true)
-                return attempt?.Result ?? Guid.Empty;
+            if (obj[key]?.ToString().TryGetValueAs<Guid>(out var guid) is true)
+                return guid;
         }
 
         return Guid.Empty;

--- a/uSync.Core/Mapping/Mappers/MemberGroupPickerManager.cs
+++ b/uSync.Core/Mapping/Mappers/MemberGroupPickerManager.cs
@@ -3,6 +3,7 @@ using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 using uSync.Core.Dependency;
+using uSync.Core.Extensions;
 using uSync.Core.Serialization;
 
 using static Umbraco.Cms.Core.Constants;
@@ -30,11 +31,10 @@ public class MemberGroupPickerMapper : SyncValueMapperBase, ISyncMapper
     /// </summary>
     public override async Task<string?> GetExportValueAsync(object value, string editorAlias)
     {
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success is false || attempt.Result is null)
+        if (value.TryGetValueAs<string>(out var stringValue) is false)
             return await base.GetExportValueAsync(value, editorAlias);
 
-        var values = attempt.Result.ToDelimitedList().ConvertItems<int>();
+        var values = stringValue.ToDelimitedList().ConvertItems<int>();
 
         var groups = new List<string>();
 
@@ -86,11 +86,10 @@ public class MemberGroupPickerMapper : SyncValueMapperBase, ISyncMapper
             return Enumerable.Empty<uSyncDependency>();
 
         // get the int value and load the group
-        var attempt = value.TryConvertTo<string>();
-        if (attempt.Success is false || attempt.Result is null) 
+        if (value.TryGetValueAs<string>(out var stringValue) is false)
             return await base.GetDependenciesAsync(value, editorAlias, flags);
 
-        var values = attempt.Result.ToDelimitedList().ConvertItems<int>();
+        var values = stringValue.ToDelimitedList().ConvertItems<int>();
 
         var dependencies = new List<uSyncDependency>();
 

--- a/uSync.Core/Mapping/Mappers/MultiUrlMapper.cs
+++ b/uSync.Core/Mapping/Mappers/MultiUrlMapper.cs
@@ -39,7 +39,7 @@ public class MultiUrlMapper : SyncValueMapperBase, ISyncMapper
     // we need to just be able to read / manipulate the storage 
     // to make things generic .
     [DataContract]
-    internal class LinkDto
+    internal sealed class LinkDto
     {
         [DataMember(Name = "name")]
         public string? Name { get; set; }

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -69,7 +69,8 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
         // and prevent double-encoding when the block value is re-serialized.
         if (result is string stringResult && value.IsNonStringJsonValue())
         {
-            return stringResult.ConvertToJsonNode() ?? result;
+            return stringResult.ConvertStringToExpandedJson() ?? result;
+            // return stringResult.ConvertToJsonNode() ?? result;
         }
 
         return result;

--- a/uSync.Core/Mapping/SyncBlockMapperBase.cs
+++ b/uSync.Core/Mapping/SyncBlockMapperBase.cs
@@ -62,18 +62,11 @@ public abstract class SyncBlockMapperBase<TBlockValue> : SyncValueMapperBase
             _logger.LogDebug("Importing block value for {PropertyEditorAlias} {valueType}", propertyType.PropertyEditorAlias, value?.GetType().Name ?? "blank");
 
         var importString = SyncBlockMapperBase<TBlockValue>.GetStringValue(value) ?? string.Empty;
-        var result = await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
 
-        // When the original value was a non-string JSON type (array, object, number, etc.),
-        // convert string results back to JsonNode to preserve the correct JSON type
-        // and prevent double-encoding when the block value is re-serialized.
-        if (result is string stringResult && value.IsNonStringJsonValue())
-        {
-            return stringResult.ConvertStringToExpandedJson() ?? result;
-            // return stringResult.ConvertToJsonNode() ?? result;
-        }
-
-        return result;
+        // revert this back to the old way - we don't expand the json we get back because umbraco is very 
+        // sensitve to what the exact format of the blocks is, and if we expand them, then calls during render
+        // can return null. 
+        return await _mapperCollection.Value.GetImportValueAsync(importString, propertyType, options);
     }
 
     private async Task<object?> GetExportProperty(object? value, IPropertyType? propertyType, SyncSerializerOptions options)

--- a/uSync.Core/Mapping/SyncValueMapperBase.cs
+++ b/uSync.Core/Mapping/SyncValueMapperBase.cs
@@ -115,10 +115,7 @@ public abstract class SyncValueMapperBase
     protected static TObject? GetValueAs<TObject>(object value)
     {
         if (value == null) return default;
-        var attempt = value.TryConvertTo<TObject>();
-        if (!attempt) return default;
-
-        return attempt.Result;
+        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
     }
 }
 

--- a/uSync.Core/Mapping/SyncValueMapperBase.cs
+++ b/uSync.Core/Mapping/SyncValueMapperBase.cs
@@ -115,7 +115,7 @@ public abstract class SyncValueMapperBase
     protected static TObject? GetValueAs<TObject>(object value)
     {
         if (value == null) return default;
-        return value.TryConvertPreChecked<TObject>(out var result) ? result : default;
+        return value.TryGetValueAs<TObject>(out var result) ? result : default;
     }
 }
 

--- a/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
+++ b/uSync.Core/Roots/Configs/SyncConfigMergerBase.cs
@@ -160,8 +160,7 @@ internal abstract class SyncConfigMergerBase
                 // targetObject[property.Key] = JsonValue.Create(_inheritedValue);
 
                 // inherited is implicit.
-                if (targetObject.ContainsKey(property.Key)) 
-                    targetObject.Remove(property.Key);
+                targetObject.Remove(property.Key);
             }
         }
 
@@ -206,9 +205,9 @@ internal abstract class SyncConfigMergerBase
         for (int i = 0; i < targetArray.Count; i++)
         {
             if (targetArray[i] is not JsonObject targetObject) continue;
-            if (targetObject.ContainsKey(removeProperty) is false) continue;
+            if (targetObject.TryGetPropertyValue(removeProperty, out JsonNode? removal) is false) continue;
 
-            if (targetObject[removeProperty]!.ToString().StartsWith(_removedLabel) is true)
+            if (removal!.ToString().StartsWith(_removedLabel) is true)
             {
                 // we can't remove it while iterating, so add to a list. 
                 removals.Add(i);

--- a/uSync.Core/Serialization/Serializers/ContentSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializer.cs
@@ -774,7 +774,15 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         => Task.FromResult(contentService.GetById(id));
 
     public override Task SaveAsync(IEnumerable<IContent> items)
-        => Task.FromResult(contentService.Save(items));
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var result = contentService.Save(items);
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save content items: {result.Result}");
+            }
+        });
 
     public override async Task SaveItemAsync(IContent item)
         => await SaveItemAsync(item, -1);
@@ -785,11 +793,16 @@ public class ContentSerializer : ContentSerializerBase<IContent>, ISyncSerialize
         {
             try
             {
-                contentService.Save(item, userId);
+                var result = contentService.Save(item, userId);
+                if (result.Success is false)
+                {
+                    throw new InvalidOperationException(
+                        $"Could not save content {item.Name}: {result.Result}");
+                }
             }
             catch (ArgumentNullException ex)
             {
-                // we can get thrown a null argument exception by the notifier, 
+                // we can get thrown a null argument exception by the notifier,
                 // which is non critical! but we are ignoring this error. ! <= 8.1.5
                 if (!ex.Message.Contains("siteUri")) throw;
             }

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -140,6 +140,18 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
                     parentKey = parent.Key;
                     parentName = parent.Name;
                 }
+                else
+                {
+                    // the parent might not be of our object type (e.g a blueprint's
+                    // parent can be a DocumentBlueprintContainer, not a DocumentBlueprint)
+                    // so fall back to an untyped lookup rather than losing the parent entirely.
+                    var entity = syncMappers.EntityCache.GetEntity(item.ParentId);
+                    if (entity != null)
+                    {
+                        parentKey = entity.Key;
+                        parentName = entity.Name ?? parentName;
+                    }
+                }
             }
         }
 
@@ -315,6 +327,8 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         return SyncAttempt<TObject>.Succeed("No check", ChangeType.NoChange);
     }
 
+    protected virtual async Task<ITreeEntity?> CreateParentIfMissingAsync(XElement parentNode, string path) => null;
+
     protected virtual async Task<IEnumerable<uSyncChange>> DeserializeBaseAsync(TObject item, XElement node, SyncSerializerOptions options)
     {
         var info = node?.Element(uSyncConstants.Xml.Info);
@@ -354,6 +368,10 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
                             parent = await FindParentByPathAsync(friendlyPath);
                         }
                     }
+
+                    // last chance blueprints will create the missing containers. 
+                    parent ??= await CreateParentIfMissingAsync(parentNode,
+                        info?.Element(uSyncConstants.Xml.Path).ValueOrDefault(string.Empty) ?? string.Empty);
 
                     if (parent != null)
                     {
@@ -918,6 +936,21 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
                     (item.Name ?? item.Id.ToString()).ToSafeAlias(shortStringHelper));
             }
 
+            // some paths contain ids for items that are not of our object type
+            // (e.g a blueprint's parent can be a DocumentBlueprintContainer, not
+            // a DocumentBlueprint) - so for anything still unresolved, fall back
+            // to an untyped lookup rather than leaving the raw id in the path.
+            var unresolvedIds = lookups.Where(id => items.All(x => x.Id != id));
+            foreach (var id in unresolvedIds)
+            {
+                var entity = syncMappers.EntityCache.GetEntity(id);
+                if (entity == null) continue;
+
+                AddToNameCache(entity.Id, entity.Key, entity.Name ?? entity.Id.ToString());
+                friendlyPath = friendlyPath.Replace($"[{entity.Id}]",
+                    (entity.Name ?? entity.Id.ToString()).ToSafeAlias(shortStringHelper));
+            }
+
             return friendlyPath;
         }
         catch (Exception ex)
@@ -1007,9 +1040,18 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
     public override string ItemAlias(TObject item)
         => item.Name ?? item.Id.ToString();
 
-    protected async Task<TObject?> FindParentAsync(XElement node, bool searchByAlias = false)
+    protected virtual async Task<ITreeEntity?> FindItemAsTreeEntityAsync(Guid key)
+        => await FindItemAsync(key);
+
+    protected virtual async Task<ITreeEntity?> FindItemAsTreeEntityAsync(string alias)
+        => await FindItemAsync(alias);
+
+    protected virtual async Task<ITreeEntity?> FindByPathAsTreeEntityAsync(IEnumerable<string> folders, bool failIfNotExits)
+        => await FindByPathAsync(folders, failIfNotExits);
+
+    protected async Task<ITreeEntity?> FindParentAsync(XElement node, bool searchByAlias = false)
     {
-        var item = default(TObject);
+        var item = default(ITreeEntity);
 
         if (node == null) return default;
 
@@ -1019,7 +1061,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
             if (logger.IsEnabled(LogLevel.Trace))
                 logger.LogTrace("Looking for Parent by Key {Key}", key);
 
-            item = await FindItemAsync(key);
+            item = await FindItemAsTreeEntityAsync(key);
             if (item != null) return item;
         }
 
@@ -1032,7 +1074,7 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
 
             if (!string.IsNullOrEmpty(alias))
             {
-                item = await FindItemAsync(node.ValueOrDefault(alias));
+                item = await FindItemAsTreeEntityAsync(node.ValueOrDefault(alias));
             }
         }
 

--- a/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
+++ b/uSync.Core/Serialization/Serializers/ContentSerializerBase.cs
@@ -706,8 +706,8 @@ public abstract class ContentSerializerBase<TObject> : SyncTreeSerializerBase<TO
         if (current != null && newValue != null && current.GetType() != newValue.GetType())
         {
             var currentType = current.GetType();
-            var attempt = newValue.TryConvertTo(currentType);
-            if (attempt.Success) return !current.Equals(attempt.Result);
+            if (newValue.TryGetValueAs(currentType, out var converted))
+                return !current.Equals(converted);
         }
 
         return true;

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -252,6 +252,21 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
             contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
         });
 
+    /// <remarks>
+    ///  has to save via SaveBlueprint, the inherited ContentSerializer.SaveAsync would
+    ///  save through IContentService.Save, and that persists the item with the Document
+    ///  node object type - so the blueprint stops being a blueprint.
+    /// </remarks>
+    public override Task SaveAsync(IEnumerable<IContent> items)
+    {
+        foreach (var item in items)
+        {
+            contentService.SaveBlueprint(item, null, Constants.Security.SuperUserId);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public override Task DeleteItemAsync(IContent item)
         => uSyncTaskHelper.FromResultOf(() =>
         {

--- a/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTemplateSerializer.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Entities;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
 
 using uSync.Core.Documents;
 using uSync.Core.Extensions;
@@ -19,6 +20,7 @@ namespace uSync.Core.Serialization.Serializers;
 public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<IContent>
 {
     private readonly IContentTypeService _contentTypeService;
+    private readonly IContentBlueprintContainerService _containerService;
 
     public ContentTemplateSerializer(
         IEntityService entityService,
@@ -31,10 +33,12 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
         SyncValueMapperCollection syncMappers,
         IUserService userService,
         ITemplateService templateService,
-        ISyncDocumentUrlCleaner urlCleaner)
+        ISyncDocumentUrlCleaner urlCleaner,
+        IContentBlueprintContainerService containerService)
         : base(entityService, languageService, relationService, shortStringHelper, logger, contentService, syncMappers, userService, templateService, urlCleaner)
     {
         _contentTypeService = contentTypeService;
+        _containerService = containerService;
         this.umbracoObjectType = UmbracoObjectTypes.DocumentBlueprint;
     }
 
@@ -115,6 +119,7 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
             // TODO: Umbraco 8 bug, the key is sometimes an old version
             var entity = entityService.Get(key);
             if (entity != null)
+
                 return contentService.GetBlueprintById(entity.Id);
 
             return null;
@@ -129,18 +134,104 @@ public class ContentTemplateSerializer : ContentSerializer, ISyncSerializer<ICon
             if (contentType == null) return
                     Attempt.Fail<IContent?>(null, new ArgumentException($"Missing content Type {itemType}"));
 
-            IContent item;
-            if (parent != null)
+            // parent can be either an existing blueprint (unlikely) or the
+            // DocumentBlueprintContainer (folder) the blueprint lives in, so
+            // we create by id rather than assuming it's always an IContent.
+            var item = new Content(alias, parent?.Id ?? -1, contentType);
+
+            return Attempt.Succeed<IContent?>(item);
+        });
+    }
+
+    protected override async Task<Attempt<IContent?>> FindOrCreateAsync(XElement node)
+    {
+        var item = await FindItemAsync(node);
+        if (item is not null) return Attempt.Succeed(item);
+
+        var info = node.Element(uSyncConstants.Xml.Info);
+        var alias = node.GetAlias();
+
+        var parentNode = info?.Element(uSyncConstants.Xml.Parent);
+        var parentKey = parentNode?.Attribute(uSyncConstants.Xml.Key).ValueOrDefault(Guid.Empty) ?? Guid.Empty;
+
+        ITreeEntity? parent = null;
+
+        if (parentKey != Guid.Empty)
+        {
+            item = await FindItemAsync(alias, parentKey);
+            if (item is not null) return Attempt.Succeed(item);
+
+            parent = await FindItemAsTreeEntityAsync(parentKey);
+            
+            // the parent might not be another blueprint, but the
+            // DocumentBlueprintContainer (folder) the blueprint lives in.
+            parent ??= await FindOrCreateContainerAsync(parentKey, parentNode?.Value ?? string.Empty,
+                info?.Element(uSyncConstants.Xml.Path).ValueOrDefault(string.Empty) ?? string.Empty);
+        }
+
+        var contentTypeAlias = info?.Element("ContentType").ValueOrDefault(node.Name.LocalName) ?? node.Name.LocalName;
+
+        return await CreateItemAsync(alias, parent, contentTypeAlias);
+    }
+
+
+    protected override async Task<ITreeEntity?> FindItemAsTreeEntityAsync(Guid key)
+        => await base.FindItemAsTreeEntityAsync(key) ?? await FindContainerAsync(key);
+
+    private async Task<EntityContainer?> FindContainerAsync(Guid key)
+        => await _containerService.GetAsync(key);
+
+    protected override async Task<ITreeEntity?> CreateParentIfMissingAsync(XElement parentNode, string path)
+    {
+        var key = parentNode.Attribute(uSyncConstants.Xml.Key).ValueOrDefault(Guid.Empty);
+        var name = parentNode.ValueOrDefault(string.Empty);
+        if (key == Guid.Empty || string.IsNullOrEmpty(name)) return null;
+
+        return await FindOrCreateContainerAsync(key, name, path);
+    }
+   
+    /// <summary>
+    ///  find (or create) the DocumentBlueprintContainer folder chain for a blueprint,
+    ///  the same way missing folders get created on the way in for content types / data types.
+    /// </summary>
+    private async Task<EntityContainer?> FindOrCreateContainerAsync(Guid key, string name, string friendlyPath)
+    {
+        var container = await FindContainerAsync(key);
+        if (container is not null) return container;
+
+        if (string.IsNullOrWhiteSpace(name)) return null;
+
+        // the friendly path is '/folder/folder/blueprintName' - the folder chain
+        // is everything except the blueprint's own name at the end.
+        var folderNames = friendlyPath.ToDelimitedList("/").ToList();
+        if (folderNames.Count > 0) folderNames.RemoveAt(folderNames.Count - 1);
+        if (folderNames.Count == 0) folderNames.Add(name);
+
+        EntityContainer? parent = null;
+
+        for (var index = 0; index < folderNames.Count; index++)
+        {
+            var folderName = folderNames[index];
+            var isTargetFolder = index == folderNames.Count - 1;
+
+            var existing = (await _containerService.GetAsync(folderName, index + 1))
+                .FirstOrDefault(x => x.Name.InvariantEquals(folderName) &&
+                    (parent == null || x.ParentId == parent.Id));
+
+            if (existing is not null)
             {
-                item = new Content(alias, (IContent)parent, contentType);
-            }
-            else
-            {
-                item = new Content(alias, -1, contentType);
+                parent = existing;
+                continue;
             }
 
-            return Attempt.Succeed(item);
-        });
+            var containerKey = isTargetFolder ? key : Guid.NewGuid();
+            var attempt = await _containerService.CreateAsync(containerKey, folderName, parent?.Key, Constants.Security.SuperUserKey);
+            if (!attempt.Success || attempt.Result is null) return parent;
+
+            parent = attempt.Result;
+        }
+
+        return parent;
     }
 
     protected override Task<SyncContentUpdateResult> DoSaveOrPublishAsync(IContent item, XElement node, SyncSerializerOptions options)

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -770,7 +770,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         return [];
     }
 
-    private class TabInfo
+    private sealed class TabInfo
     {
         public TabInfo(string alias)
         {
@@ -1012,8 +1012,8 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         if (tabNode == null) return [];
 
         var newTabs = tabNode.Elements("Tab")
-            .Select(x => GetTabAliasFromTabGroup(x))
-            .ToList();
+            .Select(GetTabAliasFromTabGroup)
+            .ToArray();
 
         var inheritedTabs =
             item.ContentTypeComposition
@@ -1151,7 +1151,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         return false;
     }
 
-    private class PropertyTypeResult
+    private sealed class PropertyTypeResult
     {
         public bool IsNew { get; set; }
         public IPropertyType? Property { get; set; }

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -153,17 +153,15 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         {
             var value = propertyInfo.GetValue(property);
 
-            var attempt = value.TryConvertTo<TValue>();
-            if (attempt.Success)
+            // TryGetValueAs treats a null conversion result as failure, so fall back
+            // to an empty element - the property still gets recorded in the xml.
+            if (value.TryGetValueAs<TValue>(out var converted))
             {
-                if (attempt.Result != null)
-                {
-                    node.Add(new XElement(propertyName, attempt.Result));
-                }
-                else
-                {
-                    node.Add(new XElement(propertyName, string.Empty));
-                }
+                node.Add(new XElement(propertyName, converted));
+            }
+            else
+            {
+                node.Add(new XElement(propertyName, string.Empty));
             }
         }
     }
@@ -727,19 +725,18 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         if (propertyInfo != null)
         {
             var value = node.Element(propertyName).ValueOrDefault(string.Empty);
-            var attempt = value.TryConvertTo<TValue>();
-            if (attempt.Success)
+            if (value.TryGetValueAs<TValue>(out var converted))
             {
                 var current = ContentTypeBaseSerializer<TObject>.GetPropertyAs<TValue>(propertyInfo, property);
 
-                if (current == null || !current.Equals(attempt.Result))
+                if (current == null || !current.Equals(converted))
                 {
-                    propertyInfo.SetValue(property, attempt.Result);
+                    propertyInfo.SetValue(property, converted);
 
                     return uSyncChange.Update($"property/{propertyName}",
                         propertyName,
                         current.ToNonBlankValue(),
-                        attempt.Result?.ToString());
+                        converted?.ToString());
                 }
             }
         }
@@ -754,12 +751,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         var value = info.GetValue(property);
         if (value == null) return default;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result;
-
-        return default;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : default;
     }
 
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -426,7 +426,8 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
         /// so we store them and do them once we've put 
         /// things in. 
         List<uSyncChange> changes = [];
-        Dictionary<string, string> propertiesToMove = [];
+        // value can be null - when the property is being moved out of all groups.
+        Dictionary<string, string?> propertiesToMove = [];
 
         List<string>? compositeProperties = default;
 
@@ -569,6 +570,15 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
                     {
                         logger.LogWarning("Cannot find tab {alias} to add {property} to", tabAlias, result.Property.Alias);
                         changes.AddWarning(alias, name, $"Unable to find tab {tabAlias} to add property too");
+                    }
+                }
+                else
+                {
+                    // no tab in the config - the property has been moved out of
+                    // any group. if it is currently in one, move it out (issue #1009)
+                    if (item.PropertyGroups.Any(x => x.PropertyTypes?.Contains(result.Property.Alias) is true))
+                    {
+                        propertiesToMove[result.Property.Alias] = null;
                     }
                 }
             }
@@ -1232,12 +1242,27 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
     }
 
 
-    private static IEnumerable<uSyncChange> MoveProperties(IContentTypeBase item, IDictionary<string, string> moves)
+    private static IEnumerable<uSyncChange> MoveProperties(IContentTypeBase item, IDictionary<string, string?> moves)
     {
         foreach (var move in moves)
         {
-            item.MovePropertyType(move.Key, move.Value);
-            yield return uSyncChange.Update($"{move.Key}/Tab/{move.Value}", move.Key, "", move.Value);
+            if (move.Value is null)
+            {
+                // moving the property out of all groups. MovePropertyType(alias, null)
+                // removes it from its current group but does *not* re-add it to the
+                // 'no group' collection, leaving it orphaned - so the change does not
+                // stick until a second import. We re-home it explicitly. (issue #1009)
+                var property = item.PropertyTypes.FirstOrDefault(x => x.Alias.InvariantEquals(move.Key));
+                item.MovePropertyType(move.Key, null!);
+                if (property is not null && item.PropertyTypes.Any(x => x.Alias.InvariantEquals(move.Key)) is false)
+                    item.AddPropertyType(property);
+            }
+            else
+            {
+                item.MovePropertyType(move.Key, move.Value);
+            }
+
+            yield return uSyncChange.Update($"{move.Key}/Tab/{move.Value}", move.Key, "", move.Value ?? "(No group)");
         }
     }
 

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1395,13 +1395,14 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
             return;
         }
 
-        if (item.Id <= 0)
+        var attempt = item.Id <= 0
+            ? await _baseService.CreateAsync(item, Constants.Security.SuperUserKey)
+            : await _baseService.UpdateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
         {
-            await _baseService.CreateAsync(item, Constants.Security.SuperUserKey);
-        }
-        else
-        {
-            await _baseService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            throw new InvalidOperationException(
+                $"Could not save {typeof(TObject).Name} {item.Alias}: {attempt.Result}");
         }
 
         //if (item.IsDirty()) _baseService.Save(item);

--- a/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeBaseSerializer.cs
@@ -1444,7 +1444,7 @@ public abstract class ContentTypeBaseSerializer<TObject> : SyncContainerSerializ
     public bool TabClashesWithExisting(TObject item, string alias, PropertyGroupType tabType)
     {
         EnsureAllTabsCacheLoaded(item);
-        return _allTabs?.ContainsKey(alias) is true && _allTabs?[alias] != tabType;
+        return _allTabs?.TryGetValue(alias, out PropertyGroupType aliasTab) is true && aliasTab != tabType;
     }
 
     public void EnsureAllTabsCacheLoaded(TObject item)

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -409,15 +409,14 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
                 var current = GetPropertyAs<string>(property, historyCleanup);
                 if (element.Value != current)
                 {
-                    // now set it. 
-                    var updatedValue = element.Value.TryConvertTo(property.PropertyType);
-                    if (updatedValue.Success)
+                    // now set it.
+                    if (element.Value.TryGetValueAs(property.PropertyType, out var updatedValue))
                     {
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.LogDebug("Saving HistoryCleanup Value: {name} {value}", element.Name.LocalName, updatedValue.Result);
+                            logger.LogDebug("Saving HistoryCleanup Value: {name} {value}", element.Name.LocalName, updatedValue);
 
-                        changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current.ToNonBlankValue(), updatedValue.Result, $"{_historyCleanupName}/{element.Name.LocalName}");
-                        property.SetValue(historyCleanup, updatedValue.Result);
+                        changes.AddUpdate($"{_historyCleanupName}:{element.Name.LocalName}", current.ToNonBlankValue(), updatedValue, $"{_historyCleanupName}/{element.Name.LocalName}");
+                        property.SetValue(historyCleanup, updatedValue);
                     }
                 }
             }
@@ -451,11 +450,6 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
         var value = info.GetValue(property);
         if (value is null) return default;
 
-        var result = value.TryConvertTo<TValue>();
-        if (result.Success)
-            return result.Result;
-
-        return default;
-
+        return value.TryGetValueAs<TValue>(out var result) ? result : default;
     }
 }

--- a/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/ContentTypeSerializer.cs
@@ -204,7 +204,12 @@ public class ContentTypeSerializer : ContentTypeBaseSerializer<IContentType>, IS
                 logger.LogDebug("Saving in Serializer because item is dirty [{properties}]", dirty);
 
 
-            await _contentTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            var attempt = await _contentTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save content type {item.Alias}: {attempt.Result}");
+            }
         }
 
         await CleanFolderAsync(item, node);

--- a/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -366,10 +366,15 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
         // see : https://github.com/umbraco/Umbraco-CMS/issues/19732
         // if (item.IsDirty() is false) return;
 
-        if (item.HasIdentity is true)
-            await _dataTypeService.UpdateAsync(item, Constants.Security.SuperUserKey);
-        else
-            await _dataTypeService.CreateAsync(item, Constants.Security.SuperUserKey);
+        var attempt = item.HasIdentity is true
+            ? await _dataTypeService.UpdateAsync(item, Constants.Security.SuperUserKey)
+            : await _dataTypeService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save data type {item.Name}: {attempt.Status}");
+        }
     }
 
     public override async Task SaveAsync(IEnumerable<IDataType> items)

--- a/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DataTypeSerializer.cs
@@ -119,7 +119,7 @@ public class DataTypeSerializer : SyncContainerSerializerBase<IDataType>, ISyncS
             // use the configuration serializers to track the rename.
             // uSync.migrations can use this to hook into the rename here, so we don't 
             // have to track it in the core. 
-            await _configurationSerializers.TrackRenamedEditorAsync(item.EditorAlias, editorAlias);
+            await _configurationSerializers.TrackRenamedEditorAsync(editorAlias, item.EditorAlias);
 
             if (editor is not null)
             {

--- a/uSync.Core/Serialization/Serializers/DictionaryItemSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DictionaryItemSerializer.cs
@@ -228,9 +228,17 @@ public class DictionaryItemSerializer : SyncSerializerBase<IDictionaryItem>, ISy
     }
 
     public override async Task SaveItemAsync(IDictionaryItem item)
-        => _ = item.HasIdentity
+    {
+        var attempt = item.HasIdentity
             ? await _dictionaryItemService.UpdateAsync(item, Constants.Security.SuperUserKey)
             : await _dictionaryItemService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save dictionary item {item.ItemKey}: {attempt.Status}");
+        }
+    }
 
     public override Task DeleteItemAsync(IDictionaryItem item)
         => _dictionaryItemService.DeleteAsync(item.Key, Constants.Security.SuperUserKey);

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -167,8 +167,7 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
 
         var result = property.GetValue(item);
 
-        var attempt = result.TryConvertTo<int>();
-        return attempt.Success ? attempt.Result : 0;
+        return result.TryGetValueAs<int>(out var sortable) ? sortable : 0;
     }
 
     /// <summary>

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -349,7 +349,7 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
         await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
     }
 
-    private class DomainSyncModel
+    private sealed class DomainSyncModel
     {
         public required Guid Key { get; set; }
         public required string DomainName { get; set; }

--- a/uSync.Core/Serialization/Serializers/DomainSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/DomainSerializer.cs
@@ -346,7 +346,12 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
                 })
         };
 
-        await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
+        var attempt = await _domainService.UpdateDomainsAsync(contentKey.Result, updateModel);
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save domain {item.DomainName}: {attempt.Status}");
+        }
     }
 
     private sealed class DomainSyncModel
@@ -366,7 +371,12 @@ public class DomainSerializer : SyncSerializerBase<IDomain>, ISyncSerializer<IDo
         var existing = await _domainService.GetAssignedDomainsAsync(contentKey.Result, true);
         var remaining = existing.Where(x => x.Key != item.Key).Select(x => new DomainModel { DomainName = x.DomainName, IsoCode = x.LanguageIsoCode! });
 
-        await _domainService.UpdateDomainsAsync(contentKey.Result, new DomainsUpdateModel { Domains = remaining });
+        var attempt = await _domainService.UpdateDomainsAsync(contentKey.Result, new DomainsUpdateModel { Domains = remaining });
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not remove domain {item.DomainName}: {attempt.Status}");
+        }
     }
 
 

--- a/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/LanguageSerializer.cs
@@ -152,9 +152,17 @@ public class LanguageSerializer : SyncSerializerBase<ILanguage>, ISyncSerializer
         => Task.FromResult(default(ILanguage));
 
     public override async Task SaveItemAsync(ILanguage item)
-        => _ = item.HasIdentity
+    {
+        var attempt = item.HasIdentity
             ? await _languageService.UpdateAsync(item, Constants.Security.SuperUserKey)
             : await _languageService.CreateAsync(item, Constants.Security.SuperUserKey);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save language {item.IsoCode}: {attempt.Status}");
+        }
+    }
 
     public override Task DeleteItemAsync(ILanguage item)
         => _languageService.DeleteAsync(item.IsoCode, Constants.Security.SuperUserKey);

--- a/uSync.Core/Serialization/Serializers/MediaSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/MediaSerializer.cs
@@ -227,13 +227,37 @@ public class MediaSerializer : ContentSerializerBase<IMedia>, ISyncSerializer<IM
     }
 
     public override Task SaveAsync(IEnumerable<IMedia> items)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Save(items); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Save(items);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save media items: {attempt.Result?.Result}");
+            }
+        });
 
     public override Task SaveItemAsync(IMedia item)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Save(item); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Save(item);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save media {item.Name}: {attempt.Result?.Result}");
+            }
+        });
 
     public override Task DeleteItemAsync(IMedia item)
-        => uSyncTaskHelper.FromResultOf(() => { return _mediaService.Delete(item); });
+        => uSyncTaskHelper.FromResultOf(() =>
+        {
+            var attempt = _mediaService.Delete(item);
+            if (attempt.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not delete media {item.Name}: {attempt.Result?.Result}");
+            }
+        });
 
     protected override Task<IMedia?> FindParentByIdAsync(int id)
         => Task.FromResult(_mediaService.GetById(id));

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -355,9 +355,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 logger.LogDebug("Saving: {alias} {path}", item.Alias, item.Path);
 
             var result = await _templateService.UpdateAsync(item, userKey);
-            
+
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
+
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save template {item.Alias}: {result.Status}");
+            }
         }
         else
         {
@@ -365,9 +371,15 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 logger.LogDebug("Creating: {alias} {path}", item.Alias, item.Path);
 
             var result = await _templateService.CreateAsync(item.Name ?? item.Alias, item.Alias, item.Content, userKey, item.Key);
-            
+
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("Update Template Result: [{key}] {result} {status}", item.Key, result.Success, result.Status);
+
+            if (result.Success is false)
+            {
+                throw new InvalidOperationException(
+                    $"Could not save template {item.Alias}: {result.Status}");
+            }
         }
     }
 

--- a/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/TemplateSerializer.cs
@@ -102,8 +102,10 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
                 contentAttempt.Result,
                 userKey, key);
 
-            if (attempt.Success is false)
-                return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template");
+            if (attempt.Success is false) 
+                return SyncAttempt<ITemplate>.Fail(name, attempt.Result, ChangeType.Import,
+                    $"Failed to create template: {attempt.Status}",
+                    new InvalidOperationException($"Failed to create template '{alias}': {attempt.Status} {attempt.Exception?.Message ?? "Unknown error"}"));
 
             item = attempt.Result;
             details.AddNew(alias, alias, "Template");
@@ -113,13 +115,6 @@ public class TemplateSerializer : SyncSerializerBase<ITemplate>, ISyncSerializer
 
             // don't need to go through the process, the create also saves it.
             return SyncAttempt<ITemplate>.Succeed(name, item, ChangeType.Import, "Created", true, details);
-        }
-
-        if (item is null)
-        {
-            // creating went wrong
-            logger.LogWarning("Failed to create template");
-            return SyncAttempt<ITemplate>.Fail(name, ChangeType.Import, "Failed to create template");
         }
 
         if (item.Key != key)

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -50,7 +50,17 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
     /// <inheritdoc/>
     /// 
     public override async Task SaveItemAsync(IWebhook item)
-        => _ = item.HasIdentity ? await _webhookService.UpdateAsync(item) : await _webhookService.CreateAsync(item);
+    {
+        var attempt = item.HasIdentity
+            ? await _webhookService.UpdateAsync(item)
+            : await _webhookService.CreateAsync(item);
+
+        if (attempt.Success is false)
+        {
+            throw new InvalidOperationException(
+                $"Could not save webhook {item.Key}: {attempt.Status}");
+        }
+    }
 
     /// <inheritdoc/>
     protected override async Task<SyncAttempt<IWebhook>> DeserializeCoreAsync(XElement node, SyncSerializerOptions options)

--- a/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
+++ b/uSync.Core/Serialization/Serializers/WebhookSerializer.cs
@@ -189,8 +189,7 @@ public class WebhookSerializer : SyncSerializerBase<IWebhook>, ISyncSerializer<I
             var headerValue = header.ValueOrDefault(string.Empty);
 
             if (headerKey == string.Empty) continue;
-            if (newHeaders.ContainsKey(headerKey)) continue; // stop duplicates.
-            newHeaders.Add(headerKey, headerValue);
+            newHeaders.TryAdd(headerKey, headerValue); // stop duplicates.
         }
 
         var existingOrderedEvents = item.Headers.OrderBy(x => x.Key).ToDictionary();

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -74,7 +74,7 @@ public class SyncSerializerOptions
     {
         if (this.Settings?.TryGetValue(key, out var value) is true && value is not null)
         {
-            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+            if (value.TryGetValueAs<TResult>(out var result) && result is not null)
                 return result;
         }
 

--- a/uSync.Core/Serialization/SyncSerializerOptions.cs
+++ b/uSync.Core/Serialization/SyncSerializerOptions.cs
@@ -2,6 +2,8 @@
 
 using Umbraco.Extensions;
 
+using uSync.Core.Extensions;
+
 namespace uSync.Core.Serialization;
 
 /// <summary>
@@ -70,11 +72,10 @@ public class SyncSerializerOptions
 
     public TResult GetSetting<TResult>(string key, TResult defaultValue)
     {
-        if (this.Settings?.TryGetValue(key, out var value) is true)
+        if (this.Settings?.TryGetValue(key, out var value) is true && value is not null)
         {
-            var attempt = value.TryConvertTo<TResult>();
-            if (attempt.Success && attempt.Result is not null)
-                return attempt.Result;
+            if (value.TryConvertPreChecked<TResult>(out var result) && result is not null)
+                return result;
         }
 
         return defaultValue;

--- a/uSync.Core/Serialization/SyncTreeSerializerBase.cs
+++ b/uSync.Core/Serialization/SyncTreeSerializerBase.cs
@@ -88,7 +88,7 @@ public abstract class SyncTreeSerializerBase<TObject> : SyncSerializerBase<TObje
     /// <summary>
     ///  calculates the Umbraco Path value for an item, based on the parent
     /// </summary>
-    protected string CalculateNodePath(TObject item, TObject? parent)
+    protected string CalculateNodePath(TObject item, ITreeEntity? parent)
     {
         if (parent == null)
         {
@@ -103,7 +103,7 @@ public abstract class SyncTreeSerializerBase<TObject> : SyncSerializerBase<TObje
     /// <summary>
     ///  calculates the Level based on the parent.
     /// </summary>
-    protected int CalculateNodeLevel(TObject item, TObject? parent)
+    protected int CalculateNodeLevel(TObject item, ITreeEntity? parent)
     {
         if (parent == null)
         {

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.4",
+  "version": "17.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.4",
+      "version": "17.3.5",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.95.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -12,7 +12,7 @@
         "@jumoo/translate": "^17.2.3",
         "@jumoo/usync": "^17.0.4",
         "@rollup/plugin-node-resolve": "^15.3.1",
-        "@umbraco-cms/backoffice": "^17.3.0",
+        "@umbraco-cms/backoffice": "^17.5.0-rc",
         "chalk": "^5.6.2",
         "lit": "^3.3.2",
         "node-fetch": "^3.3.2",
@@ -303,14 +303,6 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
-    },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -623,9 +615,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.16.0.tgz",
-      "integrity": "sha512-XegRaNuoQ/guzBQU2xHxOwFXXrtoXW9tiyXDhssSqylvZmBVSlRIPNHA6ArkHBKm6ehLf6+6Y9fF3uky1yCXYQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
+      "integrity": "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -634,13 +626,180 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.16.0"
+        "@tiptap/pm": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.1.tgz",
+      "integrity": "sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.1.tgz",
+      "integrity": "sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.1.tgz",
+      "integrity": "sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.1.tgz",
+      "integrity": "sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
+      "integrity": "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.1.tgz",
+      "integrity": "sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.1.tgz",
+      "integrity": "sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.1.tgz",
+      "integrity": "sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.1.tgz",
+      "integrity": "sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.1.tgz",
+      "integrity": "sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.1.tgz",
+      "integrity": "sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.16.0.tgz",
-      "integrity": "sha512-mTjt4kdyVtY/2dJcfxAgBae/dkH+r6GwARl7NlPtnI3EzpELFR65FNuOQyTxFXP3yfV9uMtPpq6Wevk8aLTsxQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.27.1.tgz",
+      "integrity": "sha512-+JTahgQT+NxiGjduaB3qJVyhU/wh4m3pVkht1Earioku2bm/apj5Lb8rSowa/NJYP3B+oQgV/V4YLw5dtDgBoA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -649,13 +808,138 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0"
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.1.tgz",
+      "integrity": "sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.1.tgz",
+      "integrity": "sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
+      "integrity": "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.1.tgz",
+      "integrity": "sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.1.tgz",
+      "integrity": "sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.1.tgz",
+      "integrity": "sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.1.tgz",
+      "integrity": "sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.1.tgz",
+      "integrity": "sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.16.0.tgz",
-      "integrity": "sha512-CQbX7RQRh7+KHbg9ir0rusVvCx+MM8KsUXE1M1Lh4uqWHo3EwtzeLGaK3S66IxXzKQShuyfngAIXHoop2fq5Bg==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.27.1.tgz",
+      "integrity": "sha512-A8bokr7c7QBndZcMX0F4AK1y4xEYd5MvOczojFusaiTfvAnH3D8PwFbOPQs3ZLB8W9K3bn4g/XH55P1IAPFGyg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -664,14 +948,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/pm": "^3.16.0"
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-superscript": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.16.0.tgz",
-      "integrity": "sha512-WQXingnt9+UwPWggxU1cI4XVYCkjxpcqEgnPzCZL4dcIaoooan+kDbZ/opD9Emy+RFn/IEaXdFj8FHJNbyBFtQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.27.1.tgz",
+      "integrity": "sha512-8021uld246dqhtzZdzjvnWcfiJwElPQ50zZe7Fc3QGFiNRDVWQ2ATXGJFmXEopgCU5GuZaytPMtAq4UVDXc6xw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -680,14 +964,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/pm": "^3.16.0"
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.16.0.tgz",
-      "integrity": "sha512-m7h7YdffWxI0lglKUfR+39UD9psOprn/E4qYzjxOSXl1rg8DnP6zi8LF+5X+v32my9WBbizXxVBIdy8AuDWxAw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.27.1.tgz",
+      "integrity": "sha512-tNB8kjxo0+XPremnWkd6NUikpeJ+JQrss7HntL8GgIxX4t0gkdnLn9yUWb0JzcaYP7Y8iTZZHdkPs0P154DG8Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -696,14 +980,29 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/pm": "^3.16.0"
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.1.tgz",
+      "integrity": "sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.16.0.tgz",
-      "integrity": "sha512-+9mgmd9rSM394/wwBBcxLW9/xzz66j+vUSYMeWcZFC0so/jibu4HcW1lPqKJfQ2F6xAD/xe4cQfckvpdjQaR1Q==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.27.1.tgz",
+      "integrity": "sha512-EXawuJBO55wd8WcTbHTMoPhv0CGQxza4yCCPB5Hqz4ZPQwahIr3ej+8yp/kimIl0xokabwZ0/Fu8STQ4AkZv5g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -712,13 +1011,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0"
+        "@tiptap/core": "3.27.1"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.16.0.tgz",
-      "integrity": "sha512-D+gIqMvCDYTCvnOVpFwfqjSi0UVAbe/9jXP765WlZsN5SOZm4tGOCo+AGxdxReWHsfteM+bdxaK6It1EDRrmiA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz",
+      "integrity": "sha512-J48WIl+6YDYTFPhWXUBQk+u7+AKVUqTdvrZOQyPYCGuQMgHrYzgWrI5+HeEifUgXJ5rMIWWP3qytp7KhVVqpDQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -727,13 +1026,28 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0"
+        "@tiptap/core": "3.27.1"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.1.tgz",
+      "integrity": "sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.27.1"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.16.0.tgz",
-      "integrity": "sha512-0iVrn0FHcHIRMdsQLQbf16NgYrKz+Sup/8dDMVBy1QoHn5Hb51QZABqXJTZ6u7My34b4fNZrSggzBAE7l7N/pA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
+      "integrity": "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -742,36 +1056,31 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/pm": "^3.16.0"
+        "@tiptap/core": "3.27.1",
+        "@tiptap/pm": "3.27.1"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.16.0.tgz",
-      "integrity": "sha512-FMxZ6Tc5ONKa/EByDV8lswct6YW2lF/wn11zqXmrfBZhdG7UQPTijpSwb6TCqaO5GOHmixaIaDPj+zimUREHQA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
+      "integrity": "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
         "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.7",
         "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.0",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.8"
       },
       "funding": {
         "type": "github",
@@ -779,422 +1088,37 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.16.0.tgz",
-      "integrity": "sha512-eWi+77SgKyhSx91Hmn32ER+gPN6FfInGtod4A+XxSG+LqS/sn6kpUEdowYrnqiZzhUXZCSTSJvC+UcMUZHOkxQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.1.tgz",
+      "integrity": "sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/extension-blockquote": "^3.16.0",
-        "@tiptap/extension-bold": "^3.16.0",
-        "@tiptap/extension-bullet-list": "^3.16.0",
-        "@tiptap/extension-code": "^3.16.0",
-        "@tiptap/extension-code-block": "^3.16.0",
-        "@tiptap/extension-document": "^3.16.0",
-        "@tiptap/extension-dropcursor": "^3.16.0",
-        "@tiptap/extension-gapcursor": "^3.16.0",
-        "@tiptap/extension-hard-break": "^3.16.0",
-        "@tiptap/extension-heading": "^3.16.0",
-        "@tiptap/extension-horizontal-rule": "^3.16.0",
-        "@tiptap/extension-italic": "^3.16.0",
-        "@tiptap/extension-link": "^3.16.0",
-        "@tiptap/extension-list": "^3.16.0",
-        "@tiptap/extension-list-item": "^3.16.0",
-        "@tiptap/extension-list-keymap": "^3.16.0",
-        "@tiptap/extension-ordered-list": "^3.16.0",
-        "@tiptap/extension-paragraph": "^3.16.0",
-        "@tiptap/extension-strike": "^3.16.0",
-        "@tiptap/extension-text": "^3.16.0",
-        "@tiptap/extension-underline": "^3.16.0",
-        "@tiptap/extensions": "^3.16.0",
-        "@tiptap/pm": "^3.16.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/core": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.5.tgz",
-      "integrity": "sha512-Pkjd41UJ4F6Z8cPV+gEvqnt1VhY2g66xMjbpxREs0ECA5jRezCNKSZcc2pueQRTMtmn1SaSzGM9U/ifhVlVYOA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-blockquote": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.20.5.tgz",
-      "integrity": "sha512-0wU6H/MWWes0rGzgSW6MMU6YDs/3ofUDkqmqCqmb+Siu1ZD0bpzOYpBtujgOYDY8moB9+zCE3G9HSYGcmZxHew==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bold": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.20.5.tgz",
-      "integrity": "sha512-hraiiWkF58n8Jy0Wl3OGwjCTrGWwZZxez/IlexrzKQ/nMFdjDpensZucWwu59zhAM9fqZwGSLDtCFuak03WKnA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.20.5.tgz",
-      "integrity": "sha512-MT3321R6F8AoVUEMJ5RiI0PQMenwvtmrSXoO1ehPCWq5TrSJLyXeZMJvZU+1CgfXk4XQU70RN78ib5+Zg+/FCg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.20.5.tgz",
-      "integrity": "sha512-jBZK/CfdMvg1gkNK/zNAk02IExpBPwUfNLRPiJvGhReL2Q73naKxZGQGp+5Lej9VaeFB70UKuRma/iIzuZbgsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-code-block": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.20.5.tgz",
-      "integrity": "sha512-0YZnqfqZ1IjzKBM4aezw8j3LZWJFEfs4+mbizHNlnZSYpKzpESYLeaLWGO5SpqF9Z8tmYmSoCaf0fqi5LwgdIA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5",
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-document": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.20.5.tgz",
-      "integrity": "sha512-BpNGHtOTAjjs/6QbkrafMTlaJqb0gsPngFzd5rB0csxx7rYRE9nIEY+oZ44qMw161+2YB4u20L17SX2mUJANBw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.20.5.tgz",
-      "integrity": "sha512-/lDG9OjvAv0ynmgFH17mt/GUeGT5bqu0iPW8JMgaRqlKawk+uUIv5SF5WkXS4SwxXih+hXdPEQD3PWZnxlQxAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.20.5.tgz",
-      "integrity": "sha512-H+bRr+mqU/DQq1vfoMlppK1o+RbfSKYBMIcAMHWOez+C96MWfj5bhooVU2HLtl4XGmQxKGr3oEOCKDPdtRNThg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-hard-break": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.20.5.tgz",
-      "integrity": "sha512-+aILNDO7BsXf0IJ4/0BYh570usFK3Q1t/ZQd8zhHuO2ATeWeDVu1x2F+ouFS4X8fmoCcioMzw15aoz93GET6kQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-heading": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.20.5.tgz",
-      "integrity": "sha512-zXxuIrCSpzgXzRxgCbRE8DZ/NFuinVaniE3pp/9LYAWgRlsAyko8pI2XrVvzzXmDQqRGi2HrNVkNy1yutUWSWQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.20.5.tgz",
-      "integrity": "sha512-4UtpUHg8cRzxWjJUGtni5VnXYbhsO7ygf1H1pr4Rv63XMBg9lfYDeSwByIuVy9biEFP7eGEFnezzb5Zlh1btmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5",
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-italic": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.20.5.tgz",
-      "integrity": "sha512-7bZCgdJVTvhR5vSmNgFQbGvgRoC6m26KcUpHqWiKA95kLL5Wk4YlMCIqdiDpvJ1eakeFEvDcGZvFLg5+1NiQ+w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-link": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.20.5.tgz",
-      "integrity": "sha512-0PukrSYnHX2CrGSThlKfQWxpPWmL7QAvdpDUraKknGvVNSH7tUjchTshy5JdLrn/SQAU92REowRCB6zzCNEFjA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "linkifyjs": "^4.3.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5",
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.5.tgz",
-      "integrity": "sha512-s+Y8Q7Orq+WQiwgFB/VPMYZe+6EAR2F69xCpvOynlzTInLO4cF6QpXomuGEYAZxLHe8ZBmeIaR7y8MH/OgjrDw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5",
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-item": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.20.5.tgz",
-      "integrity": "sha512-pFJCGLIDEin1Xn6B3ctbrZvtYyALARE56ya4SmaNfnl+Hww5MfkRR40obbwYD3byA1yOpr+bECy+I2clQqzTDw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.20.5.tgz",
-      "integrity": "sha512-rmrQgOrUb0jKtFzVUfT0UNEST2sGM2Ve4lOl+1luh66RW6TD+gvgMk/qo12/Kffl9PUiqz8oYfk2qXCwFb6Bug==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.20.5.tgz",
-      "integrity": "sha512-Y/RIE3AxUNYAFKGMM5FLlTVKxxBvOh4JlLp/qYsOCY2nJdH0Jopl2FpfBYc4xoJwFSk8BELJ4Ow0adcYb15ksg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-paragraph": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.20.5.tgz",
-      "integrity": "sha512-mwuhwmff67IpGfOViyRvUC14IlkpsOnB+hSExVnq5+hCntjt/Cr2Z8GGOgzHeIM2FIS0UqX9Lv/b6ttUg4+Now==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-strike": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.20.5.tgz",
-      "integrity": "sha512-uwhvmfS4ciGYJRLUg0AHbWsprMCwyWVWd2RXOLRm0ZQeWkvzonPXZhJvzIhIgsFkPLj/dsN5t0+LdiK4UQMnyA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-text": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.20.5.tgz",
-      "integrity": "sha512-DMa9g5cH2d/Gx1KXtV7txTxaa6FBqgG8glmfug+N93VMb8sEZR1Yu1az++yAep4SGGq9GWIGZCUS3H6W66et6Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extension-underline": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.20.5.tgz",
-      "integrity": "sha512-HMhr5KIAqZsEhlN8RxKHr/ql1a8OvBa9fLf69IwUVFolBcDExHWUtaEV/axYVRQJvvIy2oKGJxlJWDZ4hkotHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/extensions": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.5.tgz",
-      "integrity": "sha512-c4am6SznqfMnbUNSh4MvufiD7cMLdqL1BArok22uBgSWkS1sB9RVBYe8+x0jrOkk0UPEVlzDHbQ+nU+WmIyS2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.20.5",
-        "@tiptap/pm": "^3.20.5"
-      }
-    },
-    "node_modules/@tiptap/starter-kit/node_modules/@tiptap/pm": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.5.tgz",
-      "integrity": "sha512-yJhDa7Chx2EqJMX/jlewBv0za7slf1dKHWYve1XaApuVHEkxl0Ul3EDbwnx316vIITkuFW/pWSwkSsAplyBeCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "@tiptap/core": "^3.27.1",
+        "@tiptap/extension-blockquote": "^3.27.1",
+        "@tiptap/extension-bold": "^3.27.1",
+        "@tiptap/extension-bullet-list": "^3.27.1",
+        "@tiptap/extension-code": "^3.27.1",
+        "@tiptap/extension-code-block": "^3.27.1",
+        "@tiptap/extension-document": "^3.27.1",
+        "@tiptap/extension-dropcursor": "^3.27.1",
+        "@tiptap/extension-gapcursor": "^3.27.1",
+        "@tiptap/extension-hard-break": "^3.27.1",
+        "@tiptap/extension-heading": "^3.27.1",
+        "@tiptap/extension-horizontal-rule": "^3.27.1",
+        "@tiptap/extension-italic": "^3.27.1",
+        "@tiptap/extension-link": "^3.27.1",
+        "@tiptap/extension-list": "^3.27.1",
+        "@tiptap/extension-list-item": "^3.27.1",
+        "@tiptap/extension-list-keymap": "^3.27.1",
+        "@tiptap/extension-ordered-list": "^3.27.1",
+        "@tiptap/extension-paragraph": "^3.27.1",
+        "@tiptap/extension-strike": "^3.27.1",
+        "@tiptap/extension-text": "^3.27.1",
+        "@tiptap/extension-underline": "^3.27.1",
+        "@tiptap/extensions": "^3.27.1",
+        "@tiptap/pm": "^3.27.1"
       },
       "funding": {
         "type": "github",
@@ -1234,34 +1158,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1277,9 +1173,9 @@
       "license": "MIT"
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.0.tgz",
-      "integrity": "sha512-lhlCYCxLa75qNDX5MAv+nmrKn1nKk+JSZYsIzD8HN5B3n0rKsM/LQ/duHYrfseiRpbDHvNCapvUTktvKKPVH5g==",
+      "version": "17.5.0-rc",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.5.0-rc.tgz",
+      "integrity": "sha512-+uT/X8HZZhrycaSvezuJTEUURbfkMxyMVEtdoNXX986daz/mWvxF9mPa8xZ7kUoNG/uvlrcru7VLhDK9DBFmmQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1288,175 +1184,175 @@
       },
       "peerDependencies": {
         "@heximal/expressions": ">=0.1.5 <1.0.0",
-        "@hey-api/openapi-ts": ">=0.85.0 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.2 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/extension-image": "^3.16.0",
-        "@tiptap/extension-subscript": "^3.16.0",
-        "@tiptap/extension-superscript": "^3.16.0",
-        "@tiptap/extension-table": "^3.16.0",
-        "@tiptap/extension-text-align": "^3.16.0",
-        "@tiptap/extension-text-style": "^3.16.0",
-        "@tiptap/extensions": "^3.16.0",
-        "@tiptap/pm": "^3.16.0",
-        "@tiptap/starter-kit": "^3.16.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.17.2",
-        "@umbraco-ui/uui-css": "^1.17.1",
-        "diff": "^8.0.3",
-        "dompurify": "^3.3.0",
+        "@umbraco-ui/uui": "^1.18.0",
+        "@umbraco-ui/uui-css": "^1.18.0",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.1",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.1",
+        "marked": "^18.0.0",
         "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.2.tgz",
-      "integrity": "sha512-Wpa69fKWUrMAlUGxJ03vytpYigbOapaenqF6et/Gp2OydAVmYr4rkSnJvkaEqMTSHZnVAGGzf4LDLLBAfkhTVg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.18.0.tgz",
+      "integrity": "sha512-4gFmkeM/+h1w1k/g3GbhAuzY1cS4+Vg0TvXXyVY9J2d/0llhT60Mv0/HhlvDmooALUdb4ECNOwILtfG0x4MyTA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.2",
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-avatar-group": "1.17.2",
-        "@umbraco-ui/uui-badge": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2",
-        "@umbraco-ui/uui-box": "1.17.2",
-        "@umbraco-ui/uui-breadcrumbs": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-copy-text": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2",
-        "@umbraco-ui/uui-button-inline-create": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-card-block-type": "1.17.2",
-        "@umbraco-ui/uui-card-content-node": "1.17.2",
-        "@umbraco-ui/uui-card-media": "1.17.2",
-        "@umbraco-ui/uui-card-user": "1.17.2",
-        "@umbraco-ui/uui-caret": "1.17.2",
-        "@umbraco-ui/uui-checkbox": "1.17.2",
-        "@umbraco-ui/uui-color-area": "1.17.2",
-        "@umbraco-ui/uui-color-picker": "1.17.2",
-        "@umbraco-ui/uui-color-slider": "1.17.2",
-        "@umbraco-ui/uui-color-swatch": "1.17.2",
-        "@umbraco-ui/uui-color-swatches": "1.17.2",
-        "@umbraco-ui/uui-combobox": "1.17.2",
-        "@umbraco-ui/uui-combobox-list": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2",
-        "@umbraco-ui/uui-dialog": "1.17.2",
-        "@umbraco-ui/uui-dialog-layout": "1.17.2",
-        "@umbraco-ui/uui-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-file-preview": "1.17.2",
-        "@umbraco-ui/uui-form": "1.17.2",
-        "@umbraco-ui/uui-form-layout-item": "1.17.2",
-        "@umbraco-ui/uui-form-validation-message": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2",
-        "@umbraco-ui/uui-input-file": "1.17.2",
-        "@umbraco-ui/uui-input-lock": "1.17.2",
-        "@umbraco-ui/uui-input-password": "1.17.2",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.17.2",
-        "@umbraco-ui/uui-label": "1.17.2",
-        "@umbraco-ui/uui-loader": "1.17.2",
-        "@umbraco-ui/uui-loader-bar": "1.17.2",
-        "@umbraco-ui/uui-loader-circle": "1.17.2",
-        "@umbraco-ui/uui-menu-item": "1.17.2",
-        "@umbraco-ui/uui-modal": "1.17.2",
-        "@umbraco-ui/uui-pagination": "1.17.2",
-        "@umbraco-ui/uui-popover": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-progress-bar": "1.17.2",
-        "@umbraco-ui/uui-radio": "1.17.2",
-        "@umbraco-ui/uui-range-slider": "1.17.2",
-        "@umbraco-ui/uui-ref": "1.17.2",
-        "@umbraco-ui/uui-ref-list": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2",
-        "@umbraco-ui/uui-ref-node-data-type": "1.17.2",
-        "@umbraco-ui/uui-ref-node-document-type": "1.17.2",
-        "@umbraco-ui/uui-ref-node-form": "1.17.2",
-        "@umbraco-ui/uui-ref-node-member": "1.17.2",
-        "@umbraco-ui/uui-ref-node-package": "1.17.2",
-        "@umbraco-ui/uui-ref-node-user": "1.17.2",
-        "@umbraco-ui/uui-scroll-container": "1.17.2",
-        "@umbraco-ui/uui-select": "1.17.2",
-        "@umbraco-ui/uui-slider": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2",
-        "@umbraco-ui/uui-symbol-lock": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2",
-        "@umbraco-ui/uui-symbol-sort": "1.17.2",
-        "@umbraco-ui/uui-table": "1.17.2",
-        "@umbraco-ui/uui-tabs": "1.17.2",
-        "@umbraco-ui/uui-tag": "1.17.2",
-        "@umbraco-ui/uui-textarea": "1.17.2",
-        "@umbraco-ui/uui-toast-notification": "1.17.2",
-        "@umbraco-ui/uui-toast-notification-container": "1.17.2",
-        "@umbraco-ui/uui-toast-notification-layout": "1.17.2",
-        "@umbraco-ui/uui-toggle": "1.17.2",
-        "@umbraco-ui/uui-visually-hidden": "1.17.2"
+        "@umbraco-ui/uui-action-bar": "1.18.0",
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-avatar-group": "1.18.0",
+        "@umbraco-ui/uui-badge": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0",
+        "@umbraco-ui/uui-box": "1.18.0",
+        "@umbraco-ui/uui-breadcrumbs": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-copy-text": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0",
+        "@umbraco-ui/uui-button-inline-create": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-card-block-type": "1.18.0",
+        "@umbraco-ui/uui-card-content-node": "1.18.0",
+        "@umbraco-ui/uui-card-media": "1.18.0",
+        "@umbraco-ui/uui-card-user": "1.18.0",
+        "@umbraco-ui/uui-caret": "1.18.0",
+        "@umbraco-ui/uui-checkbox": "1.18.0",
+        "@umbraco-ui/uui-color-area": "1.18.0",
+        "@umbraco-ui/uui-color-picker": "1.18.0",
+        "@umbraco-ui/uui-color-slider": "1.18.0",
+        "@umbraco-ui/uui-color-swatch": "1.18.0",
+        "@umbraco-ui/uui-color-swatches": "1.18.0",
+        "@umbraco-ui/uui-combobox": "1.18.0",
+        "@umbraco-ui/uui-combobox-list": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0",
+        "@umbraco-ui/uui-dialog": "1.18.0",
+        "@umbraco-ui/uui-dialog-layout": "1.18.0",
+        "@umbraco-ui/uui-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-file-preview": "1.18.0",
+        "@umbraco-ui/uui-form": "1.18.0",
+        "@umbraco-ui/uui-form-layout-item": "1.18.0",
+        "@umbraco-ui/uui-form-validation-message": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0",
+        "@umbraco-ui/uui-input-file": "1.18.0",
+        "@umbraco-ui/uui-input-lock": "1.18.0",
+        "@umbraco-ui/uui-input-password": "1.18.0",
+        "@umbraco-ui/uui-keyboard-shortcut": "1.18.0",
+        "@umbraco-ui/uui-label": "1.18.0",
+        "@umbraco-ui/uui-loader": "1.18.0",
+        "@umbraco-ui/uui-loader-bar": "1.18.0",
+        "@umbraco-ui/uui-loader-circle": "1.18.0",
+        "@umbraco-ui/uui-menu-item": "1.18.0",
+        "@umbraco-ui/uui-modal": "1.18.0",
+        "@umbraco-ui/uui-pagination": "1.18.0",
+        "@umbraco-ui/uui-popover": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-progress-bar": "1.18.0",
+        "@umbraco-ui/uui-radio": "1.18.0",
+        "@umbraco-ui/uui-range-slider": "1.18.0",
+        "@umbraco-ui/uui-ref": "1.18.0",
+        "@umbraco-ui/uui-ref-list": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0",
+        "@umbraco-ui/uui-ref-node-data-type": "1.18.0",
+        "@umbraco-ui/uui-ref-node-document-type": "1.18.0",
+        "@umbraco-ui/uui-ref-node-form": "1.18.0",
+        "@umbraco-ui/uui-ref-node-member": "1.18.0",
+        "@umbraco-ui/uui-ref-node-package": "1.18.0",
+        "@umbraco-ui/uui-ref-node-user": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0",
+        "@umbraco-ui/uui-select": "1.18.0",
+        "@umbraco-ui/uui-slider": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0",
+        "@umbraco-ui/uui-symbol-lock": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0",
+        "@umbraco-ui/uui-symbol-sort": "1.18.0",
+        "@umbraco-ui/uui-table": "1.18.0",
+        "@umbraco-ui/uui-tabs": "1.18.0",
+        "@umbraco-ui/uui-tag": "1.18.0",
+        "@umbraco-ui/uui-textarea": "1.18.0",
+        "@umbraco-ui/uui-toast-notification": "1.18.0",
+        "@umbraco-ui/uui-toast-notification-container": "1.18.0",
+        "@umbraco-ui/uui-toast-notification-layout": "1.18.0",
+        "@umbraco-ui/uui-toggle": "1.18.0",
+        "@umbraco-ui/uui-visually-hidden": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.2.tgz",
-      "integrity": "sha512-58FCYYVcr/kDx3vCtBNKMUD/Wm9hLSRJ+Vcz7B+PB+Ksj5mHNXtfxEqwZkh8E1CXosrYVvd9IrGjjIo9keQx5w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.18.0.tgz",
+      "integrity": "sha512-8nGvHoqXuGoLkQXcW5KbMi64wDEhUaoPi4DEIOt7WcmqJOV9Bjc7zbwwBxUfcqVqbCQj884xQqQDKrCTuhp1GQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.2.tgz",
-      "integrity": "sha512-9tQ7YvHBfQhy30yI0c/+gAGOMGRBlAj06nalAlOeeRE96Gs+qLD4xFfmhdl4+A4QJNube/VvujTOShrlACdfqA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.18.0.tgz",
+      "integrity": "sha512-PKsDmvVML7iWOZhQOCFGTSxaZ2R91/6sdcQ0awdzD3bB9CAdKExYvcFyO70TPaZRoFnXs44tQfozp0F4uLIMGw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.2.tgz",
-      "integrity": "sha512-It0ml/h4PWm/Uoy7VdESJEV/xjvEJnC5dQjZlG6I6x+HmpejbJs8/EPNiWiksNff7A6yZ0zHNJOoZjJPTEcGmQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.18.0.tgz",
+      "integrity": "sha512-ddDPB3CMW9peXwiO0bDcvDSnc1loXMjF6JJxg9P6oGXEvb/BNoopnVFB638GCWrNJzJ5BBB0lO5HACb10HgmGQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.2.tgz",
-      "integrity": "sha512-JLbzuWk7lsN2e3wLPxD4+gGTAoufIo+cAjIR+3+UAPY36PXwuUulnypuATLElqL5PPBQssjQmBF/K0o83V2HjQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.18.0.tgz",
+      "integrity": "sha512-G9qwSc6rnYUhF8PLBsUOXsOYkrA/pGN/MMHUJd/5+wKjhNvcO6qcQYsVQtAGsTLhEyq2AplxzRHtmiVD0fWnPA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.2.tgz",
-      "integrity": "sha512-UZkHUY2vdc61t9uq8ey2o4Qpb2aAAQC5HoeBqUu/lEpaWRezHk7QoFIeQrzo3QC2xUa6lSqmSuTYQRWUdFaH2Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.18.0.tgz",
+      "integrity": "sha512-bsy+pIQgkRZleTOmi7v0gr8PGEuiGib7LqENW5+Zq235qSkHceDehoyJ7QY07T3IuCrA7wP7T8ebcmgz1AarYA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1465,267 +1361,267 @@
       }
     },
     "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.2.tgz",
-      "integrity": "sha512-34gdbpSCQRUeLTzh0N+w4GazRbqR4bWAvi5HQe5N/qKrI/5ziQEVQNRaintmxTZ3S6WxxAbF5yaF60UbCW75iA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.18.0.tgz",
+      "integrity": "sha512-Jbn2GqNIwoO1oDFyn4CHp3qxhjBSl6NOtr6YIrbx/7NMUOjfSh9i5roimSK1pfM0Ayu9FblTfzFQ1JHeDXx+iw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.2.tgz",
-      "integrity": "sha512-tXBSnb1Gmxub7772SqQvHngbmMkrPzfZ6TorZkNLJlddlNgYJmpoGeFZKGVaJpwCOR+W3O7LcT/juOv+sPvv4A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.18.0.tgz",
+      "integrity": "sha512-qTSR8dKmF5WVSLgfRdVkRpu39ZplKAPd44770W00beO6LFcjuJB90FE12j43YcrHph5U8rZpMLP0ilfgDmeQ3Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.2.tgz",
-      "integrity": "sha512-KRFyw7c0OS12zSPFN8A1uCFPdBEshN0SWHMXcZsP4nswjYkj6sJYe6sWUjDETgmgtf9zYK6SzUjI8gyZoFuLFQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.18.0.tgz",
+      "integrity": "sha512-U3jTCdNrck+OTIHjqe7X/IaxnALRBlrdNKGpAphCK9nYVoBH0K8Qobo7pl7RAtCx70i5Z5Yd0ulqo2l3K+gHLA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-responsive-container": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-responsive-container": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.2.tgz",
-      "integrity": "sha512-F3NO89b3vHOOhWrfM170Z383HsYf9Nji1LxZAedXtAyNzXjIGRKQH5cbiDJBZ8r9J51dVOl0glr23Di4SHiNsA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.18.0.tgz",
+      "integrity": "sha512-F2mfPByJOIgsHaXgX/2l73KgciDqwqI8OZwLC3ZWvA2aL2oGKbj1xTDBriR8zMjB5cGrFynH/VcXqx6SmAZ3XA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-copy-text": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.2.tgz",
-      "integrity": "sha512-vbaykS2iQM5Lj1oJpSrkfMErYgeR/hxIsYdpGyl41Xc0XZbQxA6ZhhXuOwKnkALnJX3rr0myhSfzk+xBA1nZ6Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.18.0.tgz",
+      "integrity": "sha512-/leCME/s5QpKxXqZwekzIS08f/FdymFjiAW4qFVn3e4D86ZDEA8QROfoaPNkXIZ1jLDFRjLMF6NO4SfMJ2C12A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.2.tgz",
-      "integrity": "sha512-XvSN8wngvTCPKgIRei1glKiMhBiATFpzNLuc1nJFnDoljlrehzbViwUNtGv+dtxe5XmdEp1cKQB5LW4PesQrZw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.18.0.tgz",
+      "integrity": "sha512-65siyrZetA9WNcH7vFtH4JYPvwtffaEzAKiT8tvC9JJdRceRcNB2xpxHD5NimvqA6H2eu1XKgfCTKDPOp5nU8Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.2.tgz",
-      "integrity": "sha512-NLzwh0mMOIZSe3mj5bHy1vobSqU7VW/G1ixswngwj2FSBsIxLOZY32pECvXPA8dGfazH2Xl5dIIemyrh8vN4xw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.18.0.tgz",
+      "integrity": "sha512-S9+GY84pCigNX6rJa8o7e/GFiYm+jzUj0VvAG476qaVSghaO6ccw8Slp/zzLd+JQM1TNVohRv5BA8L2iRR818Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.2.tgz",
-      "integrity": "sha512-8WpXK0MU6ycSidpG41wTxWrn8iHR9A/xWZgx2wuol3qF73wakRVR7IdoWxsTAtj7uVg2xp6q19ABZLML+BUG9g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.18.0.tgz",
+      "integrity": "sha512-ca05RxgHuAyLUktiyqKDmXdp1a+Qns2o+cFo/QdAe2aRURnCA003NtNupp6qov7l6/MQHWMG+0FDGikhT5jfxA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-checkbox": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-checkbox": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.2.tgz",
-      "integrity": "sha512-GPuUNj1rjy+HavtzkvF5LEDvYmhN5W7DTRB+5WSpUmX6cyNP/J+LJfx6q0FxOD1DtmLl3/lTLhZxfNe/E2QKsA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.18.0.tgz",
+      "integrity": "sha512-LZetD81cwtWpLD67smnQENZuzTNiFrp1VGbo6oHyrapQOnQij4L/c+GjqPpFk9qWIillJuvxovW+vO8p7djUWA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.2.tgz",
-      "integrity": "sha512-21gwLrvS/A3CuYo0fdD5CLZEil+LehqNk0OY+OwYu07n72O0lQK97BTuwqrDI8IeRhm+xtAof45RiWPBu4ydww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.18.0.tgz",
+      "integrity": "sha512-DwsHyeIL+4qmz5WN83i+xaU+adejcSRLZwUqv/eMa1s/OrPAv9WaDnWrbSM2s3Hg9Ne7gAD/q+r154ZH/JThig==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.2.tgz",
-      "integrity": "sha512-pOs9DMkdFH00OZlYMfODCgA+BQA8EkTutkTdx1YiucmJUfRt+Lt6pnZjHn+BW0vuo1S69Bn4qXP+1XzbwCREqw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.18.0.tgz",
+      "integrity": "sha512-l2XZftt7lwaT13zSB8fLugSDgR06zbOfh2bvsEU0t7D6kdc+JOFCgmAa064pPVqAge6SPC8EXfbfwtb+rmXOug==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.2.tgz",
-      "integrity": "sha512-jnqIMQ66pV1QDMxkDeljbnm+QTSpqyuTu4UIwWtEi2F2z4yIidZ7E5Ii9T1Z2lOW9hxKBuR4DG0LrxIg0ZeniA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.18.0.tgz",
+      "integrity": "sha512-ZLea0QOaw0cc8OCkbBhLHa0ApAm7w76c9HGMQsHVvv8p0sW4+JJlx1iFEsRXocTaBgC+TZCdcSTX514SZmYecg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-card": "1.17.2"
+        "@umbraco-ui/uui-avatar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-card": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.2.tgz",
-      "integrity": "sha512-8nDsGmr/K2uYpdKMImofvK9rYvdfLqppLOvXEE2JwzEsFT04LACm14rvTUsYHGKAAOYwCosb/NDm+bPCagJVvA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.18.0.tgz",
+      "integrity": "sha512-XdKU5yv1nGN+e2A0d0DfUlQlM8V1blE5S+yB/M5/xWfiKXqw1XRKmZBf3fp5Fi8qA3jW9SyZOFSLNVeEM49zEg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.2.tgz",
-      "integrity": "sha512-9NTKAdaqMHVnOyX7ya8pJ4hEyIh1p2DciOJCpL8Jy73K2NqsHl5VQLs7YR7LnijlAoJsOXKES0LxcYgfOzDOpA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.18.0.tgz",
+      "integrity": "sha512-BqDEPCVBoTEsyJnVCTOsKMqcui/VdOGhQGpzhnlYoYIEeEPpyLjU9LHgnYQ4pTNSeV6tm9aSJUA+Kh+WAkrkjw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.2.tgz",
-      "integrity": "sha512-4NWt9OoyG81JvifcsrBufhOeJL1CBkmEeSIRms3Rokbsg6imeEJ/e6Ga4AJFauAhsroloxirf7QBfUUQ+lEueg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.18.0.tgz",
+      "integrity": "sha512-P4CiBXhxX6xFInaMTfTsjqyeqT8bR+IBoZQF3a8zkBdG9gmzVgzTzRQlahldn1UAQEtBsgkSWDZQ+f0S6Pshkw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
+        "@umbraco-ui/uui-base": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.2.tgz",
-      "integrity": "sha512-SOpJtZb11gm33WZfRltmoSmRgw7JDsG14GqbBwi4KL556+GLzeNMRPswU4hDCb7e69A1hK8+oBoMIVQwXPB6vw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.18.0.tgz",
+      "integrity": "sha512-pNaSMGtk7yA8BdE7oCuW/jKaqFAAaomnJpFM/mfHPU/Tp9mjrROm4bEXYdTauxOgXoRpYHyZEcjKYfTUOCJhwg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.2.tgz",
-      "integrity": "sha512-sCygVWQHOw4eOxTl3EpN1/3BF9wLnnBostEWG8Om6EFRoXCb9DMBvh/kTfkF6ZoUIGxPFPAD1hpXF/ANtUka2Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.18.0.tgz",
+      "integrity": "sha512-JzljnkfOIzjrj66FWdb1ik+fl+sHUCvz2eWY+ymTfHQqviCzT+u9Xr2QZDDF3prZ2BhoiObHbLg5SbLDvs1Gjw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.2.tgz",
-      "integrity": "sha512-hMAUzXDCNR2H4yPZDJmUig4kQt9xL/gH7ghcazYxeY7vuLLnGucxljTfTiZISqdjeQpheSt807gz9XnWDLY9Ng==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.18.0.tgz",
+      "integrity": "sha512-rEP01M6QmS9w0ObEXya15VZd1bY5VPkrXBzX7PQb/GgWkVzS+Uuows2I/jZD5TRUZMS7pmMU1Q7AVakeMJDEYA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.2.tgz",
-      "integrity": "sha512-M0flkhmZvcx2oYcn5ffK2z/ByKMEjALd4fy0BQ4Yzz4OerWFliojkXfv1Dc27Lyzl+UKJFf7LK61UY/MA2Z42Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.18.0.tgz",
+      "integrity": "sha512-XKDRzsrccVm47wDsoGwfIFxmb6oVltZkD1uWNvcQXCbYqSs1oyxWCI1vmSBa/OFNbK4br53q7vp/7cgNDZv8Mg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-color-swatch": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-color-swatch": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.2.tgz",
-      "integrity": "sha512-X3PqQzpkvj8mfbjb/ntLgLPIWTy6Mvw2lIyPcOCGN6eg5CAai51qZjt/S9KSg5c//UQings3i//G/ycyIBKBEg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.18.0.tgz",
+      "integrity": "sha512-AoUTrkgbx/GvgKw7sttVs3FxjRxuvpV6ffU2J/DeO1EFaxw1rHWZUgxKURQcBnPs3Jd0cDmjjloALyswcIgtTQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-combobox-list": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-scroll-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-combobox-list": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.2.tgz",
-      "integrity": "sha512-EPVQfG692sS9XT+qn6QU4dUbGTgQzneF4sHcmbm6gyHfutW3pv0xCa43RspoXK8iMjNdrHEqZqW1bpSWIhp3fA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.18.0.tgz",
+      "integrity": "sha512-niLRnK8Yjx5uThBYPtOr4ptEYiMwg/QlgXofxtgb1TQw0sfw/S8Q5mBose9M9gVlbnvDzf3ejNJMeMsgeY2RBA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.2.tgz",
-      "integrity": "sha512-+g+Za0i2ZUZTf9C5GOmJ6olJxH3J181GIB79mg7soAUG/ofMTOw0uKR34sG9SUXG2+qoenzWoF9B5qUjydJOeQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.18.0.tgz",
+      "integrity": "sha512-ncKenHQX6ZX4bbF6ZKVZErLjY4JFh2FNJFrZBtHbiK1oU3p1Lrecgv7zczTLXjqn6FszEwkUcwafVewxwxAT0Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1734,674 +1630,675 @@
       }
     },
     "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.2.tgz",
-      "integrity": "sha512-6f89YWRvYUHcLLf5yZ5UXT36bPuRTBRt6AqCREy2NTox1M0e2fU4+T61UrEy8XjcF25+8Ylc+ETb7KCHeUb1FA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.18.0.tgz",
+      "integrity": "sha512-0FqGYbkpT0KNSeB+xJwIHksTzE8VSItuobHUvpN/pg0QxXmZ/Hv5svIKAmw0baJPiho3w1UdsLQwRB43yXTqgA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.2.tgz",
-      "integrity": "sha512-sBeFz6UZUtArP9/bnykuZVT1S4oYK9JjIOm36Z0Wurw893aPAHiNCq9hrCaZF8xmS+ZLrqSmkNhZ22slKWkw6Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.18.0.tgz",
+      "integrity": "sha512-I9W5xDBmlkU1Qskj/4NRQk01ofFxd0i8pXUTkJGKt/N0YwQzG98Jpu7Xdi1YQ3uo2xZObPiNtbqIYGJN1Y7Iiw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.2.tgz",
-      "integrity": "sha512-1JnURFHBHpO/QCEaMXJOj1xj1ttOPjn7twxOlZeJgpZoKDepqxRCW2UX9vqwop+ge3LWoMMvSTxa6GNHBs34gA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.18.0.tgz",
+      "integrity": "sha512-SJYZP6Cs2FcZYzlpBoI6B8srwT4bduQYBpOXYHeUP9gP7w3dD984StoxNLFssEdazgghLIb7OvQQ4yjUBSzi7w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.2.tgz",
-      "integrity": "sha512-L+w5mMIcgwNlWA6/SAWoU9bpEbzEB/reVWALWOAScv1Lvqo/HmjjxHMclFJzm+6DSM3euH53X2zOHmAp1oUnOA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.18.0.tgz",
+      "integrity": "sha512-7iyZ/uiC8SzojYP3lkyYE2gYJSAQ3J2G2/LOctUpgM3b7ghJt4WAs1Zj95C86uHPFP7gYmjkf+qyRR+5R2KO+A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-symbol-file": "1.17.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.2",
-        "@umbraco-ui/uui-symbol-folder": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-symbol-file": "1.18.0",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.18.0",
+        "@umbraco-ui/uui-symbol-folder": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.2.tgz",
-      "integrity": "sha512-39ynzYgPdhpDSyVxpBJBDPrRmGKfnhcHVrMTcv5ITUnmsHizqd4tK5+gdf5tcHXrAxb+AWHEufwjjNcRHdl/Ww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.18.0.tgz",
+      "integrity": "sha512-ZvkYdk3qL0wx4PTUnbtbsqY2Q3My6fN2aJHe89Il2Ptx/aY3gsjEshZ9GfJZjPWnEieRlbOwEu4LyhqPqBG4AA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.2.tgz",
-      "integrity": "sha512-FLDd+Y5x/6L8cHAPzicX/e4mxH/tx2DBWuzXV4MeNp8eRS132xCBM9laI+1/dnBjCzYzJuVd8ibmFO0+Yjf8Uw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.18.0.tgz",
+      "integrity": "sha512-1FLIB2lsWPMUFlF76hXG/Ws4NIBP2dzETjUMt12WVaFEvcM1vQGKqfj91RneZBDvfbscgNbIlZPvQ2R+p1iXww==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-form-validation-message": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-form-validation-message": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.2.tgz",
-      "integrity": "sha512-AWI9WC7wZW7qgrZ1EUnzCt40KdB1iiJBPwUnyffm4L3MsGyUVEQYYO96v/y04PGFr6DUlcDlAerhSqcsaJK7Kw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.18.0.tgz",
+      "integrity": "sha512-eJzFrFVlrpu+80VqxX9Obcw4WQ5G1TNxgADjQ1uAAsAt8ovJ2sjMqWe0S1FJMpdFSgLeQj8PQLBlCNAZ3h//Cw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.2.tgz",
-      "integrity": "sha512-7WmGW3nn7IeL5nMZtIYaSWaV0AeBoE90rfAqjbK/fHzyDtgM1gsokXhCtEQH9VLnjFfs02bXF+Xlw+ZEP3+p5A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.18.0.tgz",
+      "integrity": "sha512-t9xebF5fA1SSznf7inH2PRMHWpr8m9u1q4+prZVjMtWAtL5wDBsS2QZA6v2EG3Lv9T1cGhN5zbbmyLc5qYmYTQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.2.tgz",
-      "integrity": "sha512-P5ypiDGswu0uPhyVcltuFHLkVax9DURUgz2jgsuNDkLJh4BW34TFTHu7c7XKVRzVMIb7356SxO8B+q6fYEPNqA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.18.0.tgz",
+      "integrity": "sha512-xv7bhzCFZfuRmDhMrHww3Ucu2osKJnZPyYmPkBKraS75X4K+tD2012QZxtUI9Dq+WRLTZ6htpOX75JL2FE3PKA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.2.tgz",
-      "integrity": "sha512-vfumKb+H6bT1tTMKOHK/rZW4QDBxzANzAqvAqpeB7n0EEd5j+82tSv15DDZDlyXHvMNUnoBrI+zNpCYsDbNV5Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.18.0.tgz",
+      "integrity": "sha512-0tOFOZtjpzkbpfZsTczRV2tWFXxZJb+GnA77WI/dFoJEXVfXWMeHiwQPbN/znhE3TSqrRPt2LN3B9PTp5lWZNQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.2.tgz",
-      "integrity": "sha512-8aoM58rkLEYdQljWHBA8hgwEqnjeVXzFfMdO+QuwgLpKEBZij/33iWBl2j/IGmxByiFcxSvsbzEFhXHNRlU4Jg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.18.0.tgz",
+      "integrity": "sha512-KBXxmRNO9K+I7iNrUkl6x3rz20M+Dnn7bf2kWNqDrQ6xWxaSePX3bfJIBy5DVOcV2CgqnT4UcdrAf7ByPU/3Rg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.2.tgz",
-      "integrity": "sha512-bWwp6KkMDuMvIjmRh9WOXBdVyaEdcCyvdqBYss+BrXEeHF+Qs9SMHK4giLGAosYIWxzctmT9tUZfUpuJu8QP0w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.18.0.tgz",
+      "integrity": "sha512-f6q6sebzA3/1V6mcTG9dq8meE4R5c0ObGbzQBPyDH6oD3bl6z2insoDrLVifPPeXpu+jxPIzcFOLzNwczP7Tmg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.2",
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-file-dropzone": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
+        "@umbraco-ui/uui-action-bar": "1.18.0",
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-file-dropzone": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.2.tgz",
-      "integrity": "sha512-Vu6TViMQuERTqx5kd518aujwrtztxbErHqAw1VNl6aT1q4GoADLtVyxnFYMhtg6mokUJL4ZxTxMuiAKVLjJM9Q==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.18.0.tgz",
+      "integrity": "sha512-thSsryOwf5zDgQJbgijtum1WRjfXnd+lTZWnmh2Ewh97iZVeCXw8t/3ScmaQdgMvnNv7D7WKRAA3nK1AerWlew==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.2.tgz",
-      "integrity": "sha512-a7hLURjTwNpuqepeBAWOGyKmvuy9dPXs2YdxakaoUsia486gjerIZOKv29vQ83Uw5EivdvYZMuFGM4TngQZ26g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.18.0.tgz",
+      "integrity": "sha512-BbbB7TYiX8xCMD+/ZVJJlS1tCzkiJUK7bobRtcKC3Alrv5ogKSqAyfsXDqqNyAKsGhR+HCzShEVzpMUJjD9Kyg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
-        "@umbraco-ui/uui-input": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0",
+        "@umbraco-ui/uui-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.2.tgz",
-      "integrity": "sha512-2XXU9p80iGJVsHvIDA4u/IsRTD1psW5yEmWZbUJI0nouhGfoBGjF6mgo2AYEVczrP90JBvWJhhunCe1JfPK9WQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.18.0.tgz",
+      "integrity": "sha512-PA9BPA7e14HpsjWNAnzNCHJ8i3Ex56Gv6ERzlTVGXISS8cv7HvrJAPsYVEywt6jci2l9jDvi35MdAcL14WrUfg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.2.tgz",
-      "integrity": "sha512-xbvmKU2zGNaIo1Zn7cOy6EmidxzFYoihsEkbOrMBItbebhZcZc+MUHuEFr+brgMHowk0CtUJnITjpSsow/4BUA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.18.0.tgz",
+      "integrity": "sha512-GfPD7YsoaUs3UU9f8+OxYVxTKId/xWXG6o8KaTK8XfVvICnxWaQIqcbaHyRR773+5H8kvfxBr67ahPcGSoo2JQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.2.tgz",
-      "integrity": "sha512-wnR47k7zbDG4upQmucTuaNyyFR9VKVoBiGLTGTITNvK66G+EpwL96xwd3YqbJx4oRXQEkCyorlbE8oxY2B9Xig==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.18.0.tgz",
+      "integrity": "sha512-BQwK7+Ldv5V2IpBIeFaJ426zruKYc9X/+IE3YCTiIAn3lrLx03IUlLQwxzI7R3sU0SHR0/HQjK/2KKYA//NOwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.2.tgz",
-      "integrity": "sha512-KHe1W3pHaJ5SX+D1TcLOYti5Z+RuVd5o0Wm4XONvWN7DZ/cs1E8pO0mvgJYLZbZv989u9RwhH4cuOCxTByt4ew==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.18.0.tgz",
+      "integrity": "sha512-UY3cE0d9MkPWGxIpuv0zbdgsEqUi9RyT5V1yWXi5GPBGJ/fU6/Hu8oHBkrAPC088vGLu9e52hLs5e0oaL1LYSQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.2.tgz",
-      "integrity": "sha512-pYXvXEhm+oNWDNc2QKNDK9nILAPnegyTkQEdhBumF5RqISCZT0OXufhP8//Ez7Ao/c84I0Jv/jVNqgmDIxg0wg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.18.0.tgz",
+      "integrity": "sha512-HN7TPxDplGA1WD2bnuZggblBFsQXSEmXtHkmTOidLzwggZIkZyDBoi0hbGD2PN0fJvLsLV+1aSxDXqmRVRhWXA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.2.tgz",
-      "integrity": "sha512-aDAp61Z/3/1qQN34phkekYHH+IpCldNp26VF4PZBb7YlpxYfbEbO/xKqxkRQYvrEeq1TNpDQF8vhmbJn0BdmaA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.18.0.tgz",
+      "integrity": "sha512-yT4DwOxPls0Rh549PJFdwgI46Hen9oPBVF6c6iGOTBgEbzsSgpoUWi1UaCtZe4WxDQ1+1SsF+JW//W+ZKJAmzQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-loader-bar": "1.17.2",
-        "@umbraco-ui/uui-symbol-expand": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-loader-bar": "1.18.0",
+        "@umbraco-ui/uui-symbol-expand": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.2.tgz",
-      "integrity": "sha512-IFrpRuFrouYo8DqrK1DyrGWkmHbf8sP5OQjCqYfmZ15AwqPt791h4uwTponrjJVOwFwy2sq3mZPAR7ob/V/6DA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.18.0.tgz",
+      "integrity": "sha512-7x6yhHTYtfvZVZRc8hhgBkiwRq5SlXoJ/jdQ69xlL8iLEjoFTA3ZqBkcKLQHpWXVMYAkAWGiJhDtQ2WCmED5Xw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.2.tgz",
-      "integrity": "sha512-ECWL/9p5IDBf8EKES9pG8QL+5hNNagmtE+3hCZH2x+D3yW28fcMh8SW5QtBgfebBNXdZAp4lrxcTtUyFA6By+g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.18.0.tgz",
+      "integrity": "sha512-7jlFROK1Kuu/waZ+mWd6+ks/x5xxf+NiwT6J4cQTnYJUqQKLmZ9ZesTndtU8fHBKER+H6bT/m4Rb7RkMIQ7Keg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.2.tgz",
-      "integrity": "sha512-Pqh7k+ZpEGGMdpRbNO6+6p9ggZ/wtZs9MyylB6/56PLlIepVqhGBqlJbJ6+z4Ph4S752btMmqz04GdJ09yaZuA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.18.0.tgz",
+      "integrity": "sha512-FXIuz745J9GAHKZ+GQ8UODwxmxe6FHfWb15Y4JMTLg+OzIiCe1az1Y2rX49/iSULvmB2x8ci6w+EyaIZtiE7Ow==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.2.tgz",
-      "integrity": "sha512-lCzQFUo3QESYbKkk69KJMC5cmJ4VS3hEPdSRATzBqEDtzj/h6aEdrww1EOAOOLCw+JgNd0wKS/+sp3RCmiZxeg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.18.0.tgz",
+      "integrity": "sha512-gyQKjGp/m2WGBZgX99Q5GJBJ4ZGYl9vQDltVUzuIS8mlD8GJYukSWa3ALs/dRrN3nuT4f+rZWOt1NI4ZBR2tJg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-scroll-container": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.2.tgz",
-      "integrity": "sha512-I/T0K4l9QcWJGSOI4G7Zr4uMz/UjgM4nA7ebjDc2cgY5hLcefknFS5LSGWjPxTe+R9OIFFkFXLvQqlFZnH2AcQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.18.0.tgz",
+      "integrity": "sha512-zGkokXSwvZQvhEcdhf6mHTpeqqWZ4lFXmrLifih0VFzzBHgDHS4wuE3COQLNbOkk2r77Ute6/QBf9dph4GOaTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.2.tgz",
-      "integrity": "sha512-iDvaEUltTAAwqRYY/8bIRyfN2j9vGc3CpZlWNe5nC2QOD+tPVEq5MWyg3N3Gbx6K9bkg+DrIAblk2Mc8YFEHAg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.18.0.tgz",
+      "integrity": "sha512-Sy9e6/sA2uTN9EVPLQv5BBzQJXHGSudCr2nZ5MbhcI30mkip+pSEccv9Q32zoSJU2FG5WafQbZZnxl2kmhzuFA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.2.tgz",
-      "integrity": "sha512-mjgxoHQnkIKrYv2I1mjESgSy8yPZOSHoFURoeh9fc3G0bnkoTbNwLMKMWL3NSQObHo+TpK6djSaiXLB1vIAwJA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.18.0.tgz",
+      "integrity": "sha512-d+nPhZfhMmUVHzPqJ8RzSFLaxUN2HQSNr1Q+yuUGhrJKCPxN7aHVPwHKDu+baR1tPI14vqiWpucZ2tIGMNcaoQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.2.tgz",
-      "integrity": "sha512-SWyS/sduAw8vmesw0Sm7jsblhZ7i9vckOAzCQs2Hrbtssgq1EZ0PkkICS2Vg3rVnR0HSYt8T2s7Fy7yjK4MYHQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.18.0.tgz",
+      "integrity": "sha512-JBH0YwQMPT49F5C98xl5fLhJsbEDKxIwf4KBltov8enO53vO9wP5nKOeTIHgJwRKpC4unxwIDws/8rKpwiXryA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.2.tgz",
-      "integrity": "sha512-LzKcN94JSpbH0YmpBj9fl58WdwFeGbovFhLBInUcLOX8WqK0E+lNdBLRya7l8KYIKmhQKE3TUbqiN6Qcwhr2mA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.18.0.tgz",
+      "integrity": "sha512-ZJwwcNCaNqQLa5wkYcSCw1EElJq9cVRe4F30gbCTlax4rXqR++Sx1XrKyA2+ib2Bt9N+6p1IQ0pFmyyG57uDqg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.2.tgz",
-      "integrity": "sha512-C6fqnEDYlGlqF3gEQFPy8908LcZLzPqhVHC1p6AXXNkTPnnKqSAPxRPKRUk7XUoQSYFDXfCzFnlyKdlpWSIJBQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.18.0.tgz",
+      "integrity": "sha512-3WkGnRdLUQxZFtKGb/5rmvKBbK1Q4G9qZm4m1SpXB7qDzXelrR92SNjmr0My1nMk2JF29/ZFLihep9798H8Peg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-ref": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-ref": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.2.tgz",
-      "integrity": "sha512-nEEKv8TYjueZprnfFg9sW1u/Y3Z8X+IqGPWRg0Hx+gLLKmOPHbvlYUIB8M4Q4G61XlcY8dfw+TDZ8kxTekmEWA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.18.0.tgz",
+      "integrity": "sha512-jV9uWHwgUzCJun1UPAs46zS6VdJ1DrmqVSf0EfIQsGmHGiTlWP9FWfmeRe+hQ2XmqhgApo786X3oOrzChCO/jQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.2.tgz",
-      "integrity": "sha512-w+qe2g9FDUTHLzRStffDOoudHUeWw+RXgoOLtI8f5xktbuKDcpz6qiIOIvTO9ipfy9vpbU/WiUr7OSBVdxGSaQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.18.0.tgz",
+      "integrity": "sha512-FfPc4E0DXhEv6EBUBWEhwMNfGK5Oe8GjEBJ+vyj5FjaLlsmmj6bG2i2NERHyb6mwV/BXpmU8Eji4giVsJeV88g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.2.tgz",
-      "integrity": "sha512-056oxK3ffKIERFfYgYG+Ies4S75TPEdME1WXYYG6p9QzfZ06Y0VaNCQbzoHwS8CcbtO5/m2C3BXB6b0l26lDkg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.18.0.tgz",
+      "integrity": "sha512-7X6VwMtvqwX9BOM3JysppnrbY9EsNzJyb2HY+9+BFANko8wf7heM9xOi5wv4H7cvi7xfKGZL2Vlt5UAvo1cc6g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.2.tgz",
-      "integrity": "sha512-oeWQHu7u1/xK9IOnm5YMceLPzfGsuIsYyU+UJRJkwIiWYT155gosdGoxCz/AkMr58NBT223ES1UKFCZJaRFTGg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.18.0.tgz",
+      "integrity": "sha512-+NRJLZz9avT7ibcybil06gweudgulwKVSWIhQMzbWLI3NaronRvQ2R5uoag+yC+9oe4YZKqgzK9VgQkzogjXnA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.2.tgz",
-      "integrity": "sha512-3hWJvvOCLYOZNt0fMdH8atwQrrPF6eM3ftZcxPCch8/cW3AQ5jWIpYnP/s4hRhNFCWKkKW7Y5l/vBbT2LKEtUA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.18.0.tgz",
+      "integrity": "sha512-KX+FNt8SNEmVgHApZ2mweLSU6w7bXiUY7ktH5ScO4x24G4fwZW60i8HZpXGzCq2xshxcYKaiwfqFgTN3cHLOWQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.2.tgz",
-      "integrity": "sha512-9KdVhHe10UXN3RnZJ5pMT1WBpbKZxdOREpSq0tjN+o1EYEqnSw9EM5RrCVZx/OsljJzgzFNZRkhEr+zlmsr30A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.18.0.tgz",
+      "integrity": "sha512-mgVPiedvhJFJLqT2LmmGLyTOYqopXO/5z65mn3AiNfMv/40dEj9gcnAhiw8pOn/Zhj/3kl3UI29rWXeZjCqGJg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-ref-node": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-ref-node": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-responsive-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.2.tgz",
-      "integrity": "sha512-eH4x9JpJyw7/IPyqAE6EpNq4jp7OlMkHlirnAMJZsp0v6Ou/NhuIossFaxla/OMX4PtulGL1WsoeIX3D4B7fQQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.18.0.tgz",
+      "integrity": "sha512-G+V62k4iR9/C5Qeme6dfIWHtp3RH8R2Orf47A0B5EP5aYM9409/jDvE7u/1iWzBMPXYvGImLswatE7P73LRpJA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-button-group": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-button-group": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.2.tgz",
-      "integrity": "sha512-ZdpJINTnguUIGFkjrm/6MPl2KrAai3UrrVYBOjx2CBvYxnfAsu/zicQ54kIoqsoYXDnIx/9xCKLodKLlHhz6LA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.18.0.tgz",
+      "integrity": "sha512-G3r6WMo6KvubCgaFgEV62Qgfu7s9BSXA3nfN9GPoXIwQgMulba5RK2LsVAv+z2TmmlmGzIFlHhK5ykyempNiFA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.2.tgz",
-      "integrity": "sha512-IhocB11XsXFDI5hcEEXJJSeUfYZLKwqBWMh2TemFKEsafzFkGvmOEqppxrZD1J3wcWZAXODoSLoURcKIafQqLA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.18.0.tgz",
+      "integrity": "sha512-17jq8QNCbefC9yy4iP5Br0JFEb1RKME+QFW+c2ndWP8cQC5/EB/a4V3oEVJ+pK9M/eb4ljkdBWqexO3jQYLaHA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.2.tgz",
-      "integrity": "sha512-ewO5NYZptQUMJRkO1MFH5RdwtjFEpaVtLBbBAfmV7CevY+kY7q6KeITlBZW8J8alMM3lNF8HGg0ccTg0gJ7I8g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.18.0.tgz",
+      "integrity": "sha512-OTx7kyHO/HspBARTbtMLdsVY7KqSP+cKWDJvuJVKey43qTUCDSGkxHxRe7yoThUceuwEDZUtGEvTaalkUrRAtA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.2.tgz",
-      "integrity": "sha512-qOee3XhHOu7QsbBUp1TOGHBpiE+oj+BY8Eh/lC8cDkwGc9yTndM4SU+YX/HN1qcLfIvqiAu3TnX53/KOjyKdzw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.18.0.tgz",
+      "integrity": "sha512-fr8ZxC0Ti5oM1mKmQQx29FCAZ3LS8Cql/PxqO7vqdZneC8i/K8vGmCssgTRy6a+O+Lyqoc6V8KxZEX6ir86gHw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.2.tgz",
-      "integrity": "sha512-flDs3M9h+uAp8WJPXLLHNR9nLqDLU1TRTyCS3L7OYJz81/WuAwlvt3okezTJEC5dgtNH4guoIXJbHsY7XMVYNw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.18.0.tgz",
+      "integrity": "sha512-C7ADFl8P9M1y2v0ypZrozju5na6IGEdwJ/563M0umdDRA4pyzRgBC/c/EStSbQvTAKdO3ZXIuH+RZKpkIWL+2g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.2.tgz",
-      "integrity": "sha512-WwG5o5Gm1j3UKUYMCQW3PM2sIUHOecmxq1FQETyhUoPFJKRTgsP2J261pWk/2S+VbEEtKB1v0MlZWSdz60D3Ww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.18.0.tgz",
+      "integrity": "sha512-42B+nEBTsW/KPLKaKW5P5uwZXaxOvtz6NrdFuzjRVxWReyMRfpSWRzaiZrJsEPCq2DTSkPTX8TxdDMlr1Gd9Cg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.2.tgz",
-      "integrity": "sha512-IF4fcz4wGFy5qpi0hE5sWyTl5gnw0wrnDaCZapi0Xfie6le6m7CgJCz9dp8CWPQFl01UDWr/1eR6C0XEO0FlNQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.18.0.tgz",
+      "integrity": "sha512-7SllU9o6NVkvr5wagpXdkxSjqm4P76TWSPg0ZGas6ODTOyTPXBaPz95W6cWUVbF6k6Z6WUmlIcmS5x23JUncmQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.2.tgz",
-      "integrity": "sha512-08ma38W6h805EiHELsGojS+Q3CoBoVKoR5yIY5f1/Pb/a2etCcTVRmKQuAlUD1vc9sSBdJBsoNOeczZPy7xCYQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.18.0.tgz",
+      "integrity": "sha512-6IYJRO3JtGgfc+CwPvUmcIyY25m4rEVAUM7fqMQrk/WT+WGQSOqcXEGPlm2bVLx+0bKIUqfD/lohWhlYmUQZVw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.2.tgz",
-      "integrity": "sha512-DJkcQs519aSlezLMxTl/hf0gMAg1GVA6QiQhX6hOEARV4C6/TUpwDpXK/j9/5M9mtqjgPfDG97+SJi0iVgcsew==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.18.0.tgz",
+      "integrity": "sha512-uRmtMdCc2CLdOPIgHEu9Gbl6od8QVv32vr0969wS2MgeQeGo56Q1X6QyQoiUbO4j0/wREYWs983mPxXyhphbhw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.2.tgz",
-      "integrity": "sha512-7F49+dHg5l2a4Ftv0aZAkirZZlkhKDLjyupAX+/FvSiv+cJbmKwgmmre4n2fShWkxeJ4RKh/AT1MR1l8GzxH4g==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.18.0.tgz",
+      "integrity": "sha512-PZd3Z66KdfTc9VJJku4FtSCEXyPnlE+/tU81HJsmOkx45q0U9kcpnaOFNIswC7vjftCO3F5GrAGlbDf542wkRA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.2.tgz",
-      "integrity": "sha512-7k9ckDBrBf5O3UNveAIL2KIzXSZq8CE3C3HTn2k0EPjK0pZZXGYCc0u8fU8JuxNxX8GA3N8IeVOpM3OaHKa8vg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.18.0.tgz",
+      "integrity": "sha512-xcYbSLLaM3+zEqNxaJDSi3HdYpIQmJO97gKv/nXZZKpOwvPSKOWdiNeWEqtfPxMEmhLbWrzrHgw0FTQjbYOkkg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.2.tgz",
-      "integrity": "sha512-pjVK3gZ00ucXzsmB32EaxRXrxXbFSP+trcZm3qiFcD6cK2wLx6HMtcVxHgHGQR+OYJ/0v7Q7KvIBepC7gdA7fQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.18.0.tgz",
+      "integrity": "sha512-3uUV2OWDQfQj0Ui/muO6O0iBzNW0I0jxa1Z5Xj4NjqNfkcsF7TXdKLypMPB3NrgBvyG5IpCRFurQIVdd+F22ng==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.2.tgz",
-      "integrity": "sha512-5GjxdMTYbAsDcIhJqAfsdypkE7yHvYXrsSc6vTDldB3mn9yA3BxpgzAijWnjptugMhG/a9L7myODp3kt4k4Z/w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.18.0.tgz",
+      "integrity": "sha512-q2LymkAcN1PLUMu+fxp7XHxhSug5EU3c0QC+Jtbdjy8b1BWl+EULXhAvNy9zYN8BtRJ85PPIXptU8Ly8vHwxsw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-popover-container": "1.17.2",
-        "@umbraco-ui/uui-symbol-more": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-popover-container": "1.18.0",
+        "@umbraco-ui/uui-symbol-more": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.2.tgz",
-      "integrity": "sha512-LCwC3ZrMu1A624VZz1oNGzd1SQ5UImEH+hpptb0BunEOQ3JkOOiwNKJny/Sfc/Z+GAWFnrOiRxNQPBzgAWXFJw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.18.0.tgz",
+      "integrity": "sha512-fazWCxOotzDfuYKde/2CpvJrEVt0vgXuniw1NAs94Gc+hJ6fRQcNEddCzSf33QtZVVH3ov3EqHoKKOj5dourkg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.2.tgz",
-      "integrity": "sha512-6ZdTsIcSAPOT7K+YxLowEmQpRu330Vawqp7vuegC7VgmqFZerIGJZhPcJbLnUJJ5co8IH2IWj5DYyMLOx3Eqaw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.18.0.tgz",
+      "integrity": "sha512-B7iVItNSY3PJsui8HUBugCazFdFwNfuiLml+jqS2/leM+VUx/svwK1Z/Xb46qCo6DVN801lUy9KkCFJq/baCSA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.2.tgz",
-      "integrity": "sha512-bu5JTbgiJje6b5FTXNNjefaXhDZNiBeUaUgGDlG6c8q7Q/fdm5fqwcaOKQog2hc0dZn+thqeVHRZwFBrvsgeYg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.18.0.tgz",
+      "integrity": "sha512-2tnhjRPPbH4OfAGb6NMyuIxe9AYeKON0Op2v58Ydo2Y9LUSYnf/tccRKxX72p5a/FYAwLGZmqhBA62M2xYipEA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-button": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2",
-        "@umbraco-ui/uui-icon": "1.17.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-button": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0",
+        "@umbraco-ui/uui-icon": "1.18.0",
+        "@umbraco-ui/uui-icon-registry-essential": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.2.tgz",
-      "integrity": "sha512-6wrHbpd1C+vHJT4Y1rVh09+dPpHFpQslcVvrh9Jk4U2QJiAph6UURj6QbxKutQrYRH6snq2Nue4vHq++LYNS8w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.18.0.tgz",
+      "integrity": "sha512-1vdfySxVNf0ZIlpUmctT3vwjng1Vxnb3NxDeDZP76xqhIxwnoq7/Ku7J+T871N+zNB9UZgFziPOpbrpOF1g0Sg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-toast-notification": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-toast-notification": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.2.tgz",
-      "integrity": "sha512-9XSmjrwXzy6dc08f36bqcUaPUkKDApjlwF+CpjUgwrLtdGVjOrixNEQnj8oFSxQEas01VzO0rhH+mYzYNC6fwQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.18.0.tgz",
+      "integrity": "sha512-jBVbb1whgkm5FqPGhPmshYRpl2QNJz/UlUQTJxggh/OeOvWdPscowgZ2115zxTuBDr7pAL3xZNCyZsqHZtd0Jg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-css": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-css": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.2.tgz",
-      "integrity": "sha512-brc2pKPd7j5TKOFKdbkRaZQah03XYGAPlO7j3IkdM2AXQRc0BaVseD/xHb8FeENzTYLL4XL7rseYkn16GbBhFQ==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.18.0.tgz",
+      "integrity": "sha512-lWNGJbterJv4k489zl8PgEaCulBbiXYAwEUPLYr33jMAsPuxcYVbd6Rf9HZLZRw8O5153nP6RS2tN73VhGku6Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2",
-        "@umbraco-ui/uui-boolean-input": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0",
+        "@umbraco-ui/uui-boolean-input": "1.18.0"
       }
     },
     "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.2.tgz",
-      "integrity": "sha512-OxWccGa7VGjr1nvK0f6F6+DcqVYaW8QN/83Sg81eaKSg88Td15un3tws9w0BPjoaMYWFbvZXk3uofDs1V7vDrw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.18.0.tgz",
+      "integrity": "sha512-DLgnQkF5dWxH2hF+svjomESD+JS9/IwX6ikHgVIKF/7S/LMoeNwgvNaszUEewUzOpnY82Nl1jPl3xji3ZmLKww==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.2"
+        "@umbraco-ui/uui-base": "1.18.0"
       }
     },
     "node_modules/abort-controller": {
@@ -2594,14 +2491,6 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2715,9 +2604,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2726,9 +2615,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -2756,34 +2645,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
@@ -3342,21 +3203,10 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
-      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -3406,29 +3256,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
     "node_modules/marked": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
-      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3438,14 +3269,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
@@ -3753,25 +3576,14 @@
       }
     },
     "node_modules/prosemirror-changeset": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
-      "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
       }
     },
     "node_modules/prosemirror-commands": {
@@ -3852,53 +3664,15 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz",
+      "integrity": "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -3942,27 +3716,10 @@
         "prosemirror-view": "^1.41.4"
       }
     },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
-      }
-    },
     "node_modules/prosemirror-transform": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
-      "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3971,14 +3728,14 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.7",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
-      "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
+      "version": "1.41.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.9.tgz",
+      "integrity": "sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }
@@ -4001,17 +3758,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4429,14 +4175,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -4463,9 +4201,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "usync-history-client",
       "version": "17.3.6",
       "devDependencies": {
-        "@hey-api/openapi-ts": "^0.97.0",
+        "@hey-api/openapi-ts": "^0.97.3",
         "@jumoo/translate": "^17.2.3",
         "@jumoo/usync": "^17.0.4",
         "@rollup/plugin-node-resolve": "^15.3.1",
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.1.tgz",
-      "integrity": "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.2.tgz",
+      "integrity": "sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -113,15 +113,15 @@
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
-      "integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.2.tgz",
+      "integrity": "sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "yaml": "2.8.3"
+        "js-yaml": "4.1.1"
       },
       "engines": {
         "node": ">=22.13.0"
@@ -131,15 +131,15 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.97.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.0.tgz",
-      "integrity": "sha512-WZkKgrDlZpxKlDv2HkBCzaAYeuM+EtZKFmKGBv9/JblAKpX3JQTROi7PzlCZE3eisetRPSakbcRgn+LGyB7EiQ==",
+      "version": "0.97.3",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.3.tgz",
+      "integrity": "sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.1",
-        "@hey-api/json-schema-ref-parser": "1.4.1",
-        "@hey-api/shared": "0.4.2",
+        "@hey-api/codegen-core": "0.8.2",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
+        "@hey-api/shared": "0.4.5",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "@lukeed/ms": "2.0.2",
@@ -162,14 +162,14 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.2.tgz",
-      "integrity": "sha512-4fconS10E0Xr4/acV8G+BkApxaIStxrT0GhB9BDTQWvrFTy5/nV933SyFk8qImcbpKvgv9hpn3N+7bV8oFrbjA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.5.tgz",
+      "integrity": "sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.8.1",
-        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/codegen-core": "0.8.2",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
         "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
@@ -2358,6 +2358,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -2682,9 +2689,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2794,9 +2801,9 @@
       }
     },
     "node_modules/giget": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
-      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2926,6 +2933,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4400,22 +4420,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -136,7 +136,6 @@
       "integrity": "sha512-lk5C+WKl5yqEmliQihEyhX/jNcWlAykTSEqkDeKa9xSq5YDAzOFvx7oos8YTqiIzdc4TemtlEaB8Rns7+8A0qg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.7.4",
         "@hey-api/json-schema-ref-parser": "1.3.1",
@@ -247,6 +246,7 @@
       "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "eventsource": "^2.0.2",
@@ -261,6 +261,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -308,7 +309,8 @@
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -782,6 +784,7 @@
       "integrity": "sha512-eWi+77SgKyhSx91Hmn32ER+gPN6FfInGtod4A+XxSG+LqS/sn6kpUEdowYrnqiZzhUXZCSTSJvC+UcMUZHOkxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tiptap/core": "^3.16.0",
         "@tiptap/extension-blockquote": "^3.16.0",
@@ -834,6 +837,7 @@
       "integrity": "sha512-0wU6H/MWWes0rGzgSW6MMU6YDs/3ofUDkqmqCqmb+Siu1ZD0bpzOYpBtujgOYDY8moB9+zCE3G9HSYGcmZxHew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -848,6 +852,7 @@
       "integrity": "sha512-hraiiWkF58n8Jy0Wl3OGwjCTrGWwZZxez/IlexrzKQ/nMFdjDpensZucWwu59zhAM9fqZwGSLDtCFuak03WKnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -862,6 +867,7 @@
       "integrity": "sha512-MT3321R6F8AoVUEMJ5RiI0PQMenwvtmrSXoO1ehPCWq5TrSJLyXeZMJvZU+1CgfXk4XQU70RN78ib5+Zg+/FCg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -876,6 +882,7 @@
       "integrity": "sha512-jBZK/CfdMvg1gkNK/zNAk02IExpBPwUfNLRPiJvGhReL2Q73naKxZGQGp+5Lej9VaeFB70UKuRma/iIzuZbgsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -890,6 +897,7 @@
       "integrity": "sha512-0YZnqfqZ1IjzKBM4aezw8j3LZWJFEfs4+mbizHNlnZSYpKzpESYLeaLWGO5SpqF9Z8tmYmSoCaf0fqi5LwgdIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -905,6 +913,7 @@
       "integrity": "sha512-BpNGHtOTAjjs/6QbkrafMTlaJqb0gsPngFzd5rB0csxx7rYRE9nIEY+oZ44qMw161+2YB4u20L17SX2mUJANBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -919,6 +928,7 @@
       "integrity": "sha512-/lDG9OjvAv0ynmgFH17mt/GUeGT5bqu0iPW8JMgaRqlKawk+uUIv5SF5WkXS4SwxXih+hXdPEQD3PWZnxlQxAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -933,6 +943,7 @@
       "integrity": "sha512-H+bRr+mqU/DQq1vfoMlppK1o+RbfSKYBMIcAMHWOez+C96MWfj5bhooVU2HLtl4XGmQxKGr3oEOCKDPdtRNThg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -947,6 +958,7 @@
       "integrity": "sha512-+aILNDO7BsXf0IJ4/0BYh570usFK3Q1t/ZQd8zhHuO2ATeWeDVu1x2F+ouFS4X8fmoCcioMzw15aoz93GET6kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -961,6 +973,7 @@
       "integrity": "sha512-zXxuIrCSpzgXzRxgCbRE8DZ/NFuinVaniE3pp/9LYAWgRlsAyko8pI2XrVvzzXmDQqRGi2HrNVkNy1yutUWSWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -975,6 +988,7 @@
       "integrity": "sha512-4UtpUHg8cRzxWjJUGtni5VnXYbhsO7ygf1H1pr4Rv63XMBg9lfYDeSwByIuVy9biEFP7eGEFnezzb5Zlh1btmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -990,6 +1004,7 @@
       "integrity": "sha512-7bZCgdJVTvhR5vSmNgFQbGvgRoC6m26KcUpHqWiKA95kLL5Wk4YlMCIqdiDpvJ1eakeFEvDcGZvFLg5+1NiQ+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1004,6 +1019,7 @@
       "integrity": "sha512-0PukrSYnHX2CrGSThlKfQWxpPWmL7QAvdpDUraKknGvVNSH7tUjchTshy5JdLrn/SQAU92REowRCB6zzCNEFjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "linkifyjs": "^4.3.2"
       },
@@ -1038,6 +1054,7 @@
       "integrity": "sha512-pFJCGLIDEin1Xn6B3ctbrZvtYyALARE56ya4SmaNfnl+Hww5MfkRR40obbwYD3byA1yOpr+bECy+I2clQqzTDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1052,6 +1069,7 @@
       "integrity": "sha512-rmrQgOrUb0jKtFzVUfT0UNEST2sGM2Ve4lOl+1luh66RW6TD+gvgMk/qo12/Kffl9PUiqz8oYfk2qXCwFb6Bug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1066,6 +1084,7 @@
       "integrity": "sha512-Y/RIE3AxUNYAFKGMM5FLlTVKxxBvOh4JlLp/qYsOCY2nJdH0Jopl2FpfBYc4xoJwFSk8BELJ4Ow0adcYb15ksg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1080,6 +1099,7 @@
       "integrity": "sha512-mwuhwmff67IpGfOViyRvUC14IlkpsOnB+hSExVnq5+hCntjt/Cr2Z8GGOgzHeIM2FIS0UqX9Lv/b6ttUg4+Now==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1094,6 +1114,7 @@
       "integrity": "sha512-uwhvmfS4ciGYJRLUg0AHbWsprMCwyWVWd2RXOLRm0ZQeWkvzonPXZhJvzIhIgsFkPLj/dsN5t0+LdiK4UQMnyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1108,6 +1129,7 @@
       "integrity": "sha512-DMa9g5cH2d/Gx1KXtV7txTxaa6FBqgG8glmfug+N93VMb8sEZR1Yu1az++yAep4SGGq9GWIGZCUS3H6W66et6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1122,6 +1144,7 @@
       "integrity": "sha512-HMhr5KIAqZsEhlN8RxKHr/ql1a8OvBa9fLf69IwUVFolBcDExHWUtaEV/axYVRQJvvIy2oKGJxlJWDZ4hkotHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1216,7 +1239,8 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -1224,6 +1248,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1234,7 +1259,8 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -1387,6 +1413,7 @@
       "integrity": "sha512-58FCYYVcr/kDx3vCtBNKMUD/Wm9hLSRJ+Vcz7B+PB+Ksj5mHNXtfxEqwZkh8E1CXosrYVvd9IrGjjIo9keQx5w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button-group": "1.17.2"
@@ -1398,6 +1425,7 @@
       "integrity": "sha512-9tQ7YvHBfQhy30yI0c/+gAGOMGRBlAj06nalAlOeeRE96Gs+qLD4xFfmhdl4+A4QJNube/VvujTOShrlACdfqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1408,6 +1436,7 @@
       "integrity": "sha512-It0ml/h4PWm/Uoy7VdESJEV/xjvEJnC5dQjZlG6I6x+HmpejbJs8/EPNiWiksNff7A6yZ0zHNJOoZjJPTEcGmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.17.2",
         "@umbraco-ui/uui-base": "1.17.2"
@@ -1419,6 +1448,7 @@
       "integrity": "sha512-JLbzuWk7lsN2e3wLPxD4+gGTAoufIo+cAjIR+3+UAPY36PXwuUulnypuATLElqL5PPBQssjQmBF/K0o83V2HjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1429,6 +1459,7 @@
       "integrity": "sha512-UZkHUY2vdc61t9uq8ey2o4Qpb2aAAQC5HoeBqUu/lEpaWRezHk7QoFIeQrzo3QC2xUa6lSqmSuTYQRWUdFaH2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "lit": ">=2.8.0"
       }
@@ -1439,6 +1470,7 @@
       "integrity": "sha512-34gdbpSCQRUeLTzh0N+w4GazRbqR4bWAvi5HQe5N/qKrI/5ziQEVQNRaintmxTZ3S6WxxAbF5yaF60UbCW75iA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1449,6 +1481,7 @@
       "integrity": "sha512-tXBSnb1Gmxub7772SqQvHngbmMkrPzfZ6TorZkNLJlddlNgYJmpoGeFZKGVaJpwCOR+W3O7LcT/juOv+sPvv4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-css": "1.17.2"
@@ -1460,6 +1493,7 @@
       "integrity": "sha512-KRFyw7c0OS12zSPFN8A1uCFPdBEshN0SWHMXcZsP4nswjYkj6sJYe6sWUjDETgmgtf9zYK6SzUjI8gyZoFuLFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-responsive-container": "1.17.2"
@@ -1471,6 +1505,7 @@
       "integrity": "sha512-F3NO89b3vHOOhWrfM170Z383HsYf9Nji1LxZAedXtAyNzXjIGRKQH5cbiDJBZ8r9J51dVOl0glr23Di4SHiNsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon-registry-essential": "1.17.2"
@@ -1482,6 +1517,7 @@
       "integrity": "sha512-vbaykS2iQM5Lj1oJpSrkfMErYgeR/hxIsYdpGyl41Xc0XZbQxA6ZhhXuOwKnkALnJX3rr0myhSfzk+xBA1nZ6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2"
@@ -1493,6 +1529,7 @@
       "integrity": "sha512-XvSN8wngvTCPKgIRei1glKiMhBiATFpzNLuc1nJFnDoljlrehzbViwUNtGv+dtxe5XmdEp1cKQB5LW4PesQrZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1503,6 +1540,7 @@
       "integrity": "sha512-NLzwh0mMOIZSe3mj5bHy1vobSqU7VW/G1ixswngwj2FSBsIxLOZY32pECvXPA8dGfazH2Xl5dIIemyrh8vN4xw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1513,6 +1551,7 @@
       "integrity": "sha512-8WpXK0MU6ycSidpG41wTxWrn8iHR9A/xWZgx2wuol3qF73wakRVR7IdoWxsTAtj7uVg2xp6q19ABZLML+BUG9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-checkbox": "1.17.2"
@@ -1524,6 +1563,7 @@
       "integrity": "sha512-GPuUNj1rjy+HavtzkvF5LEDvYmhN5W7DTRB+5WSpUmX6cyNP/J+LJfx6q0FxOD1DtmLl3/lTLhZxfNe/E2QKsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-card": "1.17.2"
@@ -1535,6 +1575,7 @@
       "integrity": "sha512-21gwLrvS/A3CuYo0fdD5CLZEil+LehqNk0OY+OwYu07n72O0lQK97BTuwqrDI8IeRhm+xtAof45RiWPBu4ydww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-card": "1.17.2",
@@ -1547,6 +1588,7 @@
       "integrity": "sha512-pOs9DMkdFH00OZlYMfODCgA+BQA8EkTutkTdx1YiucmJUfRt+Lt6pnZjHn+BW0vuo1S69Bn4qXP+1XzbwCREqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-card": "1.17.2",
@@ -1560,6 +1602,7 @@
       "integrity": "sha512-jnqIMQ66pV1QDMxkDeljbnm+QTSpqyuTu4UIwWtEi2F2z4yIidZ7E5Ii9T1Z2lOW9hxKBuR4DG0LrxIg0ZeniA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-avatar": "1.17.2",
         "@umbraco-ui/uui-base": "1.17.2",
@@ -1572,6 +1615,7 @@
       "integrity": "sha512-8nDsGmr/K2uYpdKMImofvK9rYvdfLqppLOvXEE2JwzEsFT04LACm14rvTUsYHGKAAOYwCosb/NDm+bPCagJVvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1582,6 +1626,7 @@
       "integrity": "sha512-9NTKAdaqMHVnOyX7ya8pJ4hEyIh1p2DciOJCpL8Jy73K2NqsHl5VQLs7YR7LnijlAoJsOXKES0LxcYgfOzDOpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-boolean-input": "1.17.2",
@@ -1594,6 +1639,7 @@
       "integrity": "sha512-4NWt9OoyG81JvifcsrBufhOeJL1CBkmEeSIRms3Rokbsg6imeEJ/e6Ga4AJFauAhsroloxirf7QBfUUQ+lEueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "colord": "^2.9.3"
@@ -1605,6 +1651,7 @@
       "integrity": "sha512-SOpJtZb11gm33WZfRltmoSmRgw7JDsG14GqbBwi4KL556+GLzeNMRPswU4hDCb7e69A1hK8+oBoMIVQwXPB6vw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-popover-container": "1.17.2",
@@ -1617,6 +1664,7 @@
       "integrity": "sha512-sCygVWQHOw4eOxTl3EpN1/3BF9wLnnBostEWG8Om6EFRoXCb9DMBvh/kTfkF6ZoUIGxPFPAD1hpXF/ANtUka2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1627,6 +1675,7 @@
       "integrity": "sha512-hMAUzXDCNR2H4yPZDJmUig4kQt9xL/gH7ghcazYxeY7vuLLnGucxljTfTiZISqdjeQpheSt807gz9XnWDLY9Ng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
@@ -1639,6 +1688,7 @@
       "integrity": "sha512-M0flkhmZvcx2oYcn5ffK2z/ByKMEjALd4fy0BQ4Yzz4OerWFliojkXfv1Dc27Lyzl+UKJFf7LK61UY/MA2Z42Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-color-swatch": "1.17.2"
@@ -1650,6 +1700,7 @@
       "integrity": "sha512-X3PqQzpkvj8mfbjb/ntLgLPIWTy6Mvw2lIyPcOCGN6eg5CAai51qZjt/S9KSg5c//UQings3i//G/ycyIBKBEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -1666,6 +1717,7 @@
       "integrity": "sha512-EPVQfG692sS9XT+qn6QU4dUbGTgQzneF4sHcmbm6gyHfutW3pv0xCa43RspoXK8iMjNdrHEqZqW1bpSWIhp3fA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1687,6 +1739,7 @@
       "integrity": "sha512-6f89YWRvYUHcLLf5yZ5UXT36bPuRTBRt6AqCREy2NTox1M0e2fU4+T61UrEy8XjcF25+8Ylc+ETb7KCHeUb1FA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-css": "1.17.2"
@@ -1698,6 +1751,7 @@
       "integrity": "sha512-sBeFz6UZUtArP9/bnykuZVT1S4oYK9JjIOm36Z0Wurw893aPAHiNCq9hrCaZF8xmS+ZLrqSmkNhZ22slKWkw6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1708,6 +1762,7 @@
       "integrity": "sha512-1JnURFHBHpO/QCEaMXJOj1xj1ttOPjn7twxOlZeJgpZoKDepqxRCW2UX9vqwop+ge3LWoMMvSTxa6GNHBs34gA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-symbol-file-dropzone": "1.17.2"
@@ -1719,6 +1774,7 @@
       "integrity": "sha512-L+w5mMIcgwNlWA6/SAWoU9bpEbzEB/reVWALWOAScv1Lvqo/HmjjxHMclFJzm+6DSM3euH53X2zOHmAp1oUnOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-symbol-file": "1.17.2",
@@ -1732,6 +1788,7 @@
       "integrity": "sha512-39ynzYgPdhpDSyVxpBJBDPrRmGKfnhcHVrMTcv5ITUnmsHizqd4tK5+gdf5tcHXrAxb+AWHEufwjjNcRHdl/Ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1742,6 +1799,7 @@
       "integrity": "sha512-FLDd+Y5x/6L8cHAPzicX/e4mxH/tx2DBWuzXV4MeNp8eRS132xCBM9laI+1/dnBjCzYzJuVd8ibmFO0+Yjf8Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-form-validation-message": "1.17.2"
@@ -1753,6 +1811,7 @@
       "integrity": "sha512-AWI9WC7wZW7qgrZ1EUnzCt40KdB1iiJBPwUnyffm4L3MsGyUVEQYYO96v/y04PGFr6DUlcDlAerhSqcsaJK7Kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1763,6 +1822,7 @@
       "integrity": "sha512-7WmGW3nn7IeL5nMZtIYaSWaV0AeBoE90rfAqjbK/fHzyDtgM1gsokXhCtEQH9VLnjFfs02bXF+Xlw+ZEP3+p5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1773,6 +1833,7 @@
       "integrity": "sha512-P5ypiDGswu0uPhyVcltuFHLkVax9DURUgz2jgsuNDkLJh4BW34TFTHu7c7XKVRzVMIb7356SxO8B+q6fYEPNqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon": "1.17.2"
@@ -1784,6 +1845,7 @@
       "integrity": "sha512-vfumKb+H6bT1tTMKOHK/rZW4QDBxzANzAqvAqpeB7n0EEd5j+82tSv15DDZDlyXHvMNUnoBrI+zNpCYsDbNV5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon-registry": "1.17.2"
@@ -1795,6 +1857,7 @@
       "integrity": "sha512-8aoM58rkLEYdQljWHBA8hgwEqnjeVXzFfMdO+QuwgLpKEBZij/33iWBl2j/IGmxByiFcxSvsbzEFhXHNRlU4Jg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1805,6 +1868,7 @@
       "integrity": "sha512-bWwp6KkMDuMvIjmRh9WOXBdVyaEdcCyvdqBYss+BrXEeHF+Qs9SMHK4giLGAosYIWxzctmT9tUZfUpuJu8QP0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-action-bar": "1.17.2",
         "@umbraco-ui/uui-base": "1.17.2",
@@ -1820,6 +1884,7 @@
       "integrity": "sha512-Vu6TViMQuERTqx5kd518aujwrtztxbErHqAw1VNl6aT1q4GoADLtVyxnFYMhtg6mokUJL4ZxTxMuiAKVLjJM9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -1833,6 +1898,7 @@
       "integrity": "sha512-a7hLURjTwNpuqepeBAWOGyKmvuy9dPXs2YdxakaoUsia486gjerIZOKv29vQ83Uw5EivdvYZMuFGM4TngQZ26g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon-registry-essential": "1.17.2",
@@ -1845,6 +1911,7 @@
       "integrity": "sha512-2XXU9p80iGJVsHvIDA4u/IsRTD1psW5yEmWZbUJI0nouhGfoBGjF6mgo2AYEVczrP90JBvWJhhunCe1JfPK9WQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1855,6 +1922,7 @@
       "integrity": "sha512-xbvmKU2zGNaIo1Zn7cOy6EmidxzFYoihsEkbOrMBItbebhZcZc+MUHuEFr+brgMHowk0CtUJnITjpSsow/4BUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1865,6 +1933,7 @@
       "integrity": "sha512-wnR47k7zbDG4upQmucTuaNyyFR9VKVoBiGLTGTITNvK66G+EpwL96xwd3YqbJx4oRXQEkCyorlbE8oxY2B9Xig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1875,6 +1944,7 @@
       "integrity": "sha512-KHe1W3pHaJ5SX+D1TcLOYti5Z+RuVd5o0Wm4XONvWN7DZ/cs1E8pO0mvgJYLZbZv989u9RwhH4cuOCxTByt4ew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1885,6 +1955,7 @@
       "integrity": "sha512-pYXvXEhm+oNWDNc2QKNDK9nILAPnegyTkQEdhBumF5RqISCZT0OXufhP8//Ez7Ao/c84I0Jv/jVNqgmDIxg0wg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1895,6 +1966,7 @@
       "integrity": "sha512-aDAp61Z/3/1qQN34phkekYHH+IpCldNp26VF4PZBb7YlpxYfbEbO/xKqxkRQYvrEeq1TNpDQF8vhmbJn0BdmaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-loader-bar": "1.17.2",
@@ -1907,6 +1979,7 @@
       "integrity": "sha512-IFrpRuFrouYo8DqrK1DyrGWkmHbf8sP5OQjCqYfmZ15AwqPt791h4uwTponrjJVOwFwy2sq3mZPAR7ob/V/6DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1917,6 +1990,7 @@
       "integrity": "sha512-ECWL/9p5IDBf8EKES9pG8QL+5hNNagmtE+3hCZH2x+D3yW28fcMh8SW5QtBgfebBNXdZAp4lrxcTtUyFA6By+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -1929,6 +2003,7 @@
       "integrity": "sha512-Pqh7k+ZpEGGMdpRbNO6+6p9ggZ/wtZs9MyylB6/56PLlIepVqhGBqlJbJ6+z4Ph4S752btMmqz04GdJ09yaZuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1939,6 +2014,7 @@
       "integrity": "sha512-lCzQFUo3QESYbKkk69KJMC5cmJ4VS3hEPdSRATzBqEDtzj/h6aEdrww1EOAOOLCw+JgNd0wKS/+sp3RCmiZxeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1949,6 +2025,7 @@
       "integrity": "sha512-I/T0K4l9QcWJGSOI4G7Zr4uMz/UjgM4nA7ebjDc2cgY5hLcefknFS5LSGWjPxTe+R9OIFFkFXLvQqlFZnH2AcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1959,6 +2036,7 @@
       "integrity": "sha512-iDvaEUltTAAwqRYY/8bIRyfN2j9vGc3CpZlWNe5nC2QOD+tPVEq5MWyg3N3Gbx6K9bkg+DrIAblk2Mc8YFEHAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1969,6 +2047,7 @@
       "integrity": "sha512-mjgxoHQnkIKrYv2I1mjESgSy8yPZOSHoFURoeh9fc3G0bnkoTbNwLMKMWL3NSQObHo+TpK6djSaiXLB1vIAwJA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1979,6 +2058,7 @@
       "integrity": "sha512-SWyS/sduAw8vmesw0Sm7jsblhZ7i9vckOAzCQs2Hrbtssgq1EZ0PkkICS2Vg3rVnR0HSYt8T2s7Fy7yjK4MYHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1989,6 +2069,7 @@
       "integrity": "sha512-LzKcN94JSpbH0YmpBj9fl58WdwFeGbovFhLBInUcLOX8WqK0E+lNdBLRya7l8KYIKmhQKE3TUbqiN6Qcwhr2mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -1999,6 +2080,7 @@
       "integrity": "sha512-C6fqnEDYlGlqF3gEQFPy8908LcZLzPqhVHC1p6AXXNkTPnnKqSAPxRPKRUk7XUoQSYFDXfCzFnlyKdlpWSIJBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-icon": "1.17.2",
@@ -2011,6 +2093,7 @@
       "integrity": "sha512-nEEKv8TYjueZprnfFg9sW1u/Y3Z8X+IqGPWRg0Hx+gLLKmOPHbvlYUIB8M4Q4G61XlcY8dfw+TDZ8kxTekmEWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2022,6 +2105,7 @@
       "integrity": "sha512-w+qe2g9FDUTHLzRStffDOoudHUeWw+RXgoOLtI8f5xktbuKDcpz6qiIOIvTO9ipfy9vpbU/WiUr7OSBVdxGSaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2033,6 +2117,7 @@
       "integrity": "sha512-056oxK3ffKIERFfYgYG+Ies4S75TPEdME1WXYYG6p9QzfZ06Y0VaNCQbzoHwS8CcbtO5/m2C3BXB6b0l26lDkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2044,6 +2129,7 @@
       "integrity": "sha512-oeWQHu7u1/xK9IOnm5YMceLPzfGsuIsYyU+UJRJkwIiWYT155gosdGoxCz/AkMr58NBT223ES1UKFCZJaRFTGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2055,6 +2141,7 @@
       "integrity": "sha512-3hWJvvOCLYOZNt0fMdH8atwQrrPF6eM3ftZcxPCch8/cW3AQ5jWIpYnP/s4hRhNFCWKkKW7Y5l/vBbT2LKEtUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2066,6 +2153,7 @@
       "integrity": "sha512-9KdVhHe10UXN3RnZJ5pMT1WBpbKZxdOREpSq0tjN+o1EYEqnSw9EM5RrCVZx/OsljJzgzFNZRkhEr+zlmsr30A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-ref-node": "1.17.2"
@@ -2077,6 +2165,7 @@
       "integrity": "sha512-eH4x9JpJyw7/IPyqAE6EpNq4jp7OlMkHlirnAMJZsp0v6Ou/NhuIossFaxla/OMX4PtulGL1WsoeIX3D4B7fQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -2091,6 +2180,7 @@
       "integrity": "sha512-ZdpJINTnguUIGFkjrm/6MPl2KrAai3UrrVYBOjx2CBvYxnfAsu/zicQ54kIoqsoYXDnIx/9xCKLodKLlHhz6LA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2101,6 +2191,7 @@
       "integrity": "sha512-IhocB11XsXFDI5hcEEXJJSeUfYZLKwqBWMh2TemFKEsafzFkGvmOEqppxrZD1J3wcWZAXODoSLoURcKIafQqLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2111,6 +2202,7 @@
       "integrity": "sha512-ewO5NYZptQUMJRkO1MFH5RdwtjFEpaVtLBbBAfmV7CevY+kY7q6KeITlBZW8J8alMM3lNF8HGg0ccTg0gJ7I8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2121,6 +2213,7 @@
       "integrity": "sha512-qOee3XhHOu7QsbBUp1TOGHBpiE+oj+BY8Eh/lC8cDkwGc9yTndM4SU+YX/HN1qcLfIvqiAu3TnX53/KOjyKdzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2131,6 +2224,7 @@
       "integrity": "sha512-flDs3M9h+uAp8WJPXLLHNR9nLqDLU1TRTyCS3L7OYJz81/WuAwlvt3okezTJEC5dgtNH4guoIXJbHsY7XMVYNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2141,6 +2235,7 @@
       "integrity": "sha512-WwG5o5Gm1j3UKUYMCQW3PM2sIUHOecmxq1FQETyhUoPFJKRTgsP2J261pWk/2S+VbEEtKB1v0MlZWSdz60D3Ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2151,6 +2246,7 @@
       "integrity": "sha512-IF4fcz4wGFy5qpi0hE5sWyTl5gnw0wrnDaCZapi0Xfie6le6m7CgJCz9dp8CWPQFl01UDWr/1eR6C0XEO0FlNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2161,6 +2257,7 @@
       "integrity": "sha512-08ma38W6h805EiHELsGojS+Q3CoBoVKoR5yIY5f1/Pb/a2etCcTVRmKQuAlUD1vc9sSBdJBsoNOeczZPy7xCYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2171,6 +2268,7 @@
       "integrity": "sha512-DJkcQs519aSlezLMxTl/hf0gMAg1GVA6QiQhX6hOEARV4C6/TUpwDpXK/j9/5M9mtqjgPfDG97+SJi0iVgcsew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2181,6 +2279,7 @@
       "integrity": "sha512-7F49+dHg5l2a4Ftv0aZAkirZZlkhKDLjyupAX+/FvSiv+cJbmKwgmmre4n2fShWkxeJ4RKh/AT1MR1l8GzxH4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2191,6 +2290,7 @@
       "integrity": "sha512-7k9ckDBrBf5O3UNveAIL2KIzXSZq8CE3C3HTn2k0EPjK0pZZXGYCc0u8fU8JuxNxX8GA3N8IeVOpM3OaHKa8vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2201,6 +2301,7 @@
       "integrity": "sha512-pjVK3gZ00ucXzsmB32EaxRXrxXbFSP+trcZm3qiFcD6cK2wLx6HMtcVxHgHGQR+OYJ/0v7Q7KvIBepC7gdA7fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2211,6 +2312,7 @@
       "integrity": "sha512-5GjxdMTYbAsDcIhJqAfsdypkE7yHvYXrsSc6vTDldB3mn9yA3BxpgzAijWnjptugMhG/a9L7myODp3kt4k4Z/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -2224,6 +2326,7 @@
       "integrity": "sha512-LCwC3ZrMu1A624VZz1oNGzd1SQ5UImEH+hpptb0BunEOQ3JkOOiwNKJny/Sfc/Z+GAWFnrOiRxNQPBzgAWXFJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2234,6 +2337,7 @@
       "integrity": "sha512-6ZdTsIcSAPOT7K+YxLowEmQpRu330Vawqp7vuegC7VgmqFZerIGJZhPcJbLnUJJ5co8IH2IWj5DYyMLOx3Eqaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2244,6 +2348,7 @@
       "integrity": "sha512-bu5JTbgiJje6b5FTXNNjefaXhDZNiBeUaUgGDlG6c8q7Q/fdm5fqwcaOKQog2hc0dZn+thqeVHRZwFBrvsgeYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-button": "1.17.2",
@@ -2258,6 +2363,7 @@
       "integrity": "sha512-6wrHbpd1C+vHJT4Y1rVh09+dPpHFpQslcVvrh9Jk4U2QJiAph6UURj6QbxKutQrYRH6snq2Nue4vHq++LYNS8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-toast-notification": "1.17.2"
@@ -2269,6 +2375,7 @@
       "integrity": "sha512-9XSmjrwXzy6dc08f36bqcUaPUkKDApjlwF+CpjUgwrLtdGVjOrixNEQnj8oFSxQEas01VzO0rhH+mYzYNC6fwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-css": "1.17.2"
@@ -2280,6 +2387,7 @@
       "integrity": "sha512-brc2pKPd7j5TKOFKdbkRaZQah03XYGAPlO7j3IkdM2AXQRc0BaVseD/xHb8FeENzTYLL4XL7rseYkn16GbBhFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2",
         "@umbraco-ui/uui-boolean-input": "1.17.2"
@@ -2291,6 +2399,7 @@
       "integrity": "sha512-OxWccGa7VGjr1nvK0f6F6+DcqVYaW8QN/83Sg81eaKSg88Td15un3tws9w0BPjoaMYWFbvZXk3uofDs1V7vDrw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@umbraco-ui/uui-base": "1.17.2"
       }
@@ -2301,6 +2410,7 @@
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2454,7 +2564,8 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -2488,7 +2599,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2651,6 +2763,7 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -2664,6 +2777,7 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2684,6 +2798,7 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2694,6 +2809,7 @@
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2753,6 +2869,7 @@
       "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
       "dev": true,
       "license": "Unlicense",
+      "peer": true,
       "dependencies": {
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
@@ -3231,6 +3348,7 @@
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -3240,7 +3358,8 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -3248,7 +3367,6 @@
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -3294,6 +3412,7 @@
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -3325,7 +3444,8 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
@@ -3333,6 +3453,7 @@
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -3344,6 +3465,7 @@
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3354,6 +3476,7 @@
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3502,7 +3625,8 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-key": {
       "version": "4.0.0",
@@ -3571,9 +3695,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -3634,6 +3758,7 @@
       "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
       }
@@ -3644,6 +3769,7 @@
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -3654,6 +3780,7 @@
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -3666,6 +3793,7 @@
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -3678,6 +3806,7 @@
       "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -3691,6 +3820,7 @@
       "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -3704,6 +3834,7 @@
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -3715,6 +3846,7 @@
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -3726,6 +3858,7 @@
       "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
@@ -3738,6 +3871,7 @@
       "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "crelt": "^1.0.0",
         "prosemirror-commands": "^1.0.0",
@@ -3762,6 +3896,7 @@
       "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.0"
       }
@@ -3772,6 +3907,7 @@
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -3797,6 +3933,7 @@
       "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.2.3",
         "prosemirror-model": "^1.25.4",
@@ -3811,6 +3948,7 @@
       "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@remirror/core-constants": "3.0.0",
         "escape-string-regexp": "^4.0.0"
@@ -3827,6 +3965,7 @@
       "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
@@ -3850,6 +3989,7 @@
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -3863,6 +4003,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3873,6 +4014,7 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3882,7 +4024,8 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rc9": {
       "version": "2.1.2",
@@ -3914,7 +4057,8 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4100,7 +4244,8 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -4144,7 +4289,8 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4232,6 +4378,7 @@
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -4248,6 +4395,7 @@
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4257,7 +4405,8 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -4272,7 +4421,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4286,7 +4434,8 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -4307,6 +4456,7 @@
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -4333,7 +4483,6 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4483,7 +4632,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -4500,7 +4650,8 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -4508,6 +4659,7 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -4535,6 +4687,7 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -4383,9 +4383,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.5",
+  "version": "17.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.5",
+      "version": "17.3.6",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.97.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.2",
+  "version": "17.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.2",
+      "version": "17.3.3",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.95.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3491,9 +3491,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3511,7 +3511,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "usync-history-client",
       "version": "17.3.5",
       "devDependencies": {
-        "@hey-api/openapi-ts": "^0.95.0",
+        "@hey-api/openapi-ts": "^0.97.0",
         "@jumoo/translate": "^17.2.3",
         "@jumoo/usync": "^17.0.4",
         "@rollup/plugin-node-resolve": "^15.3.1",
@@ -94,64 +94,65 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.7.4.tgz",
-      "integrity": "sha512-DGd9yeSQzflOWO3Y5mt1GRXkXH9O/yIMgbxPjwLI3jwu/3nAjoXXD26lEeFb6tclYlg0JAqTIs5d930G/qxHeA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.1.tgz",
+      "integrity": "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
-        "c12": "3.3.3",
+        "c12": "3.3.4",
         "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.3.1.tgz",
-      "integrity": "sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
+      "integrity": "sha512-DoPJGxVApDlktP1yYLjmOrF0YBEqb32ieCbx1S1i09n8TyCgdoh4yQaQ3kp0sMTauH+bwNKPsFh7S8qiWCoKZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.1.1"
+        "yaml": "2.8.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.95.0.tgz",
-      "integrity": "sha512-lk5C+WKl5yqEmliQihEyhX/jNcWlAykTSEqkDeKa9xSq5YDAzOFvx7oos8YTqiIzdc4TemtlEaB8Rns7+8A0qg==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.0.tgz",
+      "integrity": "sha512-WZkKgrDlZpxKlDv2HkBCzaAYeuM+EtZKFmKGBv9/JblAKpX3JQTROi7PzlCZE3eisetRPSakbcRgn+LGyB7EiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.7.4",
-        "@hey-api/json-schema-ref-parser": "1.3.1",
-        "@hey-api/shared": "0.3.0",
-        "@hey-api/spec-types": "0.1.0",
+        "@hey-api/codegen-core": "0.8.1",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/shared": "0.4.2",
+        "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
         "color-support": "1.1.3",
         "commander": "14.0.3",
-        "get-tsconfig": "4.13.6"
+        "get-tsconfig": "4.14.0"
       },
       "bin": {
         "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -161,32 +162,32 @@
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.3.0.tgz",
-      "integrity": "sha512-G+4GPojdLEh9bUwRG88teMPM1HdqMm/IsJ38cbnNxhyDu1FkFGwilkA1EqnULCzfTam/ZoZkaLdmAd8xEh4Xsw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.2.tgz",
+      "integrity": "sha512-4fconS10E0Xr4/acV8G+BkApxaIStxrT0GhB9BDTQWvrFTy5/nV933SyFk8qImcbpKvgv9hpn3N+7bV8oFrbjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hey-api/codegen-core": "0.7.4",
-        "@hey-api/json-schema-ref-parser": "1.3.1",
-        "@hey-api/spec-types": "0.1.0",
+        "@hey-api/codegen-core": "0.8.1",
+        "@hey-api/json-schema-ref-parser": "1.4.1",
+        "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
         "cross-spawn": "7.0.6",
         "open": "11.0.0",
-        "semver": "7.7.3"
+        "semver": "7.7.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.13.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/spec-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.1.0.tgz",
-      "integrity": "sha512-StS4RrAO5pyJCBwe6uF9MAuPflkztriW+FPnVb7oEjzDYv1sxPwP+f7fL6u6D+UVrKpZ/9bPNx/xXVdkeWPU6A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -238,6 +239,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.4.0"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@microsoft/signalr": {
@@ -2347,13 +2358,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -2371,24 +2375,24 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
-      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^17.2.3",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
         "exsolve": "^1.0.8",
-        "giget": "^2.0.0",
+        "giget": "^3.2.0",
         "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2"
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
         "magicast": "*"
@@ -2458,16 +2462,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
-    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -2502,16 +2496,6 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2602,9 +2586,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2648,9 +2632,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -2797,9 +2781,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2810,19 +2794,11 @@
       }
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.0.tgz",
+      "integrity": "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -2950,19 +2926,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3388,13 +3351,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/node-fetch-native": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -3411,31 +3367,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "citty": "^0.2.0",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -3528,14 +3459,14 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
       }
     },
@@ -3796,14 +3727,14 @@
       "peer": true
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/readdirp": {
@@ -4040,9 +3971,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4112,16 +4043,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -4479,6 +4400,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.6",
+  "version": "17.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.6",
+      "version": "17.3.7",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.97.3",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -19,7 +19,7 @@
         "prettier": "^3.8.1",
         "rm-rs": "^0.2.3",
         "typescript": "^5.9.3",
-        "vite": "^8.0.5",
+        "vite": "^8.0.16",
         "vite-plugin-checker": "^0.12.0"
       }
     },
@@ -49,21 +49,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -278,26 +278,28 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
-      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -305,9 +307,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -322,9 +324,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -339,9 +341,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -356,9 +358,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -373,9 +375,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -390,13 +392,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,13 +412,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -424,13 +432,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,13 +452,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -458,13 +472,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,13 +492,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -492,9 +512,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -509,9 +529,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -519,16 +539,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -543,9 +565,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -560,9 +582,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1126,9 +1148,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3308,9 +3330,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "dev": true,
       "funding": [
         {
@@ -3518,9 +3540,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3538,7 +3560,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3952,14 +3974,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3968,21 +3990,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rope-sequence": {
@@ -4102,14 +4124,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -4216,17 +4238,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4242,7 +4264,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/uSync.History/history-client/package-lock.json
+++ b/uSync.History/history-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usync-history-client",
-      "version": "17.3.3",
+      "version": "17.3.4",
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.95.0",
         "@jumoo/translate": "^17.2.3",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -17,7 +17,7 @@
     "generate-client": "node scripts/generate-openapi.js https://localhost:44398/umbraco/swagger/uSync.History/swagger.json?urls.primaryName=uSync+Management+Api"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "^0.95.0",
+    "@hey-api/openapi-ts": "^0.97.0",
     "@jumoo/translate": "^17.2.3",
     "@jumoo/usync": "^17.0.4",
     "@rollup/plugin-node-resolve": "^15.3.1",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.2",
+  "version": "17.3.3",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -21,7 +21,7 @@
     "@jumoo/translate": "^17.2.3",
     "@jumoo/usync": "^17.0.4",
     "@rollup/plugin-node-resolve": "^15.3.1",
-    "@umbraco-cms/backoffice": "^17.3.0",
+    "@umbraco-cms/backoffice": "^17.5.0-rc",
     "chalk": "^5.6.2",
     "lit": "^3.3.2",
     "node-fetch": "^3.3.2",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -28,7 +28,7 @@
     "prettier": "^3.8.1",
     "rm-rs": "^0.2.3",
     "typescript": "^5.9.3",
-    "vite": "^8.0.5",
+    "vite": "^8.0.16",
     "vite-plugin-checker": "^0.12.0"
   }
 }

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.6",
+  "version": "17.3.7",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.5",
+  "version": "17.3.6",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -17,7 +17,7 @@
     "generate-client": "node scripts/generate-openapi.js https://localhost:44398/umbraco/swagger/uSync.History/swagger.json?urls.primaryName=uSync+Management+Api"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "^0.97.0",
+    "@hey-api/openapi-ts": "^0.97.3",
     "@jumoo/translate": "^17.2.3",
     "@jumoo/usync": "^17.0.4",
     "@rollup/plugin-node-resolve": "^15.3.1",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.4",
+  "version": "17.3.5",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.History/history-client/package.json
+++ b/uSync.History/history-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usync-history-client",
-  "version": "17.3.3",
+  "version": "17.3.4",
   "licence": "Custom",
   "description": "uSync history function",
   "type": "module",

--- a/uSync.History/uSyncHistory.cs
+++ b/uSync.History/uSyncHistory.cs
@@ -24,7 +24,7 @@ namespace uSync.History
         public int SortOrder => 20;
     }
 
-    internal class SyncHistoryConstants
+    internal sealed class SyncHistoryConstants
     {
         public const string ApiName = "uSync.History";
         public const string AppName = "uSync.History";

--- a/uSync.History/uSyncHistoryComposer.cs
+++ b/uSync.History/uSyncHistoryComposer.cs
@@ -18,6 +18,7 @@ using Umbraco.Extensions;
 
 using uSync.BackOffice;
 using uSync.BackOffice.Extensions;
+using uSync.Core.Extensions;
 using uSync.History.Service;
 
 namespace uSync.History
@@ -26,6 +27,10 @@ namespace uSync.History
     {
         public void Compose(IUmbracoBuilder builder)
         {
+            // don't load if the backoffice is not loaded as part of the project. 
+            if (builder.IsUmbracoBackOfficeEnabled() is false)
+                return;
+
             builder.Services.AddSingleton<ISyncHistoryService, SyncHistoryService>();
 
             builder.AddNotificationAsyncHandler<uSyncImportCompletedNotification, uSyncHistoryNotificationHandler>();

--- a/uSync.SchemaGenerator/AppSettings.cs
+++ b/uSync.SchemaGenerator/AppSettings.cs
@@ -4,14 +4,14 @@ using uSync.BackOffice.Configuration;
 
 namespace uSync;
 
-internal class AppSettings
+internal sealed class AppSettings
 {
     public uSyncDefinition uSync { get; set; }
 
     /// <summary>
     /// Configuration of uSync settings
     /// </summary>
-    internal class uSyncDefinition
+    internal sealed class uSyncDefinition
     {
         /// <summary>
         /// uSync settings
@@ -33,12 +33,12 @@ internal class AppSettings
         /// </summary>
         public AutoTemplatesDefinition AutoTemplates { get; set; }
 
-        internal class uSyncSetsDefinition
+        internal sealed class uSyncSetsDefinition
         {
             public uSyncHandlerSetSettings Default { get; set; }
         }
 
-        internal class AutoTemplatesDefinition
+        internal sealed class AutoTemplatesDefinition
         {
             /// <summary>
             /// Enable AutoTemplates feature

--- a/uSync.SchemaGenerator/Options.cs
+++ b/uSync.SchemaGenerator/Options.cs
@@ -2,7 +2,7 @@
 
 namespace uSync;
 
-internal class Options
+internal sealed class Options
 {
     [Option('o', "outputFile", Required = false,
         HelpText = "",

--- a/uSync.SchemaGenerator/Program.cs
+++ b/uSync.SchemaGenerator/Program.cs
@@ -10,7 +10,7 @@ namespace uSync;
 ///  Generate the JSON Schema file for uSync. 
 ///   just like in the Umbraco Core - https://github.com/umbraco/Umbraco-CMS/tree/v9/contrib/src/JsonSchema
 /// </summary>
-internal class Program
+internal sealed class Program
 {
     public static async Task Main(string[] args)
     {

--- a/uSync.Tests/Cache/SyncEntityCacheTests.cs
+++ b/uSync.Tests/Cache/SyncEntityCacheTests.cs
@@ -1,0 +1,75 @@
+using System;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+
+using uSync.Core.Cache;
+
+namespace uSync.Tests.Cache;
+
+[TestFixture]
+internal class SyncEntityCacheTests
+{
+    private Mock<IEntityService> _entityServiceMock;
+    private Mock<IContentTypeService> _contentTypeServiceMock;
+    private SyncEntityCache _cache;
+
+    [SetUp]
+    public void Setup()
+    {
+        _entityServiceMock = new Mock<IEntityService>();
+        _contentTypeServiceMock = new Mock<IContentTypeService>();
+        _cache = new SyncEntityCache(_entityServiceMock.Object, _contentTypeServiceMock.Object);
+    }
+
+    [Test]
+    public void AddName_ThenGetName_RoundTrips()
+    {
+        var id = 1234;
+        var key = Guid.NewGuid();
+
+        _cache.AddName(id, key, "Test Name");
+
+        var result = _cache.GetName(id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Key, Is.EqualTo(key));
+            Assert.That(result.Name, Is.EqualTo("Test Name"));
+        });
+    }
+
+    // regression for uSync.Complete issue #304 - GetName used to read from the
+    // entity cache, which holds IEntitySlim objects under the same id key. That
+    // threw a swallowed InvalidCastException (IEntitySlim -> CachedName) and
+    // never returned the name. GetName must read from the name cache instead.
+    [Test]
+    public void GetName_WhenEntityCachedUnderSameId_StillReturnsName()
+    {
+        var id = 4321;
+        var key = Guid.NewGuid();
+
+        var entityMock = new Mock<IEntitySlim>();
+        entityMock.SetupGet(x => x.Id).Returns(id);
+        _entityServiceMock.Setup(x => x.Get(id)).Returns(entityMock.Object);
+
+        // populate the entity cache for this id (as GetFriendlyPath does).
+        _ = _cache.GetEntity(id);
+
+        _cache.AddName(id, key, "Real Name");
+
+        var result = _cache.GetName(id);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Key, Is.EqualTo(key));
+            Assert.That(result.Name, Is.EqualTo("Real Name"));
+        });
+    }
+}

--- a/uSync.Tests/Extensions/TryConvertPreCheckedTests.cs
+++ b/uSync.Tests/Extensions/TryConvertPreCheckedTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Text.Json;
+
+using NUnit.Framework;
+
+using uSync.Core.Extensions;
+
+namespace uSync.Tests.Extensions;
+
+/// <summary>
+///  tests for the JsonElement pre-check that avoids the swallowed
+///  InvalidCastException Umbraco's TryConvertTo throws on JsonElement values
+///  (uSync.Complete issue #304).
+/// </summary>
+[TestFixture]
+internal class TryConvertPreCheckedTests
+{
+    [Test]
+    public void JsonElementTrue_ConvertsToBool()
+    {
+        object value = JsonSerializer.SerializeToElement(true);
+
+        var success = value.TryConvertPreChecked<bool>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.True);
+        });
+    }
+
+    [Test]
+    public void JsonElementFalse_ConvertsToBool()
+    {
+        object value = JsonSerializer.SerializeToElement(false);
+
+        var success = value.TryConvertPreChecked<bool>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.False);
+        });
+    }
+
+    [Test]
+    public void JsonElementNumber_ConvertsToInt()
+    {
+        object value = JsonSerializer.SerializeToElement(42);
+
+        var success = value.TryConvertPreChecked<int>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.EqualTo(42));
+        });
+    }
+
+    [Test]
+    public void JsonElementString_ConvertsToGuid()
+    {
+        var guid = Guid.NewGuid();
+        object value = JsonSerializer.SerializeToElement(guid.ToString());
+
+        var success = value.TryConvertPreChecked<Guid>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.EqualTo(guid));
+        });
+    }
+
+    [Test]
+    public void JsonElementString_ConvertsToString()
+    {
+        object value = JsonSerializer.SerializeToElement("hello");
+
+        var success = value.TryConvertPreChecked<string>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.EqualTo("hello"));
+        });
+    }
+
+    // a plain CLR value skips the JsonElement branch and still converts via
+    // the TryConvertTo fallback - behaviour must be unchanged for these.
+    [Test]
+    public void PlainString_ConvertsToInt_ViaFallback()
+    {
+        object value = "42";
+
+        var success = value.TryConvertPreChecked<int>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.True);
+            Assert.That(result, Is.EqualTo(42));
+        });
+    }
+
+    [Test]
+    public void Null_ReturnsFalse()
+    {
+        object? value = null;
+
+        var success = value.TryConvertPreChecked<bool>(out var result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(success, Is.False);
+            Assert.That(result, Is.False);
+        });
+    }
+}

--- a/uSync.Tests/Extensions/TryGetValueAsTests.cs
+++ b/uSync.Tests/Extensions/TryGetValueAsTests.cs
@@ -13,14 +13,14 @@ namespace uSync.Tests.Extensions;
 ///  (uSync.Complete issue #304).
 /// </summary>
 [TestFixture]
-internal class TryConvertPreCheckedTests
+internal class TryGetValueAsTests
 {
     [Test]
     public void JsonElementTrue_ConvertsToBool()
     {
         object value = JsonSerializer.SerializeToElement(true);
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -34,7 +34,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement(false);
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -48,7 +48,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement(42);
 
-        var success = value.TryConvertPreChecked<int>(out var result);
+        var success = value.TryGetValueAs<int>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -63,7 +63,7 @@ internal class TryConvertPreCheckedTests
         var guid = Guid.NewGuid();
         object value = JsonSerializer.SerializeToElement(guid.ToString());
 
-        var success = value.TryConvertPreChecked<Guid>(out var result);
+        var success = value.TryGetValueAs<Guid>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -77,7 +77,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = JsonSerializer.SerializeToElement("hello");
 
-        var success = value.TryConvertPreChecked<string>(out var result);
+        var success = value.TryGetValueAs<string>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -93,7 +93,7 @@ internal class TryConvertPreCheckedTests
     {
         object value = "42";
 
-        var success = value.TryConvertPreChecked<int>(out var result);
+        var success = value.TryGetValueAs<int>(out var result);
 
         Assert.Multiple(() =>
         {
@@ -107,7 +107,7 @@ internal class TryConvertPreCheckedTests
     {
         object? value = null;
 
-        var success = value.TryConvertPreChecked<bool>(out var result);
+        var success = value.TryGetValueAs<bool>(out var result);
 
         Assert.Multiple(() =>
         {

--- a/uSync.Tests/Serializers/MovePropertyTypeTests.cs
+++ b/uSync.Tests/Serializers/MovePropertyTypeTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Strings;
+
+namespace uSync.Tests.Serializers;
+
+/// <summary>
+///  guards the behaviour the content type serializer relies on when a property
+///  is moved out of all groups (#1009).
+/// </summary>
+/// <remarks>
+///  Umbraco's <c>MovePropertyType(alias, null)</c> removes the property from its
+///  group but does NOT re-add it to the 'no group' collection - it orphans it
+///  (see <see cref="MoveToNull_OrphansTheProperty"/>). The serializer works
+///  around this by re-adding the property with <c>AddPropertyType</c>.
+/// </remarks>
+[TestFixture]
+public class MovePropertyTypeTests
+{
+    private static IShortStringHelper ShortStringHelper
+        => new DefaultShortStringHelper(new DefaultShortStringHelperConfig());
+
+    private static IContentType BuildContentTypeWithGroupedProperty()
+    {
+        var contentType = new ContentType(ShortStringHelper, -1)
+        {
+            Alias = "test",
+            Name = "Test"
+        };
+
+        var propertyType = new PropertyType(ShortStringHelper, "Umbraco.TextBox", ValueStorageType.Nvarchar)
+        {
+            Alias = "prop1",
+            Name = "Prop1"
+        };
+
+        contentType.AddPropertyGroup("content", "Content");
+        contentType.AddPropertyType(propertyType, "content", "Content");
+
+        return contentType;
+    }
+
+    [Test]
+    public void MoveToNull_OrphansTheProperty()
+    {
+        // documents the Umbraco behaviour the fix works around: moving a property
+        // to a null group removes it from the group but loses it entirely.
+        var item = BuildContentTypeWithGroupedProperty();
+
+        item.MovePropertyType("prop1", null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(item.PropertyGroups["content"].PropertyTypes.Any(x => x.Alias == "prop1"), Is.False, "removed from group");
+            Assert.That(item.PropertyTypes.Any(x => x.Alias == "prop1"), Is.False, "but also orphaned from the content type");
+        });
+    }
+
+    [Test]
+    public void MoveToNull_ThenReAdd_LandsInNoGroup()
+    {
+        // the approach the serializer uses: move out, then re-home into no-group.
+        var item = BuildContentTypeWithGroupedProperty();
+
+        var property = item.PropertyTypes.FirstOrDefault(x => x.Alias == "prop1");
+        item.MovePropertyType("prop1", null);
+        if (property is not null && item.PropertyTypes.Any(x => x.Alias == "prop1") is false)
+            item.AddPropertyType(property);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(item.PropertyGroups["content"].PropertyTypes.Any(x => x.Alias == "prop1"), Is.False, "prop1 no longer in the group");
+            Assert.That(item.PropertyTypes.Any(x => x.Alias == "prop1"), Is.True, "prop1 still exists on the content type");
+            Assert.That(item.NoGroupPropertyTypes.Any(x => x.Alias == "prop1"), Is.True, "prop1 is in NoGroupPropertyTypes");
+        });
+    }
+}

--- a/uSync.Tests/Serializers/TemplateSerializerTests.cs
+++ b/uSync.Tests/Serializers/TemplateSerializerTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.IO;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+using uSync.Core.Serialization.Serializers;
+
+namespace uSync.Tests.Serializers;
+
+/// <summary>
+///  guards against #1044 - a failed template create used to be reported as a
+///  hardcoded "Failed to create template" with no exception/status, hiding
+///  why the import failed (e.g. only reproducible on IIS/Production).
+/// </summary>
+[TestFixture]
+public class TemplateSerializerTests
+{
+    private Mock<ITemplateService> _templateServiceMock;
+    private Mock<IUserIdKeyResolver> _userIdKeyResolverMock;
+    private TemplateSerializer _serializer;
+
+    [SetUp]
+    public void Setup()
+    {
+        _templateServiceMock = new Mock<ITemplateService>();
+        _userIdKeyResolverMock = new Mock<IUserIdKeyResolver>();
+        _userIdKeyResolverMock.Setup(x => x.GetAsync(It.IsAny<int>())).ReturnsAsync(Guid.NewGuid());
+
+        var versionMock = new Mock<IUmbracoVersion>();
+        versionMock.Setup(x => x.Version).Returns(new Version(17, 3, 0));
+
+        var fileSystems = BuildFileSystems();
+
+        _serializer = new TemplateSerializer(
+            Mock.Of<IEntityService>(),
+            NullLogger<TemplateSerializer>.Instance,
+            Mock.Of<IShortStringHelper>(),
+            fileSystems,
+            new ConfigurationBuilder().Build(),
+            new uSyncCapabilityChecker(versionMock.Object),
+            _templateServiceMock.Object,
+            _userIdKeyResolverMock.Object);
+    }
+
+    private static FileSystems BuildFileSystems()
+    {
+        var hostingEnvironment = new Mock<IHostingEnvironment>();
+#pragma warning disable CS0618 // used only to satisfy FileSystems' internal setup
+        hostingEnvironment.Setup(x => x.MapPathContentRoot(It.IsAny<string>()))
+            .Returns<string>(path => "C:/temp/" + path.TrimStart('~', '/'));
+        hostingEnvironment.Setup(x => x.MapPathWebRoot(It.IsAny<string>()))
+            .Returns<string>(path => "C:/temp/" + path.TrimStart('~', '/'));
+#pragma warning restore CS0618
+        hostingEnvironment.Setup(x => x.ToAbsolute(It.IsAny<string>()))
+            .Returns<string>(path => "/" + path.TrimStart('~', '/'));
+
+        var ioHelper = new Mock<IIOHelper>();
+#pragma warning disable CS0618 // used only to satisfy FileSystems' internal setup
+        ioHelper.Setup(x => x.ResolveUrl(It.IsAny<string>())).Returns<string>(path => "/" + path.TrimStart('~', '/'));
+#pragma warning restore CS0618
+
+        return new FileSystems(
+            Mock.Of<ILoggerFactory>(),
+            ioHelper.Object,
+            Options.Create(new GlobalSettings()),
+            hostingEnvironment.Object);
+    }
+
+    private static XElement BuildTemplateNode(Guid key, string alias, string name)
+        => new XElement("Template",
+            new XAttribute(uSyncConstants.Xml.Key, key),
+            new XAttribute(uSyncConstants.Xml.Alias, alias),
+            new XElement("Name", name),
+            new XElement("Contents", new XCData("@{ Layout = null; }")));
+
+    [Test]
+    public async Task Create_WhenTemplateServiceFails_ReturnsStatusAndException()
+    {
+        // arrange: template doesn't exist locally, so the serializer will try to create it,
+        // and Umbraco's ITemplateService reports it couldn't be created (e.g. duplicate alias).
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<Guid>())).ReturnsAsync((ITemplate)null);
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync((ITemplate)null);
+        _templateServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid?>()))
+            .ReturnsAsync(Attempt<ITemplate, TemplateOperationStatus>.Fail(TemplateOperationStatus.DuplicateAlias));
+
+        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew");
+
+        // act
+        var result = await _serializer.DeserializeAsync(node, new SyncSerializerOptions());
+
+        // assert: the real Umbraco status and an exception now flow through, instead of a
+        // generic message with no way to diagnose the underlying cause.
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Success, Is.False);
+            Assert.That(result.Message, Does.Contain(nameof(TemplateOperationStatus.DuplicateAlias)));
+            Assert.That(result.Exception, Is.Not.Null);
+            Assert.That(result.Exception.Message, Does.Contain(nameof(TemplateOperationStatus.DuplicateAlias)));
+        });
+    }
+
+    [Test]
+    public async Task Create_WhenTemplateServiceSucceeds_ReturnsSucceededAttempt()
+    {
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<Guid>())).ReturnsAsync((ITemplate)null);
+        _templateServiceMock.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync((ITemplate)null);
+
+        var created = new Template(Mock.Of<IShortStringHelper>(), "LinkTreeNew", "linkTreeNew");
+        _templateServiceMock
+            .Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid?>()))
+            .ReturnsAsync(Attempt<ITemplate, TemplateOperationStatus>.Succeed(TemplateOperationStatus.Success, created));
+
+        var node = BuildTemplateNode(Guid.NewGuid(), "linkTreeNew", "LinkTreeNew");
+
+        var result = await _serializer.DeserializeAsync(node, new SyncSerializerOptions());
+
+        Assert.That(result.Success, Is.True);
+    }
+}

--- a/uSync.Tests/packages.lock.json
+++ b/uSync.Tests/packages.lock.json
@@ -2616,7 +2616,7 @@
       },
       "Umbraco.Cms": {
         "type": "CentralTransitive",
-        "requested": "[17.3.0, )",
+        "requested": "[17.4.2, )",
         "resolved": "17.3.0",
         "contentHash": "yaG/li5/5RT7354r6rloErE96HojsDEHyYE+iVxcb+ySCLn2PF424qVSXEYq5ZXAbN4Zbx2/6oytTA4HX5w2rg==",
         "dependencies": {


### PR DESCRIPTION
## Summary
- Fixes #1044: template import failures reported a hardcoded "Failed to create template" message with `exception: null`, giving no way to diagnose why creation failed - notably on IIS/Production, where the failure only reproduces in that environment and not locally.
- `TemplateSerializer.DeserializeCoreAsync` now surfaces Umbraco's real `TemplateOperationStatus` (e.g. `DuplicateAlias`) in the message and wraps it in an `InvalidOperationException`, matching the same "don't discard save-attempt results" fix already applied to other serializers in #1039/#1041 (this call site was missed).
- Removes an unreachable duplicate `item is null` check left over from an earlier refactor.

## Test plan
- [x] Added `uSync.Tests/Serializers/TemplateSerializerTests.cs` covering the template-create failure path (asserts the real status/exception now flow through) and the success path.
- [x] `dotnet test uSync.Tests/uSync.Tests.csproj` - 141/141 passing.