### PR TITLE
Add non-breaking async callback surface to uSyncCallbacks

### DIFF
--- a/uSync.BackOffice/Hubs/uSyncCallbacks.cs
+++ b/uSync.BackOffice/Hubs/uSyncCallbacks.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using uSync.BackOffice.Models;
 
@@ -11,14 +12,29 @@ namespace uSync.BackOffice;
 public delegate void SyncEventCallback(SyncProgressSummary summary);
 
 /// <summary>
-///  callback delegate for SignalR messaging 
+///  async callback delegate for SignalR messaging
+/// </summary>
+public delegate Task SyncEventCallbackAsync(SyncProgressSummary summary);
+
+/// <summary>
+///  callback delegate for SignalR messaging
 /// </summary>
 public delegate void SyncUpdateCallback(string message, int count, int total);
+
+/// <summary>
+///  async callback delegate for SignalR messaging
+/// </summary>
+public delegate Task SyncUpdateCallbackAsync(string message, int count, int total);
 
 /// <summary>
 ///  callback delegate to set the start and end range for the update counters.
 /// </summary>
 public delegate void SyncSetUpdateRange(int start, int end);
+
+/// <summary>
+///  async callback delegate to set the start and end range for the update counters.
+/// </summary>
+public delegate Task SyncSetUpdateRangeAsync(int start, int end);
 
 /// <summary>
 ///  callback to send a update message and increment the counter by one so moving the progress bar.
@@ -27,9 +43,20 @@ public delegate void SyncSetUpdateRange(int start, int end);
 public delegate void SyncIncrementalUpdateCallback(string message);
 
 /// <summary>
+///  async callback to send a update message and increment the counter by one so moving the progress bar.
+/// </summary>
+/// <param name="message"></param>
+public delegate Task SyncIncrementalUpdateCallbackAsync(string message);
+
+/// <summary>
 ///  callback to signal that the sync is complete
 /// </summary>
 public delegate void SyncCompleteCallBack(Guid id, string message, bool success, IEnumerable<uSyncActionView> actions);
+
+/// <summary>
+///  async callback to signal that the sync is complete
+/// </summary>
+public delegate Task SyncCompleteCallBackAsync(Guid id, string message, bool success, IEnumerable<uSyncActionView> actions);
 
 
 /// <summary>
@@ -43,9 +70,21 @@ public class uSyncCallbacks
     public SyncEventCallback? Callback { get; private set; }
 
     /// <summary>
+    ///  Async add event callback. Set alongside (or instead of) <see cref="Callback"/> when the
+    ///  consumer needs to await the send (e.g. a SignalR hub push) rather than block on it.
+    /// </summary>
+    public SyncEventCallbackAsync? CallbackAsync { get; set; }
+
+    /// <summary>
     ///  Update event callback
     /// </summary>
     public SyncUpdateCallback? Update { get; private set; }
+
+    /// <summary>
+    ///  Async update event callback. Set alongside (or instead of) <see cref="Update"/> when the
+    ///  consumer needs to await the send rather than block on it.
+    /// </summary>
+    public SyncUpdateCallbackAsync? UpdateAsync { get; set; }
 
     /// <summary>
     ///  set a start and end range for the counter.
@@ -53,18 +92,33 @@ public class uSyncCallbacks
     public SyncSetUpdateRange? SetRange { get; private set; }
 
     /// <summary>
+    ///  Async version of <see cref="SetRange"/>.
+    /// </summary>
+    public SyncSetUpdateRangeAsync? SetRangeAsync { get; set; }
+
+    /// <summary>
     ///  update and increment callback.
     /// </summary>
     public SyncIncrementalUpdateCallback? IncrementalUpdate { get; private set; }
+
+    /// <summary>
+    ///  Async version of <see cref="IncrementalUpdate"/>.
+    /// </summary>
+    public SyncIncrementalUpdateCallbackAsync? IncrementalUpdateAsync { get; set; }
 
     /// <summary>
     ///  callback to signal that the sync is complete
     /// </summary>
     public SyncCompleteCallBack? Complete { get; private set; }
 
+    /// <summary>
+    ///  Async version of <see cref="Complete"/>.
+    /// </summary>
+    public SyncCompleteCallBackAsync? CompleteAsync { get; set; }
+
 
     /// <summary>
-    ///  generate a new callback object 
+    ///  generate a new callback object
     /// </summary>
     public uSyncCallbacks(SyncEventCallback? callback, SyncUpdateCallback? update)
     {
@@ -75,9 +129,9 @@ public class uSyncCallbacks
     /// <summary>
     ///  generate a callback object with range and incremental update
     /// </summary>
-    public uSyncCallbacks(SyncEventCallback? callback, 
+    public uSyncCallbacks(SyncEventCallback? callback,
         SyncUpdateCallback? update,
-        SyncSetUpdateRange? updateRange, 
+        SyncSetUpdateRange? updateRange,
         SyncIncrementalUpdateCallback incrementalUpdate,
         SyncCompleteCallBack? complete)
         : this(callback, update)
@@ -85,5 +139,60 @@ public class uSyncCallbacks
         this.SetRange = updateRange;
         this.IncrementalUpdate = incrementalUpdate;
         this.Complete = complete;
+    }
+
+    /// <summary>
+    ///  raise the <see cref="Callback"/> / <see cref="CallbackAsync"/> event, awaiting the async
+    ///  version (if set) so callers no longer need to block on it.
+    /// </summary>
+    public async Task RaiseCallbackAsync(SyncProgressSummary summary)
+    {
+        Callback?.Invoke(summary);
+        if (CallbackAsync is not null)
+            await CallbackAsync(summary).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  raise the <see cref="Update"/> / <see cref="UpdateAsync"/> event, awaiting the async
+    ///  version (if set) so callers no longer need to block on it.
+    /// </summary>
+    public async Task RaiseUpdateAsync(string message, int count, int total)
+    {
+        Update?.Invoke(message, count, total);
+        if (UpdateAsync is not null)
+            await UpdateAsync(message, count, total).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  raise the <see cref="SetRange"/> / <see cref="SetRangeAsync"/> event, awaiting the async
+    ///  version (if set) so callers no longer need to block on it.
+    /// </summary>
+    public async Task RaiseSetRangeAsync(int start, int end)
+    {
+        SetRange?.Invoke(start, end);
+        if (SetRangeAsync is not null)
+            await SetRangeAsync(start, end).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  raise the <see cref="IncrementalUpdate"/> / <see cref="IncrementalUpdateAsync"/> event, awaiting
+    ///  the async version (if set) so callers no longer need to block on it.
+    /// </summary>
+    public async Task RaiseIncrementalUpdateAsync(string message)
+    {
+        IncrementalUpdate?.Invoke(message);
+        if (IncrementalUpdateAsync is not null)
+            await IncrementalUpdateAsync(message).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  raise the <see cref="Complete"/> / <see cref="CompleteAsync"/> event, awaiting the async
+    ///  version (if set) so callers no longer need to block on it.
+    /// </summary>
+    public async Task RaiseCompleteAsync(Guid id, string message, bool success, IEnumerable<uSyncActionView> actions)
+    {
+        Complete?.Invoke(id, message, success, actions);
+        if (CompleteAsync is not null)
+            await CompleteAsync(id, message, success, actions).ConfigureAwait(false);
     }
 }

--- a/uSync.BackOffice/Services/SyncActionService.cs
+++ b/uSync.BackOffice/Services/SyncActionService.cs
@@ -124,7 +124,8 @@ internal class SyncActionService : ISyncActionService
             request.ActionOptions.GetSetOrDefault(_uSyncConfig.Settings.DefaultSet),
             request.Actions);
 
-        request.Callbacks?.Update?.Invoke("Post Import Complete", 1, 1);
+        if (request.Callbacks is not null)
+            await request.Callbacks.RaiseUpdateAsync("Post Import Complete", 1, 1);
         return new SyncActionResult([.. actions.Where(x => x.Change > Core.ChangeType.NoChange)]);
     }
 
@@ -218,7 +219,8 @@ internal class SyncActionService : ISyncActionService
                 request.HandlerAction, request.Actions.CountChanges(), request.Actions.Count(), elapsed);
         }
 
-        request.Callbacks?.Update?.Invoke($"{request.HandlerAction} completed ({elapsed:#,#}ms)", 1, 1);
+        if (request.Callbacks is not null)
+            await request.Callbacks.RaiseUpdateAsync($"{request.HandlerAction} completed ({elapsed:#,#}ms)", 1, 1);
 
         // for speed we return an empty list. the merge will just take 
         // what we where passed in, and we avoid a whole copy and compare step

--- a/uSync.BackOffice/Services/SyncService.cs
+++ b/uSync.BackOffice/Services/SyncService.cs
@@ -198,7 +198,8 @@ public partial class SyncService : ISyncService
                 summary.UpdateHandler(
                     handler.Name, HandlerStatus.Processing, $"Importing {handler.Name}", 0);
 
-                callbacks?.Callback?.Invoke(summary);
+                if (callbacks is not null)
+                    await callbacks.RaiseCallbackAsync(summary);
 
                 var handlerActions = await this.ImportHandlerAsync(handler.Alias, importOptions);
 
@@ -228,14 +229,18 @@ public partial class SyncService : ISyncService
             if (actions.ContainsErrors())
                 _logger.LogWarning("uSync Import: Errors detected in import : {count}", actions.CountErrors());
 
-            callbacks?.Update?.Invoke($"Processed {actions.Count} items in {sw.ElapsedMilliseconds}ms", 1, 1);
+            if (callbacks is not null)
+                await callbacks.RaiseUpdateAsync($"Processed {actions.Count} items in {sw.ElapsedMilliseconds}ms", 1, 1);
 
             summary.Message = "Completed";
             summary.Total = handlers.Count() + 1;
             var finalActions = actions.Select(x => x.AsActionView()).ToList();
 
-            callbacks?.Callback?.Invoke(summary);
-            callbacks?.Complete?.Invoke(requestId, "Sync complete", true, finalActions);
+            if (callbacks is not null)
+            {
+                await callbacks.RaiseCallbackAsync(summary);
+                await callbacks.RaiseCompleteAsync(requestId, "Sync complete", true, finalActions);
+            }
 
             return actions;
         }
@@ -392,7 +397,8 @@ public partial class SyncService : ISyncService
             summary.UpdateHandler(
                 handler.Name, HandlerStatus.Processing, $"Exporting {handler.Name}", 0);
 
-            callbacks?.Callback?.Invoke(summary);
+            if (callbacks is not null)
+                await callbacks.RaiseCallbackAsync(summary);
 
             var handlerActions = await handler.ExportAllAsync([$"{folder}/{handler.DefaultFolder}"], configuredHandler.Settings, callbacks?.Update);
 
@@ -405,7 +411,8 @@ public partial class SyncService : ISyncService
 
 
         summary.UpdateMessage("Export Completed");
-        callbacks?.Callback?.Invoke(summary);
+        if (callbacks is not null)
+            await callbacks.RaiseCallbackAsync(summary);
 
         await _mutexService.FireBulkCompleteAsync(new uSyncExportCompletedNotification(actions, null));
 
@@ -419,7 +426,8 @@ public partial class SyncService : ISyncService
                 sw.ElapsedMilliseconds);
         }
 
-        callbacks?.Update?.Invoke($"Processed {actions.Count} items in {sw.ElapsedMilliseconds}ms", 1, 1);
+        if (callbacks is not null)
+            await callbacks.RaiseUpdateAsync($"Processed {actions.Count} items in {sw.ElapsedMilliseconds}ms", 1, 1);
 
         return actions;
     }

--- a/uSync.BackOffice/Services/SyncService_Single.cs
+++ b/uSync.BackOffice/Services/SyncService_Single.cs
@@ -59,8 +59,9 @@ public partial class SyncService
             }
 
 
-            options.Callbacks?.Update?.Invoke(item.Node.GetAlias(),
-                CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseUpdateAsync(item.Node.GetAlias(),
+                    CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
 
             if (handlerPair != null)
             {
@@ -131,8 +132,9 @@ public partial class SyncService
                                 continue;
                             }
 
-                            options.Callbacks?.Update?.Invoke(node.GetAlias(),
-                                CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
+                            if (options.Callbacks is not null)
+                                await options.Callbacks.RaiseUpdateAsync(node.GetAlias(),
+                                    CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
 
                             if (handlerPair != null)
                             {
@@ -208,8 +210,9 @@ public partial class SyncService
                                 continue;
                             }
 
-                            options.Callbacks?.Update?.Invoke($"Second Pass: {action.Name}",
-                                CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
+                            if (options.Callbacks is not null)
+                                await options.Callbacks.RaiseUpdateAsync($"Second Pass: {action.Name}",
+                                    CalculateProgress(index, total, options.ProgressMin, options.ProgressMax), 100);
 
                             secondPassActions.AddRange(await handlerPair.Handler.ImportSecondPassAsync(action, handlerPair.Settings, options));
 
@@ -273,7 +276,8 @@ public partial class SyncService
                     {
                         if (handlerPair.Handler is ISyncPostImportHandler postImportHandler)
                         {
-                            options.Callbacks?.Update?.Invoke(actionItem.alias, index, folders.Count);
+                            if (options.Callbacks is not null)
+                                await options.Callbacks.RaiseUpdateAsync(actionItem.alias, index, folders.Count);
 
                             var handlerActions = actions.Where(x => x.HandlerAlias.InvariantEquals(handlerPair.Handler.Alias));
                             results.AddRange(await postImportHandler.ProcessPostImportAsync(handlerActions, handlerPair.Settings));
@@ -326,7 +330,8 @@ public partial class SyncService
 
                     if (handlerPair.Handler is ISyncCleanEntryHandler cleanEntryHandler)
                     {
-                        options.Callbacks?.Update?.Invoke(actionItem.alias, index, cleans.Count);
+                        if (options.Callbacks is not null)
+                            await options.Callbacks.RaiseUpdateAsync(actionItem.alias, index, cleans.Count);
 
                         var handlerActions = actions.Where(x => x.HandlerAlias.InvariantEquals(handlerPair.Handler.Alias));
                         results.AddRange(await cleanEntryHandler.ProcessCleanActionsAsync(actionItem.folder, handlerActions, handlerPair.Settings));

--- a/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
+++ b/uSync.BackOffice/SyncHandlers/SyncHandlerRoot.cs
@@ -266,11 +266,13 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         var cacheKey = PrepCaches();
         try
         {
-            options.Callbacks?.Update?.Invoke("Calculating import order", 1, 9);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseUpdateAsync("Calculating import order", 1, 9);
 
             var items = await GetMergedItemsAsync(folders, new SyncMergeOptions(options.Callbacks?.Update));
 
-            options.Callbacks?.Update?.Invoke($"Processing {items.Count} items", 2, 9);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseUpdateAsync($"Processing {items.Count} items", 2, 9);
 
             // create the update list with items.count space. this is the max size we need this list.
             List<uSyncAction> actions = new(items.Count);
@@ -280,7 +282,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
             int count = 0;
             int total = items.Count;
 
-            options.Callbacks?.SetRange?.Invoke(count, total);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseSetRangeAsync(count, total);
 
             foreach (var item in items)
             {
@@ -326,7 +329,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
                 await PerformImportCleanAsync(cleanMarkers, actions, config, options.Callbacks?.Update);
             }
 
-            options.Callbacks?.Update?.Invoke("Done", 3, 3);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseUpdateAsync("Done", 3, 3);
 
             if (logger.IsEnabled(LogLevel.Debug))
                 logger.LogDebug("ImportAll: {count} items imported", actions.Count);
@@ -458,7 +462,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
         {
             var actions = new List<uSyncAction>();
             var elements = node.Elements().ToList();
-            options.Callbacks?.SetRange?.Invoke(0, elements.Count);
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseSetRangeAsync(0, elements.Count);
             foreach (var item in elements)
             {
                 actions.AddRange(await ImportSingleElementAsync(new XElement(item), filename, settings, options));
@@ -492,7 +497,8 @@ public abstract class SyncHandlerRoot<TObject, TContainer>
 
         try
         {
-            options.Callbacks?.IncrementalUpdate?.Invoke(node.GetAlias());
+            if (options.Callbacks is not null)
+                await options.Callbacks.RaiseIncrementalUpdateAsync(node.GetAlias());
 
             // merge the options from the handler and any import options into our serializer options.
             var serializerOptions = new SyncSerializerOptions(options.Flags, settings.Settings, options.UserId);

--- a/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
+++ b/uSync.Backoffice.Management.Api/Services/uSyncManagementService.cs
@@ -269,7 +269,7 @@ internal class uSyncManagementService : ISyncManagementService
         if (actionRequest.StepNumber >= handlers.Count)
         {
             var actions = await PerformFinalSteps(requestId, action, handlerOptions, callbacks, user?.Username);
-            return SummerizeCompleteProcess(actionRequest, action, handlers, requestId, callbacks, actions);
+            return await SummerizeCompleteProcess(actionRequest, action, handlers, requestId, callbacks, actions);
         }
 
 
@@ -282,7 +282,7 @@ internal class uSyncManagementService : ISyncManagementService
         var allActions = _syncManagementCache.GetCachedActions(requestId);
 
         var summaries = GetSummaries(action, handlers, actionRequest.StepNumber, allActions);
-        callbacks.Callback?.Invoke(new SyncProgressSummary(summaries, "Processing " + action.ToString(), handlers.Count));
+        await callbacks.RaiseCallbackAsync(new SyncProgressSummary(summaries, "Processing " + action.ToString(), handlers.Count));
 
         return new PerformActionResponse
         {
@@ -293,15 +293,18 @@ internal class uSyncManagementService : ISyncManagementService
         };
     }
 
-    private static PerformActionResponse SummerizeCompleteProcess(PerformActionRequest actionRequest, HandlerActions action, List<SyncHandlerView> handlers, Guid requestId, uSyncCallbacks callbacks, List<uSyncAction> actions)
+    private static async Task<PerformActionResponse> SummerizeCompleteProcess(PerformActionRequest actionRequest, HandlerActions action, List<SyncHandlerView> handlers, Guid requestId, uSyncCallbacks callbacks, List<uSyncAction> actions)
     {
         var finalSummary = GetSummaries(action, handlers, actionRequest.StepNumber + 1, actions);
         var actionViews = actions.Select(x => x.AsActionView());
 
-        callbacks?.Callback?.Invoke(new SyncProgressSummary(finalSummary, "Completed", handlers.Count));
-        callbacks?.Complete?.Invoke(requestId, "Sync complete", true, actionViews);
+        if (callbacks is not null)
+        {
+            await callbacks.RaiseCallbackAsync(new SyncProgressSummary(finalSummary, "Completed", handlers.Count));
+            await callbacks.RaiseCompleteAsync(requestId, "Sync complete", true, actionViews);
+        }
 
-        // finished. 
+        // finished.
         return new PerformActionResponse
         {
             RequestId = requestId.ToString(),


### PR DESCRIPTION
## Summary
- `uSyncCallbacks`' delegates (`Callback`, `Update`, `SetRange`, `IncrementalUpdate`, `Complete`) are `void`, which forces consumers like uSync.Complete's `LocalHubClient`/`PublisherHubClient` to `.Wait()` on every SignalR send. Adds optional async counterparts (`CallbackAsync`, `UpdateAsync`, `SetRangeAsync`, `IncrementalUpdateAsync`, `CompleteAsync`) that can be set alongside the existing sync ones.
- Adds `Raise*Async` helper methods on `uSyncCallbacks` that invoke the sync delegate then await the async one if set, so callers get one call site regardless of which style a consumer wired up.
- Existing constructors, delegate types, and properties on `uSyncCallbacks` are untouched — this is purely additive, so it's non-breaking for anything currently calling into it.
- Updates the call sites that invoke callbacks directly off a `uSyncCallbacks` instance (`SyncService`, `SyncService_Single`, `SyncActionService`, `SyncHandlerRoot`, `uSyncManagementService`) to `await` the new `Raise*Async` helpers instead of firing the sync delegate directly.

## Not changed (deliberately)
Call sites that extract the raw `SyncUpdateCallback` delegate to pass into the public `ISyncHandler.ExportAllAsync`/`ReportAsync` interface (and `SyncMergeOptions`/`CreateNotificationScope`) are left as-is, since changing those public signatures would be a breaking change. This is a follow-up from investigating the "CreateRestorePoint timeout after v17 upgrade" issue — see uSync.Complete PR 178 — and unblocks wiring real per-item/progress callbacks into restore-point export without forcing a blocking `.Wait()` per SignalR message.

## Test plan
- [x] `dotnet build uSync.slnx` — succeeds, no new warnings/errors
- [x] `dotnet test uSync.Tests/uSync.Tests.csproj` — 141/141 passing